### PR TITLE
Fix invalid rgb() alpha syntax that dropped borders site-wide

### DIFF
--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -12,7 +12,7 @@
 }
 
 .footer__section p {
-  color: rgb(var(--rgb-terminal-white) / 0.6);
+  color: rgba(var(--rgb-terminal-white), 0.6);
   font-size: var(--font-size-small);
   font-weight: 500;
   line-height: 2em;

--- a/assets/css/news.css
+++ b/assets/css/news.css
@@ -9,7 +9,7 @@
   --news-measure: 51.5rem;
   --news-space: 2.75rem;
   --news-space-tight: 0.5rem;
-  --news-border-color: rgb(var(--rgb-terminal-black) / 0.8);
+  --news-border-color: rgba(var(--rgb-terminal-black), 0.8);
   --news-border-width: max(1px, 0.0625em);
 
   background: var(--color-background-night);

--- a/assets/css/root.css
+++ b/assets/css/root.css
@@ -22,7 +22,7 @@
   --color-turquoise: rgb(var(--rgb-turquoise));
   --color-white: rgb(var(--rgb-white));
 
-  --border-color: rgb(var(--rgb-terminal-black) / 0.8);
+  --border-color: rgba(var(--rgb-terminal-black), 0.8);
   --border-width: max(1px, 0.0625em);
 
   --font-family: 'JetBrains Mono', monospace;


### PR DESCRIPTION
Found this little bug while building the theme switcher: `rgb(var(--rgb-terminal-black) / 0.8)` mixes legacy syntax inside the variable which returns invalid CSS, so the border color never rendered at all, for example the news card outlines. Screenshot below:

<img width="1440" height="728" alt="localhost_8090_news_" src="https://github.com/user-attachments/assets/7b4b8aa1-ba2c-4b22-a6af-a38aa92b7054" />
<img width="1440" height="728" alt="localhost_8091_news_" src="https://github.com/user-attachments/assets/7afa3c36-50d6-40ee-a34d-a3d40b71ce33" />
