### PR TITLE
Add themes page

### DIFF
--- a/assets/css/themes.css
+++ b/assets/css/themes.css
@@ -1,0 +1,206 @@
+.main {
+  display: grid;
+  margin-bottom: var(--space-xx-large);
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: var(--space-xx-large);
+  padding-left: var(--space-large);
+  padding-right: var(--space-large);
+  width: min(100%, 90em);
+}
+
+@media (min-width: 64em) {
+  .main {
+    margin-bottom: var(--space-xxxx-large);
+    margin-top: var(--space-xxxx-large);
+    padding-left: var(--space-xx-large);
+    padding-right: var(--space-xx-large);
+  }
+}
+
+/* Filter Styles */
+.nav__filters {
+  display: grid;
+  gap: var(--space-large);
+}
+
+@media (min-width: 64em) {
+  .nav__filters {
+    align-items: start;
+    grid-template-columns: 1fr 2fr;
+    gap: var(--space-x-large);
+  }
+}
+
+.filter-group {
+  display: grid;
+  gap: var(--space-medium);
+}
+
+.filter-label {
+  color: var(--color-terminal-blue);
+  font-size: var(--font-size-medium);
+  font-weight: 700;
+  text-align: center;
+}
+
+.filter-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-medium);
+  justify-content: center;
+}
+
+.filter-button {
+  align-items: center;
+  background: var(--color-terminal-blue);
+  opacity: 0.7;
+  border: none;
+  border-radius: 0.4em;
+  box-shadow: 0 1px 0 0 rgba(var(--rgb-black), 0.1),
+    0 0.2em 1.2em -0.4em rgba(var(--rgb-black), 0.2),
+    0 0.4em 2em -0.8em rgba(var(--rgb-black), 0.3),
+    0 0.4em 0.4em -0.8em rgba(var(--rgb-black), 0.4),
+    0 0.8em 0.8em -1.2em rgba(var(--rgb-black), 0.5),
+    0 1.2em 1.2em -1.6em rgba(var(--rgb-black), 0.6);
+  color: var(--color-background-night);
+  cursor: pointer;
+  display: flex;
+  font-weight: 700;
+  gap: 1ch;
+  height: 2.9em;
+  line-height: 1;
+  padding-left: 1em;
+  padding-right: 1em;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: background var(--transition), color var(--transition);
+}
+
+.filter-button.active {
+  background: var(--color-terminal-blue);
+  color: var(--color-background-night);
+  opacity: 1;
+}
+
+@media (hover: hover) {
+  .filter-button:hover {
+    background: var(--color-turquoise);
+    color: var(--color-background-night);
+    opacity: 1;
+  }
+}
+
+/* Theme Grid */
+.themes-grid {
+  display: grid;
+  gap: var(--space-large);
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+@media (min-width: 48em) {
+  .themes-grid {
+    gap: var(--space-x-large);
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+@media (min-width: 64em) {
+  .themes-grid {
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  }
+}
+
+/* Theme Card */
+.theme-card {
+  background: var(--color-background-storm);
+  border: 2px solid var(--color-terminal-black);
+  border-radius: 0.6em;
+  display: grid;
+  gap: var(--space-medium);
+  padding: var(--space-medium);
+  transition: border-color var(--transition);
+}
+
+.theme-card:hover {
+  border-color: var(--color-terminal-blue);
+}
+
+.theme-preview-link {
+  display: block;
+  text-decoration: none;
+}
+
+.theme-preview {
+  aspect-ratio: 16 / 9;
+  background: var(--color-background-night);
+  border-radius: 0.4em;
+  overflow: hidden;
+  position: relative;
+  transition: opacity var(--transition);
+}
+
+@media (hover: hover) {
+  .theme-preview-link:hover .theme-preview {
+    opacity: 0.85;
+  }
+}
+
+.theme-preview img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.theme-preview-placeholder {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+.theme-preview-placeholder svg {
+  color: var(--color-terminal-white);
+  opacity: 0.3;
+}
+
+.theme-name {
+  color: var(--color-terminal-cyan);
+  font-size: var(--font-size-medium);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.theme-name a {
+  color: var(--color-terminal-cyan);
+  font-weight: 700;
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+@media (hover: hover) {
+  .theme-name a:hover {
+    color: var(--color-turquoise);
+  }
+}
+
+.theme-author-inline {
+  color: var(--color-terminal-white);
+  font-weight: 300;
+  font-size: (--font-size-small);
+}
+
+.theme-info {
+  display: flex;
+  gap: var(--space-small);
+  justify-content: space-between;
+}
+
+/* No Results */
+.no-results {
+  color: var(--color-terminal-white);
+  font-size: var(--font-size-medium);
+  padding: var(--space-xx-large);
+  text-align: center;
+}

--- a/assets/js/themes.js
+++ b/assets/js/themes.js
@@ -1,0 +1,135 @@
+const state = {
+  typeFilter: "all",
+  colorFilter: "all",
+  themes: [],
+};
+
+async function loadThemes() {
+  try {
+    const response = await fetch("../themes.json");
+    const themes = await response.json();
+    state.themes = themes;
+    renderThemes();
+  } catch (error) {
+    console.error("Error loading themes:", error);
+    document.getElementById("noResults").style.display = "block";
+    document.getElementById("noResults").querySelector("p").textContent =
+      "Error loading themes.";
+  }
+}
+
+function renderThemes() {
+  const grid = document.getElementById("themesGrid");
+  grid.innerHTML = "";
+
+  const filteredThemes = filterThemes();
+
+  if (filteredThemes.length === 0) {
+    document.getElementById("noResults").style.display = "block";
+    return;
+  }
+
+  document.getElementById("noResults").style.display = "none";
+
+  filteredThemes.forEach((theme) => {
+    const card = createThemeCard(theme);
+    grid.appendChild(card);
+  });
+}
+
+function filterThemes() {
+  return state.themes.filter((theme) => {
+    const typeMatch =
+      state.typeFilter === "all" || theme.type === state.typeFilter;
+    const colorMatch =
+      state.colorFilter === "all" ||
+      theme.primary_colors.includes(state.colorFilter);
+    return typeMatch && colorMatch;
+  });
+}
+
+function createThemeCard(theme) {
+  const card = document.createElement("div");
+  card.className = "theme-card";
+
+  const previewLink = document.createElement("a");
+  previewLink.href = theme.repo_url;
+  previewLink.target = "_blank";
+  previewLink.rel = "noopener noreferrer";
+  previewLink.className = "theme-preview-link";
+
+  const preview = document.createElement("div");
+  preview.className = "theme-preview";
+
+  const img = document.createElement("img");
+  img.src = theme.preview_url;
+  img.alt = `${theme.name} theme preview`;
+  img.loading = "lazy";
+
+  img.onerror = function () {
+    this.style.display = "none";
+    const placeholder = document.createElement("div");
+    placeholder.className = "theme-preview-placeholder";
+    placeholder.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" x2="22" y1="2" y2="22"/><path d="M10.41 10.41a2 2 0 1 1-2.83-2.83"/><line x1="13.5" x2="6" y1="13.5" y2="21"/><line x1="18" x2="21" y1="12" y2="15"/><path d="M3.59 3.59A1.99 1.99 0 0 0 3 5v14a2 2 0 0 0 2 2h14c.55 0 1.052-.22 1.41-.59"/><path d="M21 15V5a2 2 0 0 0-2-2H9"/></svg>`;
+    preview.appendChild(placeholder);
+  };
+
+  preview.appendChild(img);
+  previewLink.appendChild(preview);
+
+  const info = document.createElement("div");
+  info.className = "theme-info";
+
+  const nameContainer = document.createElement("h2");
+  nameContainer.className = "theme-name";
+
+  const nameLink = document.createElement("a");
+  nameLink.href = theme.repo_url;
+  nameLink.target = "_blank";
+  nameLink.rel = "noopener noreferrer";
+  nameLink.textContent = theme.name;
+
+  const authorSpan = document.createElement("span");
+  authorSpan.className = "theme-author-inline";
+  authorSpan.textContent = ` by ${theme.author}`;
+
+  nameContainer.appendChild(nameLink);
+  nameContainer.appendChild(authorSpan);
+
+  info.appendChild(nameContainer);
+
+  card.appendChild(previewLink);
+  card.appendChild(info);
+
+  return card;
+}
+
+function setupFilters() {
+  const filterButtons = document.querySelectorAll(".filter-button");
+
+  filterButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const filterType = button.dataset.filterType;
+      const filterValue = button.dataset.filterValue;
+
+      const group = button.closest(".filter-group");
+      group.querySelectorAll(".filter-button").forEach((btn) => {
+        btn.classList.remove("active");
+      });
+      button.classList.add("active");
+
+      if (filterType === "type") {
+        state.typeFilter = filterValue;
+      } else if (filterType === "color") {
+        state.colorFilter = filterValue;
+      }
+
+      renderThemes();
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupFilters();
+  loadThemes();
+});

--- a/themes.json
+++ b/themes.json
@@ -1,0 +1,522 @@
+[
+  {
+    "name": "Aetheria",
+    "author": "JJDizz1L",
+    "type": "dark",
+    "primary_colors": ["red", "blue", "green"],
+    "repo_url": "https://github.com/JJDizz1L/aetheria",
+    "preview_url": "https://raw.githubusercontent.com/JJDizz1L/aetheria/refs/heads/omarchy-aetheria-theme/preview.png"
+  },
+  {
+    "name": "Amberbyte",
+    "author": "tahfizhabib",
+    "type": "dark",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/tahfizhabib/omarchy-amberbyte-theme",
+    "preview_url": "https://raw.githubusercontent.com/tahfizhabib/omarchy-amberbyte-theme/main/media/Preview.png"
+  },
+  {
+    "name": "Arc Blueberry",
+    "author": "vale-c",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/vale-c/omarchy-arc-blueberry",
+    "preview_url": "https://raw.githubusercontent.com/vale-c/omarchy-arc-blueberry/main/theme.png"
+  },
+  {
+    "name": "Archwave",
+    "author": "davidguttman",
+    "type": "dark",
+    "primary_colors": ["purple", "cyan"],
+    "repo_url": "https://github.com/davidguttman/archwave",
+    "preview_url": "https://raw.githubusercontent.com/davidguttman/archwave/main/preview/preview-1.png"
+  },
+  {
+    "name": "Artzen",
+    "author": "tahfizhabib",
+    "type": "dark",
+    "primary_colors": ["red", "green"],
+    "repo_url": "https://github.com/tahfizhabib/omarchy-artzen-theme",
+    "preview_url": "https://raw.githubusercontent.com/tahfizhabib/omarchy-artzen-theme/4be3b5671b629bd9f6a132238d8631658bd35f7b/media/preview.png"
+  },
+  {
+    "name": "Ash",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/bjarneo/omarchy-ash-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-ash-theme/main/theme.png"
+  },
+  {
+    "name": "Aura",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["purple", "cyan"],
+    "repo_url": "https://github.com/bjarneo/omarchy-aura-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-aura-theme/main/theme.png"
+  },
+  {
+    "name": "All Hallow's Eve",
+    "author": "guilhermetk",
+    "type": "dark",
+    "primary_colors": ["orange", "green"],
+    "repo_url": "https://github.com/guilhermetk/omarchy-all-hallows-eve-theme",
+    "preview_url": "https://raw.githubusercontent.com/guilhermetk/omarchy-all-hallows-eve-theme/master/assets/tools-1.webp"
+  },
+  {
+    "name": "Ayaka",
+    "author": "abhijeet-swami",
+    "type": "dark",
+    "primary_colors": ["blue", "cyan"],
+    "repo_url": "https://github.com/abhijeet-swami/omarchy-ayaka-theme",
+    "preview_url": "https://raw.githubusercontent.com/abhijeet-swami/omarchy-ayaka-theme/main/screenshots/1.png"
+  },
+  {
+    "name": "Azure Glow",
+    "author": "Hydradevx",
+    "type": "dark",
+    "primary_colors": ["blue", "cyan"],
+    "repo_url": "https://github.com/Hydradevx/omarchy-azure-glow-theme",
+    "preview_url": "https://raw.githubusercontent.com/Hydradevx/omarchy-azure-glow-theme/main/preview.png"
+  },
+  {
+    "name": "Black Gold",
+    "author": "HANCORE-linux",
+    "type": "dark",
+    "primary_colors": ["yellow"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-blackgold-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-blackgold-theme/refs/heads/V2-Blackgold/preview.png"
+  },
+  {
+    "name": "Bliss",
+    "author": "mishonki3",
+    "type": "light",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/mishonki3/omarchy-bliss-theme",
+    "preview_url": "https://raw.githubusercontent.com/mishonki3/omarchy-bliss-theme/main/preview/preview1.png"
+  },
+  {
+    "name": "Bluedotrb",
+    "author": "dotsilva",
+    "type": "dark",
+    "primary_colors": ["blue"],
+    "repo_url": "https://github.com/dotsilva/omarchy-bluedotrb-theme",
+    "preview_url": "https://raw.githubusercontent.com/dotsilva/omarchy-bluedotrb-theme/66fa0674392bc572cf484be01f92939da923079c/preview.png"
+  },
+  {
+    "name": "Citrus Cynapse",
+    "author": "Grey-007",
+    "type": "dark",
+    "primary_colors": ["orange", "green"],
+    "repo_url": "https://github.com/Grey-007/citrus-cynapse",
+    "preview_url": "https://raw.githubusercontent.com/Grey-007/citrus-cynapse/main/image.png"
+  },
+  {
+    "name": "Cobalt2",
+    "author": "hoblin",
+    "type": "dark",
+    "primary_colors": ["blue", "cyan"],
+    "repo_url": "https://github.com/hoblin/omarchy-cobalt2-theme",
+    "preview_url": "https://raw.githubusercontent.com/hoblin/omarchy-cobalt2-theme/main/preview.png"
+  },
+  {
+    "name": "Darcula",
+    "author": "noahljungberg",
+    "type": "dark",
+    "primary_colors": ["orange", "green"],
+    "repo_url": "https://github.com/noahljungberg/omarchy-darcula-theme",
+    "preview_url": "https://raw.githubusercontent.com/noahljungberg/omarchy-darcula-theme/main/theme.png"
+  },
+  {
+    "name": "Demon",
+    "author": "HANCORE-linux",
+    "type": "dark",
+    "primary_colors": ["orange", "red"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-demon-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-demon-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Dotrb",
+    "author": "dotsilva",
+    "type": "dark",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/dotsilva/omarchy-dotrb-theme",
+    "preview_url": "https://raw.githubusercontent.com/dotsilva/omarchy-dotrb-theme/8fbdc273b1ca2773422b84dca588a540b7863d2f/preview.png"
+  },
+  {
+    "name": "Drac",
+    "author": "ShehabShaef",
+    "type": "dark",
+    "primary_colors": ["blue"],
+    "repo_url": "https://github.com/ShehabShaef/omarchy-drac-theme",
+    "preview_url": "https://raw.githubusercontent.com/ShehabShaef/omarchy-drac-theme/main/theme-preview.png"
+  },
+  {
+    "name": "Dracula",
+    "author": "catlee",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/catlee/omarchy-dracula-theme",
+    "preview_url": "https://raw.githubusercontent.com/catlee/omarchy-dracula-theme/main/theme.png"
+  },
+  {
+    "name": "Eldritch",
+    "author": "neonvoidx",
+    "type": "dark",
+    "primary_colors": ["green", "blue"],
+    "repo_url": "https://github.com/eldritch-theme/omarchy",
+    "preview_url": "https://raw.githubusercontent.com/eldritch-theme/omarchy/refs/heads/master/preview.png"
+  },
+  {
+    "name": "Evergarden",
+    "author": "celsobenedetti",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/celsobenedetti/omarchy-evergarden",
+    "preview_url": "https://raw.githubusercontent.com/celsobenedetti/omarchy-evergarden/master/.github/assets/demo.png"
+  },
+  {
+    "name": "Felix",
+    "author": "TyRichards",
+    "type": "dark",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/TyRichards/omarchy-felix-theme",
+    "preview_url": "https://raw.githubusercontent.com/TyRichards/omarchy-felix-theme/main/theme.png"
+  },
+  {
+    "name": "Fireside",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["green", "blue", "orange"],
+    "repo_url": "https://github.com/bjarneo/omarchy-fireside-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-fireside-theme/main/theme.png"
+  },
+  {
+    "name": "Flexoki Light",
+    "author": "euandeas",
+    "type": "light",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/euandeas/omarchy-flexoki-light-theme",
+    "preview_url": "https://raw.githubusercontent.com/euandeas/omarchy-flexoki-light-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Flexoki Dark",
+    "author": "euandeas",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/euandeas/omarchy-flexoki-dark-theme",
+    "preview_url": "https://raw.githubusercontent.com/euandeas/omarchy-flexoki-dark-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Forest Green",
+    "author": "abhijeet-swami",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/abhijeet-swami/omarchy-forest-green-theme",
+    "preview_url": "https://raw.githubusercontent.com/abhijeet-swami/omarchy-forest-green-theme/main/screenshot/2.png"
+  },
+  {
+    "name": "Frost",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["blue"],
+    "repo_url": "https://github.com/bjarneo/omarchy-frost-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-frost-theme/main/theme.png"
+  },
+  {
+    "name": "Futurism",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["blue", "purple"],
+    "repo_url": "https://github.com/bjarneo/omarchy-futurism-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-futurism-theme/main/theme.png"
+  },
+  {
+    "name": "Gold Rush",
+    "author": "tahayvr",
+    "type": "dark",
+    "primary_colors": ["yellow"],
+    "repo_url": "https://github.com/tahayvr/omarchy-gold-rush-theme",
+    "preview_url": "https://raw.githubusercontent.com/tahayvr/omarchy-gold-rush-theme/refs/heads/main/goldrush.png"
+  },
+  {
+    "name": "The Greek",
+    "author": "HANCORE-linux",
+    "type": "light",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-thegreek-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-thegreek-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Green Garden",
+    "author": "kalk-ak",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/kalk-ak/omarchy-green-garden-theme",
+    "preview_url": "https://raw.githubusercontent.com/kalk-ak/Stash/master/Omarchy-Green-Garden-Images/omarchy-lush-green.png"
+  },
+  {
+    "name": "Infernium",
+    "author": "RiO7MAKK3R",
+    "type": "dark",
+    "primary_colors": ["orange", "red"],
+    "repo_url": "https://github.com/RiO7MAKK3R/omarchy-infernium-dark-theme",
+    "preview_url": "https://raw.githubusercontent.com/RiO7MAKK3R/omarchy-infernium-dark-theme/main/infernium-dark-preview-2.png"
+  },
+  {
+    "name": "Mars",
+    "author": "steve-lohmeyer",
+    "type": "dark",
+    "primary_colors": ["red", "orange"],
+    "repo_url": "https://github.com/steve-lohmeyer/omarchy-mars-theme",
+    "preview_url": "https://raw.githubusercontent.com/steve-lohmeyer/omarchy-mars-theme/master/theme.png"
+  },
+  {
+    "name": "Mechanoonna",
+    "author": "HANCORE-linux",
+    "type": "dark",
+    "primary_colors": ["yellow"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-mechanoonna-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-mechanoonna-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Monokai",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/bjarneo/omarchy-monokai-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-monokai-theme/main/theme.png"
+  },
+  {
+    "name": "Neovoid",
+    "author": "RiO7MAKK3R",
+    "type": "dark",
+    "primary_colors": ["blue", "cyan"],
+    "repo_url": "https://github.com/RiO7MAKK3R/omarchy-neovoid-theme",
+    "preview_url": "https://raw.githubusercontent.com/RiO7MAKK3R/omarchy-Neovoid-theme/6c8fca10d4cb8240de59987b6f81964043bfa827/preview-1.png"
+  },
+  {
+    "name": "NES",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/bjarneo/omarchy-nes-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-nes-theme/main/theme.png"
+  },
+  {
+    "name": "Omacarchy",
+    "author": "RiO7MAKK3R",
+    "type": "dark",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/RiO7MAKK3R/omarchy-omacarchy-theme",
+    "preview_url": "https://raw.githubusercontent.com/RiO7MAKK3R/omarchy-omacarchy-theme/main/omacarchy-preview-1.png"
+  },
+  {
+    "name": "One Dark Pro",
+    "author": "sc0ttman",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/sc0ttman/omarchy-one-dark-pro-theme",
+    "preview_url": "https://raw.githubusercontent.com/sc0ttman/omarchy-one-dark-pro-theme/main/assets/screen1.png"
+  },
+  {
+    "name": "Pandora",
+    "author": "imbypass",
+    "type": "dark",
+    "primary_colors": ["blue", "purple", "green"],
+    "repo_url": "https://github.com/imbypass/omarchy-pandora-theme",
+    "preview_url": "https://raw.githubusercontent.com/imbypass/omarchy-pandora-theme/main/preview.png"
+  },
+  {
+    "name": "Pina",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["green", "yellow"],
+    "repo_url": "https://github.com/bjarneo/omarchy-pina-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-pina-theme/main/theme.png"
+  },
+  {
+    "name": "Pulsar",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["blue", "purple", "green"],
+    "repo_url": "https://github.com/bjarneo/omarchy-pulsar-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-pulsar-theme/main/theme.png"
+  },
+  {
+    "name": "Purple Wave",
+    "author": "dotsilva",
+    "type": "dark",
+    "primary_colors": ["purple", "blue"],
+    "repo_url": "https://github.com/dotsilva/omarchy-purplewave-theme",
+    "preview_url": "https://raw.githubusercontent.com/dotsilva/omarchy-purplewave-theme/a1646c64dfa3723d1d0db4765e049ac7e2a112bf/preview.png"
+  },
+  {
+    "name": "Retro PC",
+    "author": "rondilley",
+    "type": "dark",
+    "primary_colors": ["yellow"],
+    "repo_url": "https://github.com/rondilley/omarchy-retropc-theme",
+    "preview_url": "https://raw.githubusercontent.com/rondilley/omarchy-retropc-theme/main/theme.png"
+  },
+  {
+    "name": "Rose Pine Dark",
+    "author": "guilhermetk",
+    "type": "dark",
+    "primary_colors": ["red", "cyan", "blue"],
+    "repo_url": "https://github.com/guilhermetk/omarchy-rose-pine-dark",
+    "preview_url": "https://raw.githubusercontent.com/guilhermetk/omarchy-rose-pine-dark/master/assets/tools.webp"
+  },
+  {
+    "name": "Rose of Dune",
+    "author": "HANCORE-linux",
+    "type": "light",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-roseofdune-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-roseofdune-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Sakura",
+    "author": "bjarneo",
+    "type": "dark",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/bjarneo/omarchy-sakura-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-sakura-theme/main/theme.png"
+  },
+  {
+    "name": "Sapphire",
+    "author": "HANCORE-linux",
+    "type": "dark",
+    "primary_colors": ["blue"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-sapphire-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-sapphire-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Shades of Jade",
+    "author": "HANCORE-linux",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-shadesofjade-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-shadesofjade-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Space Monkey",
+    "author": "TyRichards",
+    "type": "dark",
+    "primary_colors": ["yellow", "orange"],
+    "repo_url": "https://github.com/TyRichards/omarchy-space-monkey-theme",
+    "preview_url": "https://raw.githubusercontent.com/TyRichards/omarchy-space-monkey-theme/main/theme.png"
+  },
+  {
+    "name": "Snow",
+    "author": "bjarneo",
+    "type": "light",
+    "primary_colors": ["neutral"],
+    "repo_url": "https://github.com/bjarneo/omarchy-snow-theme",
+    "preview_url": "https://raw.githubusercontent.com/bjarneo/omarchy-snow-theme/main/theme.png"
+  },
+  {
+    "name": "Solarized",
+    "author": "Gazler",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/Gazler/omarchy-solarized-theme",
+    "preview_url": "https://raw.githubusercontent.com/Gazler/omarchy-solarized-theme/master/images/solarized.png"
+  },
+  {
+    "name": "Solarized Osaka",
+    "author": "motorsss",
+    "type": "dark",
+    "primary_colors": ["blue", "cyan"],
+    "repo_url": "https://github.com/motorsss/omarchy-solarizedosaka-theme",
+    "preview_url": "https://raw.githubusercontent.com/motorsss/omarchy-solarizedosaka-theme/main/images/preview.png"
+  },
+  {
+    "name": "Sunset",
+    "author": "rondilley",
+    "type": "dark",
+    "primary_colors": ["orange", "yellow"],
+    "repo_url": "https://github.com/rondilley/omarchy-sunset-theme",
+    "preview_url": "https://raw.githubusercontent.com/rondilley/omarchy-sunset-theme/main/theme.png"
+  },
+  {
+    "name": "Sunset Drive",
+    "author": "tahayvr",
+    "type": "dark",
+    "primary_colors": ["blue", "yellow", "green"],
+    "repo_url": "https://github.com/tahayvr/omarchy-sunset-drive-theme",
+    "preview_url": "https://raw.githubusercontent.com/tahayvr/omarchy-sunset-drive-theme/main/preview.png"
+  },
+  {
+    "name": "Super Game Bro",
+    "author": "TyRichards",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/TyRichards/omarchy-super-game-bro-theme",
+    "preview_url": "https://raw.githubusercontent.com/TyRichards/omarchy-super-game-bro-theme/main/theme.png"
+  },
+  {
+    "name": "Synthwave '84",
+    "author": "omacom-io",
+    "type": "dark",
+    "primary_colors": ["purple", "red", "blue"],
+    "repo_url": "https://github.com/omacom-io/omarchy-synthwave84-theme",
+    "preview_url": ""
+  },
+  {
+    "name": "Temerald",
+    "author": "Ahmad-Mtr",
+    "type": "dark",
+    "primary_colors": ["green"],
+    "repo_url": "https://github.com/Ahmad-Mtr/omarchy-temerald-theme",
+    "preview_url": "https://raw.githubusercontent.com/Ahmad-Mtr/omarchy-temerald-theme/main/preview.png"
+  },
+  {
+    "name": "Tokyo Night OLED",
+    "author": "Justin-De-Sio",
+    "type": "dark",
+    "primary_colors": ["blue", "green"],
+    "repo_url": "https://github.com/Justin-De-Sio/omarchy-tokyoled-theme",
+    "preview_url": "https://raw.githubusercontent.com/Justin-De-Sio/omarchy-tokyoled-theme/main/preview.png"
+  },
+  {
+    "name": "Tycho",
+    "author": "leonardobetti",
+    "type": "dark",
+    "primary_colors": ["red"],
+    "repo_url": "https://github.com/leonardobetti/omarchy-tycho",
+    "preview_url": "https://raw.githubusercontent.com/leonardobetti/omarchy-tycho/main/screenshot.png"
+  },
+  {
+    "name": "White Gold",
+    "author": "HANCORE-linux",
+    "type": "light",
+    "primary_colors": ["orange", "yellow"],
+    "repo_url": "https://github.com/HANCORE-linux/omarchy-whitegold-theme",
+    "preview_url": "https://raw.githubusercontent.com/HANCORE-linux/omarchy-whitegold-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Vesper",
+    "author": "thmoee",
+    "type": "dark",
+    "primary_colors": ["orange"],
+    "repo_url": "https://github.com/thmoee/omarchy-vesper-theme",
+    "preview_url": "https://raw.githubusercontent.com/thmoee/omarchy-vesper-theme/main/assets/Screenshot.png"
+  },
+  {
+    "name": "VHS 80",
+    "author": "tahayvr",
+    "type": "dark",
+    "primary_colors": ["red", "yellow", "green"],
+    "repo_url": "https://github.com/tahayvr/omarchy-vhs80-theme",
+    "preview_url": "https://raw.githubusercontent.com/tahayvr/omarchy-vhs80-theme/refs/heads/main/preview.png"
+  },
+  {
+    "name": "Void",
+    "author": "vyrx-dev",
+    "type": "dark",
+    "primary_colors": ["purple"],
+    "repo_url": "https://github.com/vyrx-dev/omarchy-void-theme",
+    "preview_url": "https://raw.githubusercontent.com/vyrx-dev/omarchy-void-theme/master/assets/setup-1.png"
+  }
+]

--- a/themes/index.html
+++ b/themes/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <title>Omarchy Themes — Community Themes for Omarchy</title>
+
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
+    <meta name="description" content="Community Themes for Omarchy" />
+
+    <meta property="og:site_name" content="Omarchy Themes" />
+    <meta property="og:title" content="Omarchy Themes" />
+    <meta property="og:description" content="Community Themes for Omarchy" />
+    <meta
+      property="og:image"
+      content="https://omarchy.org/assets/images/opengraph.png"
+    />
+    <meta property="og:url" content="https://omarchy.org" />
+    <meta property="og:type" content="website" />
+
+    <meta name="twitter:title" content="Omarchy Themes" />
+    <meta name="twitter:description" content="Community Themes for Omarchy" />
+    <meta
+      name="twitter:image"
+      content="https://omarchy.org/assets/images/opengraph.png"
+    />
+    <meta name="twitter:image:alt" content="Omarchy" />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <link rel="icon" href="../assets/images/favicon.png" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/reset.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/root.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/fonts.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/elements.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/button.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/pre.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/header.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/nav.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/footer.css" />
+    <link rel="stylesheet" type="text/css" href="../assets/css/themes.css" />
+
+    <script src="../assets/js/themes.js" type="module"></script>
+  </head>
+
+  <body>
+    <div class="pre">
+      <a href="/">
+        <pre>
+                 ▄▄▄
+ ▄█████▄    ▄███████████▄    ▄███████   ▄███████   ▄███████   ▄█   █▄    ▄█   █▄
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   ███  ███   ███  ███   ███
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   █▀   ███   ███  ███   ███
+███   ███  ███   ███   ███ ▄███▄▄▄███ ▄███▄▄▄██▀  ███       ▄███▄▄▄███▄ ███▄▄▄███
+███   ███  ███   ███   ███ ▀███▀▀▀███ ▀███▀▀▀▀    ███      ▀▀███▀▀▀███  ▀▀▀▀▀▀███
+███   ███  ███   ███   ███  ███   ███ ██████████  ███   █▄   ███   ███  ▄██   ███
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   ███  ███   ███  ███   ███
+ ▀█████▀    ▀█   ███   █▀   ███   █▀   ███   ███  ███████▀   ███   █▀    ▀█████▀
+                                       ███   █▀
+</pre
+        >
+      </a>
+    </div>
+    <header class="header">
+      <h1>
+        <a
+          href="https://discord.com/channels/1390012484194275541/1399365674832232448"
+          >#omarchy-themes</a
+        >
+      </h1>
+    </header>
+
+    <div class="nav">
+      <div class="nav__filters">
+        <div class="filter-group">
+          <label class="filter-label">Theme Type:</label>
+          <div class="filter-buttons">
+            <button
+              class="filter-button active"
+              data-filter-type="type"
+              data-filter-value="all"
+            >
+              All
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="type"
+              data-filter-value="dark"
+            >
+              Dark
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="type"
+              data-filter-value="light"
+            >
+              Light
+            </button>
+          </div>
+        </div>
+
+        <div class="filter-group">
+          <label class="filter-label">Theme Color:</label>
+          <div class="filter-buttons">
+            <button
+              class="filter-button active"
+              data-filter-type="color"
+              data-filter-value="all"
+            >
+              All
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="red"
+            >
+              Red
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="orange"
+            >
+              Orange
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="yellow"
+            >
+              Yellow
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="green"
+            >
+              Green
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="cyan"
+            >
+              Cyan
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="blue"
+            >
+              Blue
+            </button>
+            <button
+              class="filter-button"
+              data-filter-type="color"
+              data-filter-value="purple"
+            >
+              Purple
+            </button>
+          </div>
+        </div>
+      </div>
+    <div/>
+
+    <main class="main">
+      <div class="themes-grid" id="themesGrid">
+        <!-- Themes will be loaded by JS -->
+      </div>
+
+      <div class="no-results" id="noResults" style="display: none">
+        <p>No themes match your filters. Try selecting different options.</p>
+      </div>
+    </main>
+
+     <footer class="footer">
+      <div class="footer__subhead">
+        <p>Brought to you by <a href="https://37signals.com">37signals</a></p>
+      </div>
+
+      <div class="footer__buttons">
+        <a href="https://basecamp.com"><img src="../assets/images/logo-basecamp.svg" width="145" height="32" alt="Basecamp"></a>
+        <a href="https://hey.com"><img src="../assets/images/logo-hey.svg" width="123" height="57" alt="HEY"></a>
+        <a href="https://fizzy.do"><img src="../assets/images/logo-fizzy.svg" width="56" height="56" alt="Fizzy"></a>
+        <a href="https://once.com"><img src="../assets/images/logo-once.svg" width="72" height="72" alt="ONCE"></a>
+      </div>
+
+      <div class="footer__sponsor">
+        <span>Sponsored hosting by</span>
+        <a href="https://cloudflare.com"><img src="../assets/images/logo-cloudflare.svg" width="213" height="32" alt="Cloudflare"></a>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a Themes page to the site. This will replace the "Extra Themes" page in the Omarchy Manual.

* New `themes.json` includes data for the extra themes made by community.

```json
// sample entry
{
    "name": "VHS 80",
    "author": "tahayvr",
    "type": "dark",
    "primary_colors": ["red", "yellow", "green"],
    "repo_url": "https://github.com/tahayvr/omarchy-vhs80-theme",
    "preview_url": "https://raw.githubusercontent.com/tahayvr/omarchy-vhs80-theme/main/preview.png"
  },
```

* New themes page and `themes.js` that gets the themes data from `themes.json`.

**I didn't add a button for this page in the Homepage nav to avoid conflicts but can do it once this is approved.**