### PR TITLE
Silence two dev-only warnings

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -713,11 +713,16 @@ export function HeroNavGhost() {
       aria-hidden="true"
       data-nav-ghost
       className="pointer-events-none fixed inset-x-0 top-0 z-(--z-nav) mix-blend-difference"
-      // opacity is declared, not left to the stylesheet, because the header
-      // hydrates before the hero does and its effect writes this very
-      // property onto this node in between; without it here React finds an
-      // inline opacity it never rendered and reports a hydration mismatch.
+      // The header hydrates before the hero does, and its effect writes this
+      // node's opacity in between - 1 with the hero up, 0 with the page
+      // reloaded further down, or the pointer already resting on the bar, or
+      // on a phone. React then hydrates this node against whichever value it
+      // found. Declaring the property keeps React from reporting an inline
+      // style it never rendered; suppressing the warning covers the loads
+      // where the effect's answer was 0. React does not patch attributes on
+      // a mismatch, so the effect's value, the right one, is what stays.
       style={{ paddingTop: 'env(safe-area-inset-top)', opacity: 1 }}
+      suppressHydrationWarning
     >
       <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
         {/* Holds the mark's slot without painting it */}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -116,7 +116,13 @@ const config = defineConfig({
   plugins: [
     ignoreLegacySiteCss(),
     siteFiles(),
-    devtools(),
+    // The devtools mirror the terminal into the browser console and the
+    // browser console into the terminal. Vite 8 does the second half itself
+    // whenever it detects an AI agent (Claude Code, Cursor, Codex, ...), and
+    // the two then echo each other's output forever, one prefix longer each
+    // round, twenty times a second. The panel keeps everything else; server
+    // output stays in the terminal, where it is anyway.
+    devtools({ consolePiping: { enabled: false } }),
     tailwindcss(),
     // The site ships as a folder of static files, the way omarchy.org is
     // hosted: every route is rendered at build time into dist/client, and


### PR DESCRIPTION
Follow-up on https://github.com/omacom/omarchy-site/pull/171
- Started from an AI agent, Vite 8 forwards the browser console into the terminal, and the TanStack devtools forward the terminal into the browser. The two echo each other forever. The devtools' pipe is now off; Vite's side stays.
- The header's effect writes the nav ghost's opacity before the lazy home route hydrates, so React reported a hydration mismatch on reloads below the hero. Nothing was visually wrong. That one node now carries `suppressHydrationWarning`.