### PR TITLE
Point live plugin links at plugins.omarchy.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ to put on the page.
 ## Plugins
 
 Plugins aren't in this repository. They're listed on
-[omarchyplugins.com](https://omarchyplugins.com/) from the
-[marketplace repo](https://github.com/HANCORE-linux/omarchy-plugin-marketplace),
+[plugins.omarchy.org](https://plugins.omarchy.org/) from the
+[marketplace repo](https://github.com/omacom/omarchy-plugin-marketplace),
 which has its own submission guide.

--- a/air/index.html
+++ b/air/index.html
@@ -74,7 +74,7 @@
           <article class="resident">
             <img class="resident__avatar" src="/assets/images/air/hancore.webp" width="240" height="240" alt="HANCORE" loading="lazy" decoding="async">
             <h3 class="resident__name"><a href="https://github.com/HANCORE-linux">HANCORE</a></h3>
-            <p><a href="/manual/themes/">Solitude and Last Horizon</a> both ship with Omarchy, and another twenty of his themes sit on <a href="/themes/">the extras page</a> &mdash; more than anyone else has contributed: Batou, Oxo Carbon, Velvet Night, Rose of Dune, Shades of Jade, and on it goes. He&rsquo;s a mechanical engineer who became one of the defining aesthetic forces in this community, sits on <a href="/teams/">Omarchy Core</a>, and helps steward <a href="https://omarchyplugins.com/">the plugin ecosystem</a>.</p>
+            <p><a href="/manual/themes/">Solitude and Last Horizon</a> both ship with Omarchy, and another twenty of his themes sit on <a href="/themes/">the extras page</a> &mdash; more than anyone else has contributed: Batou, Oxo Carbon, Velvet Night, Rose of Dune, Shades of Jade, and on it goes. He&rsquo;s a mechanical engineer who became one of the defining aesthetic forces in this community, sits on <a href="/teams/">Omarchy Core</a>, and helps steward <a href="https://plugins.omarchy.org/">the plugin ecosystem</a>.</p>
           </article>
 
           <article class="resident">


### PR DESCRIPTION
AIR page + README are current docs, so they should name the live marketplace host (`plugins.omarchy.org`) rather than the old `omarchyplugins.com` URL (that host still redirects).

Historical news posts are left alone. They were correct when published (Aug 19 competition, Aug 28 winners, AIR intro, Core Team).

Companion PR on the distro manual: https://github.com/omacom/omarchy/pull/10499