### PR TITLE
Update the nav mark to the new brand gradient

### DIFF
--- a/src/components/Brand.tsx
+++ b/src/components/Brand.tsx
@@ -24,16 +24,60 @@ export function OmarchyMark({ className }: { className?: string }) {
   )
 }
 
+/** Brand gradient bands as wordmark pixel rows, shared by wordmark and mark. */
+const BRAND_BANDS: [color: string, rows: number][] = [
+  ['var(--t-field-crest)', 5],
+  ['var(--t-field-hover)', 2],
+  ['var(--t-field-lit)', 4],
+  ['var(--t-field-mid)', 3],
+  ['var(--t-field-dim)', 5],
+]
+const BAND_ROWS = BRAND_BANDS.reduce((sum, [, rows]) => sum + rows, 0)
+
+/** Band edges in percent of the height. */
+const BAND_STOPS = BRAND_BANDS.reduce<{
+  stops: [string, number, number][]
+  rows: number
+}>(
+  ({ stops, rows }, [color, band]) => {
+    const pct = (n: number) => Math.round((n / BAND_ROWS) * 100000) / 1000
+    return {
+      stops: [...stops, [color, pct(rows), pct(rows + band)]],
+      rows: rows + band,
+    }
+  },
+  { stops: [], rows: 0 },
+).stops
+
 export function OmarchyMarkDrawn({ className }: { className?: string }) {
   return (
     <svg
       viewBox="0 0 1200 1200"
       fill="none"
-      stroke="currentColor"
+      stroke="url(#mark-bands)"
       strokeWidth="80"
       aria-hidden="true"
       className={cn('mark-draw', className)}
     >
+      <defs>
+        <linearGradient
+          id="mark-bands"
+          gradientUnits="userSpaceOnUse"
+          x1="0"
+          y1="0"
+          x2="0"
+          y2="1200"
+        >
+          {BAND_STOPS.flatMap(([color, from, to]) => [
+            <stop
+              key={`${color}-from`}
+              offset={`${from}%`}
+              stopColor={color}
+            />,
+            <stop key={`${color}-to`} offset={`${to}%`} stopColor={color} />,
+          ])}
+        </linearGradient>
+      </defs>
       <path pathLength={1} d="M640 1160H40V40H1160V1160H720" />
       <path pathLength={1} d="M600 40V200" />
       <path pathLength={1} d="M640 200H200V1000H1000V200H880" />
@@ -43,8 +87,9 @@ export function OmarchyMarkDrawn({ className }: { className?: string }) {
   )
 }
 
-export const WORDMARK_BANDS =
-  'linear-gradient(to bottom, var(--t-field-crest) 0 26.316%, var(--t-field-hover) 26.316% 36.842%, var(--t-field-lit) 36.842% 57.895%, var(--t-field-mid) 57.895% 73.684%, var(--t-field-dim) 73.684% 100%)'
+export const WORDMARK_BANDS = `linear-gradient(to bottom, ${BAND_STOPS.map(
+  ([color, from, to]) => `${color} ${from}% ${to}%`,
+).join(', ')})`
 
 type WordmarkProps = {
   className?: string

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -439,7 +439,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
       onClick={homeLink}
       className="mark-draw-trigger relative flex items-center"
     >
-      <OmarchyMarkDrawn className="size-[22px] shrink-0 text-brand transition-opacity duration-150 ease-out max-sm:group-data-[nav-past-hero]/bar:opacity-0 lg:size-[calc(var(--pxc)*2)]" />
+      <OmarchyMarkDrawn className="size-[22px] shrink-0 transition-opacity duration-150 ease-out max-sm:group-data-[nav-past-hero]/bar:opacity-0 lg:size-[calc(var(--pxc)*2)]" />
       <OmarchyWordmark className="absolute top-1/2 left-0 w-28 -translate-y-1/2 text-brand opacity-0 transition-opacity duration-150 ease-out group-data-[nav-past-hero]/bar:opacity-100 sm:hidden" />
     </Link>
   )


### PR DESCRIPTION
As discussed in the design chat: the gradient is now core brand identity, so the mark in the nav wears it too.

- The drawn mark strokes with the five brand bands (crest, hover, lit, mid, dim) instead of the flat brand color, the same tokens the wordmark already uses, so it follows every theme.
- The gradient sits in user space over the mark's full height, so all five strokes read the same band at the same height rather than each path carrying its own.
- The hover draw is untouched; it only moves the dash offset.
- The split is the wordmark's, 19 rows cut 5, 2, 4, 3, 5, which is also how the logo on the brand sheet is cut; the wordmark's CSS gradient and the mark's SVG stops now come from that one list.

<img width="676" height="174" alt="image" src="https://github.com/user-attachments/assets/f2a6760e-aff8-4bcd-9b03-43e7df2a6112" />
