### PR TITLE
Draw the nav mark's strokes in their own order again

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2125,21 +2125,21 @@ h6 {
 .mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path {
   animation: mark-draw 650ms cubic-bezier(0.45, 0, 0.25, 1) both;
 }
-.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-child(2) {
+.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-of-type(2) {
   animation-duration: 110ms;
   animation-delay: 250ms;
   animation-timing-function: ease-out;
 }
-.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-child(3) {
+.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-of-type(3) {
   animation-duration: 470ms;
   animation-delay: 360ms;
 }
-.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-child(4) {
+.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-of-type(4) {
   animation-name: mark-draw-back;
   animation-duration: 70ms;
   animation-delay: 540ms;
 }
-.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-child(5) {
+.mark-draw-trigger:is(:hover, :focus-visible) .mark-draw path:nth-of-type(5) {
   animation-name: mark-draw-back;
   animation-duration: 70ms;
   animation-delay: 600ms;


### PR DESCRIPTION
The hover draw of the nav mark lost its order with the gradient in #201: the gradient's <defs> became the SVG's first child, so the path:nth-child rules in the draw animation each hit the path after the one they were written for. The outer frame got the stub's 110 ms, the inner frame ran backwards, and the last stroke had no timing at all.

The rules now count with nth-of-type, so only the paths count and each stroke draws with its own timing again, whatever else the SVG holds.