### PR TITLE
Add Omarchy-style navigation and animated hero announcement

### DIFF
--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { t, language } from '@/i18n/site'
 import { Link } from '@tanstack/react-router'
-import { useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import {
   AppleIcon,
   ArrowRightIcon,
@@ -17,8 +17,8 @@ import {
   WindowsIcon,
 } from '@/components/icons'
 import { OmarchyWordmark, WORDMARK_BANDS } from '@/components/Brand'
-import { HeroNavGhost } from '@/components/SiteHeader'
 import { HeroShader } from '@/components/HeroShader'
+import { AnnouncementText } from '@/components/AnnouncementText'
 import { EtchPicker } from '@/components/EtchPicker'
 import { CardRail } from '@/components/CardRail'
 import { Figures } from '@/components/Figures'
@@ -199,32 +199,37 @@ const banner = bannerData as typeof bannerData | null
 const NEWS_PATH = /^\/news\/(\d{4})\/(\d{2})\/([^/]+)\/?$/
 
 function HeroCallout({ href, html }: { href: string; html: string }) {
-  const className =
-    'group inline-flex max-w-full items-center gap-2 border border-brand/40 bg-bg/60 px-3.5 py-1.5 text-left font-mono text-[13px] leading-snug text-brand transition-colors duration-150 ease-out hover:border-brand hover:bg-brand hover:text-bg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
+  const [paused, setPaused] = useState(false)
   const inner = (
     <>
-      <span
-        className="min-w-0 [&_s]:text-current/60"
-        dangerouslySetInnerHTML={{ __html: t(html) }}
-      />
-      <ArrowRightIcon className="size-4 shrink-0 transition-transform duration-150 ease-out group-hover:translate-x-0.5" />
+      <span className="hero-announcement__prompt" aria-hidden="true">›</span>
+      <AnnouncementText html={t(html)} identity={href} paused={paused} />
     </>
   )
   const news = NEWS_PATH.exec(href)
-  if (news)
-    return (
-      <Link
-        to="/news/$year/$month/$slug/"
-        params={{ year: news[1], month: news[2], slug: news[3] }}
-        className={className}
-      >
-        {inner}
-      </Link>
-    )
   return (
-    <a href={href} className={className}>
-      {inner}
-    </a>
+    <div className="hero-announcement-frame">
+      {/* No visible badge. Keep a persistent pause control available to
+          screen readers and reveal it on keyboard focus. */}
+      <button
+        type="button"
+        className="hero-announcement__pause sr-only"
+        onClick={() => setPaused(value => !value)}
+      >
+        {paused ? t('Resume news animation') : t('Pause news animation')}
+      </button>
+      {news ? (
+        <Link
+          to="/news/$year/$month/$slug/"
+          params={{ year: news[1], month: news[2], slug: news[3] }}
+          className="hero-announcement"
+        >
+          {inner}
+        </Link>
+      ) : (
+        <a href={href} className="hero-announcement">{inner}</a>
+      )}
+    </div>
   )
 }
 
@@ -235,6 +240,7 @@ export function HomePage({ data }: { data: HomeData }) {
   const installLink = useHashLink('install')
   const watchLink = useHashLink('watch')
   const [painted, setPainted] = useState(false)
+  const onHeroPainted = useCallback(() => setPainted(true), [])
   const [etchAsked, setEtchAsked] = useState(false)
   useEffect(() => {
     setEtchAsked(new URLSearchParams(window.location.search).has('etch'))
@@ -331,24 +337,11 @@ export function HomePage({ data }: { data: HomeData }) {
         }
         style={{ background: 'var(--t-field-bg)' }}
       >
-        <HeroShader onPainted={() => setPainted(true)} />
+        <HeroShader onPainted={onHeroPainted} />
         {etchAsked ? <EtchPicker /> : null}
-
-        {/* The bar's labels, blended against the canvas. They have to live in
-            here to reach it: the real header is sticky, and a sticky element
-            isolates everything inside it from the page behind. */}
-        <HeroNavGhost />
 
         <div className="pointer-events-none relative flex flex-1 flex-col items-center px-6">
           <div className="flex-1" />
-          {banner ? (
-            <div
-              data-hero-quiet
-              className="pointer-events-auto mb-12 flex w-full justify-center lg:mb-[calc(var(--pxr)*5)]"
-            >
-              <HeroCallout href={banner.href} html={banner.html} />
-            </div>
-          ) : null}
           {/* The slot the field measures its cell size from. Server-rendered
               as the SVG so the wordmark is there before any script runs, then
               handed over to the canvas once it has painted the same pixels. */}
@@ -401,19 +394,31 @@ export function HomePage({ data }: { data: HomeData }) {
               </span>
             </p>
 
+            {banner ? (
+              <div
+                data-hero-announcement
+                className="mt-7 flex w-full justify-center"
+              >
+                <HeroCallout href={banner.href} html={banner.html} />
+              </div>
+            ) : null}
+
             <div
               data-hero-stagger
               data-hero-cta
-              style={{ '--stagger': 2 } as React.CSSProperties}
-              className="mt-9 flex w-full max-w-xs flex-col items-stretch gap-3 sm:w-auto sm:max-w-none sm:flex-row lg:gap-[calc(var(--pxc)*2)]"
+              style={{ '--stagger': banner ? 3 : 2 } as React.CSSProperties}
+              className={cn(
+                'flex w-full max-w-xs flex-col items-stretch gap-3 sm:w-auto sm:max-w-none sm:flex-row lg:gap-[calc(var(--pxc)*2)]',
+                banner ? 'mt-3' : 'mt-9',
+              )}
             >
               {/* Both stay fully opaque, hover included: the default hover
                   drops the fill to 80% and the outline variant is a tinted
                   translucent panel, which lets the field show through the
                   one place on the site with a moving background. Both are
-                  40px tall, the pill above the word 32px: two heights on
-                  one 8px grid, and the pill stays a line, not a third
-                  button. Width follows the label. The padding is set by
+                  40px tall; the announcement above remains a lighter link,
+                  not a third primary action. Width follows the label.
+                  The padding is set by
                   eye: 16px on the text side, 12px on the icon side, since
                   the glyphs leave white space inside their own box and the
                   eye adds it to the padding. The play triangle also moves a

--- a/src/components/AnnouncementText.tsx
+++ b/src/components/AnnouncementText.tsx
@@ -11,9 +11,9 @@ const REPEAT_INTERVAL_MS = 6_000
 
 /**
  * The registry's ASCII scramble, including the highlighted amount. Each
- * position resolves independently over 26 ticks. Starts are six seconds
- * apart while visible, with no per-session cap. Keyboard pause, hover,
- * focus, hidden tabs and reduced motion keep the complete message still.
+ * position resolves independently over 26 ticks. Fine-pointer starts repeat
+ * every six seconds while visible; touch-only devices play once. Keyboard
+ * pause, hover, focus, hidden tabs and reduced motion keep the message still.
  * The real message remains available to screen readers and without JS.
  * `html` is trusted repository content, not user input.
  */
@@ -45,6 +45,9 @@ export function AnnouncementText({
       element.closest('.hero-announcement-frame') ?? element.closest('a')
     const hero = element.closest('[data-hero-sentinel]')
     const motion = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const canHover = window.matchMedia(
+      '(any-hover: hover) and (any-pointer: fine)',
+    )
     const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
     const replacements: Array<{ wrapper: HTMLSpanElement; text: Text }> = []
     let disposed = false
@@ -77,8 +80,10 @@ export function AnnouncementText({
       playing = false
     }
 
+    const canSchedule = () => canPlay() && (plays === 0 || canHover.matches)
+
     const schedule = () => {
-      if (!canPlay() || !ready || playing || timer !== undefined) return
+      if (!canSchedule() || !ready || playing || timer !== undefined) return
       timer = window.setTimeout(
         () => {
           timer = undefined
@@ -204,6 +209,8 @@ export function AnnouncementText({
       if (!canPlay()) {
         clearTimer()
         if (playing) restore()
+      } else if (!canSchedule()) {
+        clearTimer()
       } else {
         schedule()
       }
@@ -231,6 +238,7 @@ export function AnnouncementText({
     interaction?.addEventListener('focusin', sync)
     interaction?.addEventListener('focusout', afterFocus)
     motion.addEventListener('change', sync)
+    canHover.addEventListener('change', sync)
     document.addEventListener('visibilitychange', sync)
     return () => {
       disposed = true
@@ -244,6 +252,7 @@ export function AnnouncementText({
       interaction?.removeEventListener('focusin', sync)
       interaction?.removeEventListener('focusout', afterFocus)
       motion.removeEventListener('change', sync)
+      canHover.removeEventListener('change', sync)
       document.removeEventListener('visibilitychange', sync)
     }
   }, [html, identity, paused])

--- a/src/components/AnnouncementText.tsx
+++ b/src/components/AnnouncementText.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { HERO_READY_EVENT } from '@/lib/etch'
+import {
+  SCRAMBLE_IN_TICKS,
+  SCRAMBLE_TICK_MS,
+  announcementMarkup,
+  scrambleGlyph,
+} from '@/lib/announcement-scramble'
+
+const REPEAT_INTERVAL_MS = 6_000
+
+/**
+ * The registry's ASCII scramble, including the highlighted amount. Each
+ * position resolves independently over 26 ticks. Starts are six seconds
+ * apart while visible, with no per-session cap. Keyboard pause, hover,
+ * focus, hidden tabs and reduced motion keep the complete message still.
+ * The real message remains available to screen readers and without JS.
+ * `html` is trusted repository content, not user input.
+ */
+export function AnnouncementText({
+  html,
+  identity,
+  paused = false,
+}: {
+  html: string
+  identity: string
+  paused?: boolean
+}) {
+  const visual = useRef<HTMLSpanElement>(null)
+  // Parent renders must not rewrite the opaque HTML subtree while its
+  // decorative character spans are active.
+  const markup = useMemo(() => ({ __html: announcementMarkup(html) }), [html])
+
+  useEffect(() => {
+    const element = visual.current
+    if (
+      !element ||
+      paused ||
+      typeof IntersectionObserver === 'undefined' ||
+      typeof Intl.Segmenter !== 'function'
+    )
+      return
+
+    const interaction =
+      element.closest('.hero-announcement-frame') ?? element.closest('a')
+    const hero = element.closest('[data-hero-sentinel]')
+    const motion = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    const replacements: Array<{ wrapper: HTMLSpanElement; text: Text }> = []
+    let disposed = false
+    let visible = false
+    let playing = false
+    let plays = 0
+    let lastStartedAt = 0
+    let ready = !hero || hero.hasAttribute('data-hero-ready')
+    let timer: number | undefined
+    let ticker: number | undefined
+
+    const canPlay = () =>
+      !disposed &&
+      visible &&
+      !document.hidden &&
+      !motion.matches &&
+      !interaction?.matches(':hover, :focus-within')
+
+    const clearTimer = () => {
+      window.clearTimeout(timer)
+      timer = undefined
+    }
+
+    const restore = () => {
+      window.clearInterval(ticker)
+      ticker = undefined
+      for (const { wrapper, text } of replacements) wrapper.replaceWith(text)
+      replacements.length = 0
+      element.dataset.announcementPhase = 'idle'
+      playing = false
+    }
+
+    const schedule = () => {
+      if (!canPlay() || !ready || playing || timer !== undefined) return
+      timer = window.setTimeout(
+        () => {
+          timer = undefined
+          play()
+        },
+        plays === 0
+          ? 180
+          : Math.max(
+              0,
+              REPEAT_INTERVAL_MS - (performance.now() - lastStartedAt),
+            ),
+      )
+    }
+
+    const play = () => {
+      if (!canPlay() || playing) return
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      const chunks: Array<{
+        text: Text
+        characters: string[]
+        emphasized: boolean
+      }> = []
+      let count = 0
+      while (walker.nextNode()) {
+        const text = walker.currentNode as Text
+        const characters = Array.from(
+          segmenter.segment(text.data),
+          (part) => part.segment,
+        )
+        count += characters.length
+        if (count > 200) return
+        chunks.push({
+          text,
+          characters,
+          emphasized: !!text.parentElement?.closest('strong'),
+        })
+      }
+      if (!count) return
+
+      const cells: Array<{
+        element: HTMLSpanElement
+        original: string
+        settlesAt: number
+        emphasized: boolean
+      }> = []
+      for (const { text, characters, emphasized } of chunks) {
+        const wrapper = document.createElement('span')
+        text.replaceWith(wrapper)
+        replacements.push({ wrapper, text })
+        let word: HTMLSpanElement | undefined
+        for (const character of characters) {
+          if (/\s/u.test(character)) {
+            wrapper.append(document.createTextNode(character))
+            word = undefined
+            continue
+          }
+          if (!word) {
+            word = document.createElement('span')
+            word.style.whiteSpace = 'nowrap'
+            wrapper.append(word)
+          }
+          // Keep extended graphemes intact rather than narrowing an emoji
+          // or separating a combining mark into a one-column ASCII cell.
+          if (!/^[\x21-\x7e]$/u.test(character)) {
+            word.append(document.createTextNode(character))
+            continue
+          }
+          const cell = document.createElement('span')
+          cell.style.display = 'inline-block'
+          cell.style.width = '1ch'
+          word.append(cell)
+          cells.push({
+            element: cell,
+            original: character,
+            settlesAt: 1 + Math.floor(Math.random() * SCRAMBLE_IN_TICKS),
+            emphasized,
+          })
+        }
+      }
+      if (!cells.length) {
+        restore()
+        return
+      }
+      playing = true
+      plays += 1
+      lastStartedAt = performance.now()
+      element.dataset.announcementPhase = 'scrambling'
+      element.dataset.announcementPlay = String(plays)
+      let tick = 0
+      const paint = () => {
+        for (const cell of cells) {
+          const settled = tick >= cell.settlesAt
+          cell.element.textContent = scrambleGlyph(
+            cell.original,
+            tick,
+            cell.settlesAt,
+          )
+          cell.element.style.color =
+            settled || cell.emphasized
+              ? 'inherit'
+              : Math.random() < 0.24
+                ? 'var(--color-brand)'
+                : 'var(--color-text-muted)'
+        }
+      }
+      paint()
+      ticker = window.setInterval(() => {
+        if (!canPlay()) {
+          sync()
+          return
+        }
+        tick += 1
+        if (tick > SCRAMBLE_IN_TICKS) {
+          restore()
+          schedule()
+        } else {
+          paint()
+        }
+      }, SCRAMBLE_TICK_MS)
+    }
+
+    const sync = () => {
+      if (!canPlay()) {
+        clearTimer()
+        if (playing) restore()
+      } else {
+        schedule()
+      }
+    }
+    const afterFocus = () => queueMicrotask(sync)
+    const onReady = () => {
+      ready = true
+      window.clearTimeout(fallback)
+      sync()
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry.isIntersecting && entry.intersectionRatio >= 0.5
+        sync()
+      },
+      { threshold: 0.5 },
+    )
+    // Even a late/unavailable canvas must not suppress every play. The full
+    // message stays readable while waiting; later plays are logo-independent.
+    const fallback = window.setTimeout(onReady, 8000)
+    observer.observe(element)
+    hero?.addEventListener(HERO_READY_EVENT, onReady)
+    interaction?.addEventListener('pointerenter', sync)
+    interaction?.addEventListener('pointerleave', sync)
+    interaction?.addEventListener('focusin', sync)
+    interaction?.addEventListener('focusout', afterFocus)
+    motion.addEventListener('change', sync)
+    document.addEventListener('visibilitychange', sync)
+    return () => {
+      disposed = true
+      clearTimer()
+      window.clearTimeout(fallback)
+      restore()
+      observer.disconnect()
+      hero?.removeEventListener(HERO_READY_EVENT, onReady)
+      interaction?.removeEventListener('pointerenter', sync)
+      interaction?.removeEventListener('pointerleave', sync)
+      interaction?.removeEventListener('focusin', sync)
+      interaction?.removeEventListener('focusout', afterFocus)
+      motion.removeEventListener('change', sync)
+      document.removeEventListener('visibilitychange', sync)
+    }
+  }, [html, identity, paused])
+
+  return (
+    <span className="hero-announcement__text">
+      <span className="sr-only" dangerouslySetInnerHTML={markup} />
+      <span
+        ref={visual}
+        aria-hidden="true"
+        data-announcement-visual
+        data-announcement-phase="idle"
+        data-announcement-play="0"
+        dangerouslySetInnerHTML={markup}
+      />
+    </span>
+  )
+}

--- a/src/components/HeroPixelField.tsx
+++ b/src/components/HeroPixelField.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/data/wordmark-bitmap'
 import {
   ETCH_EVENT,
+  HERO_READY_EVENT,
   effectFromLocation,
   resolveEffect,
   startEtch,
@@ -1038,6 +1039,12 @@ export function HeroPixelField({
         paintedRef.current = true
         onPainted?.()
       }
+      // Announcements wait for the finished logo, not merely the first
+      // canvas frame. Theme replays do not restart a one-shot announcement.
+      if (isHero && !etching && sectionEl && !sectionEl.hasAttribute('data-hero-ready')) {
+        sectionEl.setAttribute('data-hero-ready', '')
+        sectionEl.dispatchEvent(new Event(HERO_READY_EVENT))
+      }
     }
 
     let frame = 0
@@ -1214,7 +1221,10 @@ export function HeroPixelField({
       window.removeEventListener('pointerup', onPointerUp)
       window.removeEventListener('pointercancel', onPointerCancel)
       window.removeEventListener('contextmenu', onPointerCancel)
-      if (isHero) window.dispatchEvent(new CustomEvent(GRID_CLEAR_EVENT))
+      if (isHero) {
+        sectionEl?.removeAttribute('data-hero-ready')
+        window.dispatchEvent(new CustomEvent(GRID_CLEAR_EVENT))
+      }
     }
   }, [onPainted, isHero])
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@base-ui/react/popover'
 import { useState } from 'react'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { hasTranslation, language, locale, locales, t } from '@/i18n/site'
 
 function flag(domain: string, countryCode?: string) {
@@ -13,7 +14,13 @@ function flag(domain: string, countryCode?: string) {
     : '🌐'
 }
 
-export function LanguageSwitcher({ path }: { path: string }) {
+export function LanguageSwitcher({
+  path,
+  triggerClassName,
+}: {
+  path: string
+  triggerClassName?: string
+}) {
   const [suffix, setSuffix] = useState('')
 
   return (
@@ -31,7 +38,10 @@ export function LanguageSwitcher({ path }: { path: string }) {
             size="icon"
             aria-label={`${t('Language')}: ${locale.name}`}
             data-nav-glyph
-            className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
+            className={cn(
+              'relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]',
+              triggerClassName,
+            )}
           />
         }
       >

--- a/src/components/NotFoundHero.tsx
+++ b/src/components/NotFoundHero.tsx
@@ -2,7 +2,6 @@ import { t } from '@/i18n/site'
 import { useState } from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { HeroShader } from '@/components/HeroShader'
-import { HeroNavGhost } from '@/components/SiteHeader'
 import { NotFoundWordmark } from '@/components/Brand'
 import { ArrowLeftIcon } from '@/components/icons'
 import {
@@ -26,7 +25,6 @@ export function NotFoundHero() {
   const home = useTopLink()
 
   return (
-    // The header watches this hero sentinel and paints its blended labels here.
     <main>
       <section
         data-hero-sentinel
@@ -38,8 +36,6 @@ export function NotFoundHero() {
           onPainted={() => setPainted(true)}
           onGlyphPress={() => void navigate({ to: '/' })}
         />
-
-        <HeroNavGhost />
 
         <div className="pointer-events-none relative flex flex-1 flex-col items-center px-6">
           <div className="flex-[0.5]" />

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,18 +1,16 @@
 import { t } from '@/i18n/site'
 import { Link, useLocation } from '@tanstack/react-router'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import type { ReactElement, RefObject } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
 import {
   DownloadIcon,
   GithubIcon,
-  MENU_BARS_FOLD_MS,
   MenuBarsIcon,
   PaletteIcon,
   RssIcon,
   SearchIcon,
 } from '@/components/icons'
-import { OmarchyMarkDrawn, OmarchyWordmark } from '@/components/Brand'
-import { GlobeIcon } from '@/components/icons/GlobeIcon'
+import { OmarchyMarkDrawn } from '@/components/Brand'
 import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { MusicMenuControl } from '@/components/MusicControl'
 import { Button } from '@/components/ui/button'
@@ -23,9 +21,8 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useHashLink, useTopLink } from '@/lib/hash-scroll'
-import { OPEN_PICKER_EVENT, THEME_EVENT, groundOf } from '@/lib/theme'
+import { OPEN_PICKER_EVENT } from '@/lib/theme'
 import { OPEN_SEARCH_EVENT } from '@/lib/search'
-import { cn } from '@/lib/utils'
 
 function NavTooltip({
   children,
@@ -42,7 +39,7 @@ function NavTooltip({
       <TooltipContent side="bottom" sideOffset={10}>
         {label}
         {shortcut && (
-          <kbd className="ml-1 rounded border border-current/25 px-1 font-mono text-[11px] opacity-75">
+          <kbd className="ml-1 border border-current/25 px-1 font-mono text-[11px] opacity-75">
             {shortcut}
           </kbd>
         )}
@@ -54,375 +51,60 @@ function NavTooltip({
 const navLinks = [
   { to: '/news/', label: t('News') },
   { to: '/manual/', label: t('Manual') },
-  // Old /plugins/ addresses redirect to the standalone directory.
   { href: 'https://plugins.omarchy.org', label: 'Plugins' },
   { to: '/themes/', label: t('Themes') },
 ] as const
 
-/** Observe the live hero sentinel; the header and blended labels share this state. */
-/** Choose the visible label layer before paint to prevent a navigation flash. */
-const useBeforePaint =
-  typeof document === 'undefined' ? useEffect : useLayoutEffect
-
-function useHeroInView(seed: boolean) {
-  const [heroInView, setHeroInView] = useState(seed)
-
-  useBeforePaint(() => {
-    let observer: IntersectionObserver | null = null
-    let sizeWatcher: ResizeObserver | null = null
-    let settling = 0
-    /** The sentinel currently being observed - the element, not the route.
-     *  On a client-side navigation the pathname changes before the DOM does:
-     *  the outgoing page is still mounted, so an effect keyed on the route
-     *  attaches to the outgoing page's sentinel, and when that node is
-     *  removed a moment later its observer fires one last time with
-     *  isIntersecting false. That false was permanent - the route never
-     *  changes again, so nothing re-attached, and the bar arrived at every
-     *  hero page unblended. Tracking the element makes the swap visible:
-     *  the live sentinel is no longer the watched one, so watch it instead.
-     */
-    let watched: Element | null | undefined
-
-    // The same question the observer answers, asked directly: is the hero's
-    // bottom edge still below the bar's? Asking it at once matters because
-    // the answer is needed on the first frame, and an observer's first
-    // callback is not guaranteed to have arrived by then - or at all, while
-    // the tab is not being rendered. The observer then keeps it current.
-    //
-    // null where nothing has been laid out: an unrendered tab measures every
-    // box at zero, and zero is not "the hero has scrolled away", it is "no
-    // one has asked yet". Answering it would put the bar in the wrong state
-    // with no second measurement coming to correct it.
-    const covers = (hero: Element, bar: Element) => {
-      const barBox = bar.getBoundingClientRect()
-      if (barBox.height === 0) return null
-      return hero.getBoundingClientRect().bottom > barBox.height
-    }
-
-    /**
-     * Take the measurement, and if there is nothing to measure yet, come back
-     * for it. Bounded, because a tab that is never rendered never lays
-     * anything out and would otherwise be asked forever; the observer is
-     * still watching either way, and answers as soon as it is shown.
-     */
-    const settle = (hero: Element, bar: Element, tries = 3) => {
-      const covered = covers(hero, bar)
-      if (covered !== null) {
-        setHeroInView(covered)
-        return
-      }
-      if (tries > 0)
-        settling = requestAnimationFrame(() => settle(hero, bar, tries - 1))
-    }
-
-    const watch = (hero: Element, bar: Element) => {
-      observer?.disconnect()
-      // The moment to swap is when the bar's bottom edge meets the hero's,
-      // which is the one border the hero and the section under it share.
-      // Inset the root by the bar's measured height so the two edges are
-      // compared directly: hardcoding it went off by the bar's border, and
-      // by a whole row on the narrow layout where the nav wraps under.
-      const height = bar.getBoundingClientRect().height
-      observer = new IntersectionObserver(
-        ([entry]) => setHeroInView(entry.isIntersecting),
-        { rootMargin: `-${height}px 0px 0px 0px` },
-      )
-      observer.observe(hero)
-    }
-
-    /**
-     * Point everything at whatever sentinel the page has right now. A no-op
-     * while the watched one is still the live one; a teardown-and-reattach
-     * the moment it is not, whether the page swapped its hero for another or
-     * for nothing. Disconnecting the old observer first also discards any
-     * report it has queued about the node that just left.
-     */
-    const sync = () => {
-      const hero = document.querySelector('[data-hero-sentinel]')
-      if (hero === watched) return
-      observer?.disconnect()
-      sizeWatcher?.disconnect()
-      cancelAnimationFrame(settling)
-      watched = hero
-      const bar = document.querySelector('header')
-      if (!hero || !bar) {
-        // Nothing over the bar right now - which is the right answer both on
-        // a page with no hero and on one whose chunk is still loading, since
-        // the arrivals watcher below re-runs this when a hero does mount.
-        setHeroInView(false)
-        return
-      }
-      settle(hero, bar)
-      watch(hero, bar)
-      // The bar grows a second row of links on narrow screens, so the edge
-      // it is measured against moves with the layout.
-      sizeWatcher = new ResizeObserver(() => watch(hero, bar))
-      sizeWatcher.observe(bar)
-    }
-
-    // Every arrival and departure funnels through sync, which is what lets
-    // this run once for the life of the header instead of once per route:
-    // the DOM says when the hero changes, and the DOM is what is being
-    // watched, so there is nothing for the route to add.
-    const arrivals = new MutationObserver(sync)
-    arrivals.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    })
-    sync()
-
-    return () => {
-      cancelAnimationFrame(settling)
-      observer?.disconnect()
-      sizeWatcher?.disconnect()
-      arrivals.disconnect()
-    }
-  }, [])
-
-  return heroInView
-}
-
-/** Write surface opacity to CSS while scrolling; measure section geometry once per layout. */
-function useNavSurface(
-  sheetOpen: boolean,
-  /** The blended ghost is up behind the bar, so the real labels stand aside. */
-  blended: boolean,
-  bar: RefObject<HTMLElement | null>,
-  /** Re-surveyed on arrival at a new page, whose sections are its own. */
-  pathname: string,
-) {
-  const wasOpen = useRef(sheetOpen)
-  useEffect(() => {
-    const el = bar.current
-    if (!el) return
-    const justClosed = wasOpen.current && !sheetOpen
-    wasOpen.current = sheetOpen
-    // Keep real labels visible until the menu toggle finishes its closing animation.
-    let holding = blended && justClosed
-
-    const solid = (on: boolean) => {
-      // Render the label state as an attribute so it also applies before hydration.
-      if (!on && holding) return
-      if (on) el.removeAttribute('data-nav-blend')
-      else el.setAttribute('data-nav-blend', '')
-      const ghost = document.querySelector<HTMLElement>('[data-nav-ghost]')
-      if (ghost) ghost.style.opacity = on ? '0' : '1'
-    }
-
-    type Ground = { top: number; bottom: number; colour: string }
-    let grounds: Ground[] = []
-    let height = 0
-    /** The hero bottom in page coordinates. */
-    let heroBottom = 0
-    /** The <main> the last survey read. The route changes before the DOM
-     *  does, so the one mounted when this effect runs may be the outgoing
-     *  page's; comparing identities is how the swap is noticed. */
-    let surveyed: Element | null = null
-    let heroUp = false
-    // Read hover state immediately on navigation; only mouse pointers have persistent hover.
-    let hovering =
-      window.matchMedia('(hover: hover)').matches && el.matches(':hover')
-
-    const survey = () => {
-      // Keep the size watcher pointed at whichever <main> is actually
-      // mounted; the one this effect started with may already be gone.
-      const main = document.querySelector('main')
-      if (main !== surveyed) {
-        surveyed = main
-        sizes.disconnect()
-        if (main) sizes.observe(main)
-      }
-      const hero = document.querySelector('[data-hero-sentinel]')
-      heroUp = hero !== null
-      heroBottom = hero
-        ? hero.getBoundingClientRect().bottom + window.scrollY
-        : 0
-      height = el.getBoundingClientRect().height
-      const sections = document.querySelectorAll<HTMLElement>(
-        'main > section, main [data-ground]',
-      )
-      const nodes = sections.length
-        ? [...sections]
-        : [...document.querySelectorAll<HTMLElement>('main')]
-
-      const footer = document.querySelector<HTMLElement>('footer')
-      if (footer) nodes.push(footer)
-
-      grounds = nodes
-        .filter((node) => !node.hasAttribute('data-hero-sentinel'))
-        .map((node) => {
-          const box = node.getBoundingClientRect()
-          return {
-            top: box.top + window.scrollY,
-            bottom: box.bottom + window.scrollY,
-            colour: groundOf(node) ?? 'var(--color-bg)',
-          }
-        })
-      return grounds.length > 0
-    }
-
-    /**
-     * The bar carries a section's colour only while it is wholly inside that
-     * section: from the moment its own top edge meets the section's top, to
-     * the moment its bottom edge meets the section's bottom. Outside that -
-     * which is exactly while a boundary is crossing it - it carries nothing.
-     *
-     * Both switches happen at the instant the fill and the thing behind it are
-     * the same colour, so neither is visible. What you see instead is a bar
-     * that hides the page sliding under it, and lets a section edge pass
-     * through in the open.
-     *
-     * Cheap enough to run straight from the scroll event: it reads scrollY,
-     * which costs no layout, and compares it against numbers taken once.
-     */
-    /** The innermost ground at a point down the page, or none. */
-    const groundAt = (y: number) => {
-      let found: Ground | null = null
-      for (const g of grounds) if (y >= g.top && y < g.bottom) found = g
-      return found
-    }
-
-    // On a phone the bar is never bare past the hero. Going bare lets
-    // whatever is scrolling under the bar show straight through it for the
-    // moment a section edge is crossing, which behind the wordmark read as
-    // a leak. The edge still passes through pixel by pixel: while it is
-    // inside the bar, the bar paints the upper section's colour down to the
-    // edge and the lower section's below it, both at the usual 90% over the
-    // blur, and the split moves with the scroll.
-    const phone = window.matchMedia('(max-width: 639.98px)')
-    const wash = (colour: string) =>
-      `color-mix(in srgb, ${colour} 90%, transparent)`
-
-    const paint = () => {
-      const y = window.scrollY
-      const top = groundAt(y)
-      const bottom = groundAt(y + height)
-      const whole = top && top === bottom ? top : null
-      const here = phone.matches ? (top ?? bottom) : whole
-      let image = ''
-      let fill = '1'
-      if (phone.matches && !sheetOpen && top !== bottom) {
-        const edge =
-          top && bottom
-            ? Math.min(top.bottom, bottom.top > y ? bottom.top : Infinity)
-            : top
-              ? top.bottom
-              : bottom!.top
-        const split = Math.round(edge - y)
-        const above = top ? wash(top.colour) : 'transparent'
-        const below = bottom ? wash(bottom.colour) : 'transparent'
-        image = `linear-gradient(to bottom, ${above} ${split}px, ${below} ${split}px)`
-        fill = '0'
-      }
-      el.style.backgroundImage = image
-      el.style.setProperty('--nav-fill', fill)
-      if (here) el.style.setProperty('--nav-ground', here.colour)
-      else if (!heroUp) el.style.setProperty('--nav-ground', 'var(--color-bg)')
-      el.style.setProperty('--nav-surface', here || !heroUp ? '1' : '0')
-      el.toggleAttribute(
-        'data-nav-past-hero',
-        !heroUp || (phone.matches ? y + height : y) >= heroBottom,
-      )
-      // The ghost holds the labels for as long as it is up, and hovering hands
-      // them over early: it sits under the bar and cannot answer a pointer.
-      solid(sheetOpen || !blended || hovering)
-    }
-
-    const hold = holding
-      ? window.setTimeout(() => {
-          holding = false
-          paint()
-        }, MENU_BARS_FOLD_MS)
-      : 0
-
-    const onEnter = (event: PointerEvent) => {
-      if (event.pointerType !== 'mouse') return
-      hovering = true
-      paint()
-    }
-    const onLeave = (event: PointerEvent) => {
-      if (event.pointerType !== 'mouse') return
-      hovering = false
-      paint()
-    }
-
-    const relayout = () => {
-      survey()
-      paint()
-    }
-
-    // Arriving at /#install, the page is moved to the anchor by whatever
-    // handles the hash, which may be before this attaches - and a scroll that
-    // has already happened sends no event to catch up on. One more pass once
-    // the current task is done reads wherever the page actually ended up.
-    const settle = window.setTimeout(relayout, 0)
-
-    // Sections grow as images and fonts land, which moves every edge below.
-    // survey() points this at the mounted <main>, and re-points it when the
-    // page under the bar is swapped for another.
-    const sizes = new ResizeObserver(relayout)
-
-    // The page mounts async on a client-side navigation, so wait for it.
-    let probe = 0
-    const wait = () => {
-      if (survey()) {
-        paint()
-        return
-      }
-      probe = requestAnimationFrame(wait)
-    }
-    wait()
-
-    // Observe DOM swaps because route updates can precede the incoming page mounting.
-    const arrivals = new MutationObserver(() => {
-      if (document.querySelector('main') !== surveyed) relayout()
-    })
-    arrivals.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    })
-
-    el.addEventListener('pointerenter', onEnter)
-    el.addEventListener('pointerleave', onLeave)
-    phone.addEventListener('change', paint)
-    window.addEventListener('scroll', paint, { passive: true })
-    window.addEventListener('resize', relayout)
-    // Each ground's colour is read once and held, so a theme has to say when
-    // it has changed or the bar keeps the last one until the next scroll.
-    window.addEventListener(THEME_EVENT, relayout)
-    return () => {
-      cancelAnimationFrame(probe)
-      window.clearTimeout(settle)
-      window.clearTimeout(hold)
-      arrivals.disconnect()
-      sizes.disconnect()
-      el.removeEventListener('pointerenter', onEnter)
-      el.removeEventListener('pointerleave', onLeave)
-      phone.removeEventListener('change', paint)
-      el.style.backgroundImage = ''
-      el.style.removeProperty('--nav-fill')
-      window.removeEventListener('scroll', paint)
-      window.removeEventListener('resize', relayout)
-      window.removeEventListener(THEME_EVENT, relayout)
-    }
-  }, [sheetOpen, blended, bar, pathname])
-}
-
+/**
+ * The desktop bar's composition, adapted for the web: the Omarchy menu mark
+ * and workspace-like page links on the left, a compact action tray on the
+ * right. One opaque, theme-bound surface at every scroll position; no second
+ * layer of labels blended into the hero. Touch layouts keep larger targets.
+ */
 export function SiteHeader({ path = '/' }: { path?: string }) {
   const { pathname } = useLocation({ serverPath: path })
-  const heroInView = useHeroInView(pathname === '/')
   const [menuOpen, setMenuOpen] = useState(false)
+  const toggle = useRef<HTMLButtonElement>(null)
   const installLink = useHashLink('install')
   const homeLink = useTopLink()
-  const transparent = heroInView
+
+  const currentPage = (to: string) => {
+    const current = pathname.replace(/\/+$/, '') || '/'
+    const target = to.replace(/\/+$/, '') || '/'
+    if (current === target) return 'page' as const
+    if (current.startsWith(`${target}/`)) return 'location' as const
+    return undefined
+  }
+
+  function closeMenu() {
+    setMenuOpen(false)
+    toggle.current?.focus()
+  }
 
   useEffect(() => setMenuOpen(false), [pathname])
   useEffect(() => {
     if (!menuOpen) return
-    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setMenuOpen(false)
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return
+      setMenuOpen(false)
+      toggle.current?.focus()
+    }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [menuOpen])
+
+  // A sheet opened on a phone must not remain logically open after resizing
+  // to desktop, where its controls and the sheet itself are no longer shown.
+  useEffect(() => {
+    const desktop = window.matchMedia('(min-width: 640px)')
+    const sync = () => {
+      if (desktop.matches) setMenuOpen(false)
+    }
+    desktop.addEventListener('change', sync)
+    return () => desktop.removeEventListener('change', sync)
+  }, [])
+
+  // Floating controls elsewhere on the page stand aside for the mobile menu.
   useEffect(() => {
     const root = document.documentElement
     if (menuOpen) root.dataset.navMenu = t('open')
@@ -431,188 +113,154 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
       delete root.dataset.navMenu
     }
   }, [menuOpen])
-  const bar = useRef<HTMLDivElement>(null)
-  // Continue tracking section colors after the hero leaves the viewport.
-  useNavSurface(menuOpen, transparent, bar, pathname)
-
-  const glyph = (
-    <Link
-      to="/"
-      aria-label={t('Omarchy home')}
-      onClick={homeLink}
-      className="mark-draw-trigger relative flex items-center"
-    >
-      <OmarchyMarkDrawn className="size-[22px] shrink-0 transition-opacity duration-150 ease-out max-sm:group-data-[nav-past-hero]/bar:opacity-0 lg:size-[calc(var(--pxc)*2)]" />
-      <OmarchyWordmark className="absolute top-1/2 left-0 w-28 -translate-y-1/2 text-brand opacity-0 transition-opacity duration-150 ease-out group-data-[nav-past-hero]/bar:opacity-100 sm:hidden" />
-    </Link>
-  )
-
-  const search = (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label={t('Search Omarchy')}
-      data-nav-glyph
-      className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-      onClick={() => window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))}
-    >
-      <SearchIcon className="size-5" />
-    </Button>
-  )
-
-  const theme = (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label={t('Change website theme')}
-      data-nav-glyph
-      className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-      onClick={() => window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))}
-    >
-      <PaletteIcon className="size-5" />
-    </Button>
-  )
-
-  const install = (
-    <Button
-      className="relative h-8 px-4 before:absolute before:-inset-y-1.5 lg:h-[calc(var(--pxr)*3)]"
-      nativeButton={false}
-      onClick={installLink}
-      render={<Link to="/" hash="install" />}
-    >
-      {t('Install')}
-    </Button>
-  )
 
   return (
-    <header dir="ltr" className="pixel-container sticky top-0 z-(--z-nav)">
-      <div
-        ref={bar}
-        data-nav-blend={transparent ? '' : undefined}
-        // With the sheet down, the bar is the top of the sheet and wears its
-        // ground rather than the section's: taking a colour from the page
-        // behind it would put a seam across the one surface being looked at.
-        className={cn('group/bar', menuOpen && 'bg-bg/95 backdrop-blur-lg')}
-        style={{
-          // On the bar rather than the header, so both the surface it paints
-          // and the height the hooks measure include the strip above it.
-          paddingTop: 'env(safe-area-inset-top)',
-          backgroundColor: menuOpen
-            ? undefined
-            : 'color-mix(in srgb, var(--nav-ground, var(--color-bg)) calc(var(--nav-surface, 0) * var(--nav-fill, 1) * 90%), transparent)',
-          // Keep blur off over the hero so its pixels stay sharp.
-          backdropFilter: menuOpen
-            ? undefined
-            : 'blur(calc(var(--nav-surface, 0) * 12px))',
-        }}
-      >
-        <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
-          {glyph}
+    <header dir="ltr" className="site-bar sticky top-0 z-(--z-nav)">
+      <div className="site-bar__row">
+        <Link
+          to="/"
+          aria-label={t('Omarchy home')}
+          onClick={(event) => {
+            setMenuOpen(false)
+            homeLink(event)
+          }}
+          className="site-bar__home mark-draw-trigger"
+        >
+          <OmarchyMarkDrawn className="site-bar__mark" />
+        </Link>
 
-          <nav aria-label={t('Main')} className="hidden items-center sm:flex">
-            {navLinks.map((link) =>
-              'href' in link ? (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  className="px-3 py-1.5 text-sm whitespace-nowrap text-text-secondary transition-[background-color] duration-150 ease-out hover:bg-surface-2 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                >
-                  {link.label}
-                </a>
-              ) : (
-                <Link
-                  key={link.label}
-                  to={link.to}
-                  className="px-3 py-1.5 text-sm whitespace-nowrap text-text-secondary transition-[background-color] duration-150 ease-out hover:bg-surface-2 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                  activeProps={{ className: 'text-text bg-surface-2' }}
-                >
-                  {link.label}
-                </Link>
-              ),
-            )}
-          </nav>
+        <nav aria-label={t('Main')} className="site-bar__pages hidden sm:flex">
+          {navLinks.map((link) =>
+            'href' in link ? (
+              <a key={link.label} href={link.href} className="site-bar__page">
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.label}
+                to={link.to}
+                className="site-bar__page"
+                aria-current={currentPage(link.to)}
+              >
+                {link.label}
+              </Link>
+            ),
+          )}
+        </nav>
 
-          <div className="ml-auto flex items-center gap-2.5">
-            <div className="hidden items-center gap-1 sm:flex">
-              <TooltipProvider delay={300}>
-                <NavTooltip label={t('Search Omarchy')} shortcut="⌘K / Ctrl+K">
-                  {search}
-                </NavTooltip>
-                <NavTooltip label={t('Change website theme')} shortcut="T">
-                  {theme}
-                </NavTooltip>
-                <LanguageSwitcher path={pathname} />
-                <NavTooltip label={t('Subscribe via RSS')}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t('Omarchy RSS feed')}
-                    data-nav-glyph
-                    className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-                    nativeButton={false}
-                    render={<a href="/news/rss.xml" />}
-                  >
-                    <RssIcon className="size-5" />
-                  </Button>
-                </NavTooltip>
-                <NavTooltip label={t('View Omarchy on GitHub')}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t('Omarchy on GitHub')}
-                    data-nav-glyph
-                    className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-                    nativeButton={false}
-                    render={<a href="https://github.com/omacom/omarchy" />}
-                  >
-                    <GithubIcon className="size-5" />
-                  </Button>
-                </NavTooltip>
-              </TooltipProvider>
-              <span className="ml-2 flex">{install}</span>
-            </div>
-            <div className="flex items-center gap-1 sm:hidden">
-              {theme}
-              <LanguageSwitcher path={pathname} />
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              data-nav-toggle
-              className="relative size-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 sm:hidden"
-              aria-expanded={menuOpen}
-              aria-controls="site-menu"
-              aria-label={menuOpen ? 'Close menu' : 'Menu'}
-              onClick={() => setMenuOpen((open) => !open)}
-            >
-              <MenuBarsIcon open={menuOpen} className="size-[22px]" />
-            </Button>
-          </div>
+        <div className="site-bar__tray ml-auto hidden sm:flex">
+          <TooltipProvider delay={300}>
+            <NavTooltip label={t('Search Omarchy')} shortcut="⌘K / Ctrl+K">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Search Omarchy')}
+                className="site-bar__icon"
+                onClick={() =>
+                  window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))
+                }
+              >
+                <SearchIcon />
+              </Button>
+            </NavTooltip>
+            <NavTooltip label={t('Change website theme')} shortcut="T">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Change website theme')}
+                className="site-bar__icon"
+                onClick={() =>
+                  window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))
+                }
+              >
+                <PaletteIcon />
+              </Button>
+            </NavTooltip>
+            <LanguageSwitcher
+              path={pathname}
+              triggerClassName="site-bar__icon"
+            />
+            <NavTooltip label={t('Subscribe via RSS')}>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Omarchy RSS feed')}
+                className="site-bar__icon"
+                nativeButton={false}
+                render={<a href="/news/rss.xml" />}
+              >
+                <RssIcon />
+              </Button>
+            </NavTooltip>
+            <NavTooltip label={t('View Omarchy on GitHub')}>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Omarchy on GitHub')}
+                className="site-bar__icon"
+                nativeButton={false}
+                render={<a href="https://github.com/omacom/omarchy" />}
+              >
+                <GithubIcon />
+              </Button>
+            </NavTooltip>
+          </TooltipProvider>
+          <span className="site-bar__separator" aria-hidden="true" />
+          <Button
+            variant="ghost"
+            className="site-bar__install"
+            nativeButton={false}
+            onClick={installLink}
+            render={<Link to="/" hash="install" />}
+          >
+            <DownloadIcon aria-hidden="true" />
+            {t('Install')}
+          </Button>
+        </div>
+
+        <div className="site-bar__mobile-tray ml-auto flex items-center gap-2 sm:hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t('Change website theme')}
+            className="site-bar__icon"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))
+            }
+          >
+            <PaletteIcon />
+          </Button>
+          <LanguageSwitcher path={pathname} triggerClassName="site-bar__icon" />
+          <Button
+            ref={toggle}
+            variant="ghost"
+            size="icon"
+            className="site-bar__toggle ml-auto sm:hidden"
+            aria-expanded={menuOpen}
+            aria-controls="site-menu"
+            aria-label={menuOpen ? 'Close menu' : 'Menu'}
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            <MenuBarsIcon open={menuOpen} className="size-5" />
+          </Button>
         </div>
       </div>
-      {/* Tapping the page behind the sheet closes it. The header is an
-          inline-size container, so it is the containing block for fixed
-          children as well - bottom-0 would resolve to the bar's own 56px, and
-          the scrim is sized explicitly instead. Dimmed and blurred the way
-          the search and the theme picker dim the page, so the three open
-          alike; a wash of the page's own colour barely showed on a dark
-          theme. */}
+
       {menuOpen ? (
-        <div
+        <button
+          type="button"
+          tabIndex={-1}
           data-menu-scrim
-          aria-hidden="true"
-          onClick={() => setMenuOpen(false)}
-          className="absolute inset-x-0 top-(--nav-h) h-svh bg-black/55 supports-backdrop-filter:backdrop-blur-xs sm:hidden"
+          aria-label={t('Close navigation menu')}
+          onClick={closeMenu}
+          className="fixed inset-x-0 top-(--nav-h) bottom-0 bg-bg/40 sm:hidden"
         />
       ) : null}
-
-      {/* Overlaid, not stacked: pushing the page down would change the bar's
-          height and with it the hero's offsets. */}
 
       <div
         id="site-menu"
         hidden={!menuOpen}
-        className="absolute inset-x-0 top-(--nav-h) border-b border-border-subtle bg-bg/95 backdrop-blur-lg sm:hidden"
+        className="site-bar__menu absolute inset-x-0 top-full border-b border-border-subtle bg-bg sm:hidden"
       >
         <nav
           aria-label={t('Main pages')}
@@ -624,7 +272,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
                 key={link.label}
                 href={link.href}
                 onClick={() => setMenuOpen(false)}
-                className="py-3 text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                className="site-bar__menu-link"
               >
                 {link.label}
               </a>
@@ -633,8 +281,8 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
                 key={link.label}
                 to={link.to}
                 onClick={() => setMenuOpen(false)}
-                className="py-3 text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                activeProps={{ className: 'text-text font-medium' }}
+                className="site-bar__menu-link"
+                aria-current={currentPage(link.to)}
               >
                 {link.label}
               </Link>
@@ -646,7 +294,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
               setMenuOpen(false)
               window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))
             }}
-            className="mt-2 flex items-center gap-2.5 border-t border-border-subtle py-3 pt-4 text-left text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            className="site-bar__menu-link mt-2 flex items-center gap-2.5 border-t border-border-subtle"
           >
             <SearchIcon className="size-5" />
             {t('Search Omarchy')}
@@ -657,7 +305,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
               setMenuOpen(false)
               window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))
             }}
-            className="flex items-center gap-2.5 py-3 text-left text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            className="site-bar__menu-link flex items-center gap-2.5"
           >
             <PaletteIcon className="size-5" />
             {t('Change the theme')}
@@ -698,89 +346,5 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
         </nav>
       </div>
     </header>
-  )
-}
-
-/** Render inside the hero stacking context so labels can blend with its canvas. */
-export function HeroNavGhost() {
-  // Use the header's shared hero state to keep both label layers synchronized.
-  return (
-    <div
-      aria-hidden="true"
-      dir="ltr"
-      data-nav-ghost
-      className="pointer-events-none fixed inset-x-0 top-0 z-(--z-nav) mix-blend-difference"
-      // The header hydrates before the hero does, and its effect writes this
-      // node's opacity in between - 1 with the hero up, 0 with the page
-      // reloaded further down, or the pointer already resting on the bar, or
-      // on a phone. React then hydrates this node against whichever value it
-      // found. Declaring the property keeps React from reporting an inline
-      // style it never rendered; suppressing the warning covers the loads
-      // where the effect's answer was 0. React does not patch attributes on
-      // a mismatch, so the effect's value, the right one, is what stays.
-      style={{ paddingTop: 'env(safe-area-inset-top)', opacity: 1 }}
-      suppressHydrationWarning
-    >
-      <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
-        <span className="flex items-center">
-          <span className="block size-[22px] shrink-0 lg:size-[calc(var(--pxc)*2)]" />
-        </span>
-
-        <span className="hidden items-center sm:flex">
-          {navLinks.map((link) => (
-            <span
-              key={link.label}
-              className="px-3 py-1.5 text-sm whitespace-nowrap"
-              style={{ color: 'var(--t-hdr-text-2)' }}
-            >
-              {link.label}
-            </span>
-          ))}
-        </span>
-
-        <span className="ml-auto flex items-center gap-2.5">
-          <span
-            className="hidden items-center gap-1 sm:flex"
-            style={{ color: 'var(--t-hdr-text-2)' }}
-          >
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <SearchIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <PaletteIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <GlobeIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <RssIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <GithubIcon className="size-5" />
-            </span>
-            {/* Install holds its own colours, so the ghost only holds its
-                place - same box, same type metrics, nothing painted. The
-                border is part of the box: the real button wears a 1px
-                transparent one, and without it here the ghost's icons sat
-                2px to the right of the real ones, so every swap between
-                the two layers read as a wiggle. */}
-            <span
-              aria-hidden="true"
-              className="ml-2 inline-flex h-8 items-center border border-transparent px-4 text-sm font-medium lg:h-[calc(var(--pxr)*3)]"
-              style={{ color: 'transparent' }}
-            >
-              {t('Install')}
-            </span>
-          </span>
-
-          <span
-            className="flex size-8 items-center justify-center sm:hidden"
-            style={{ color: 'var(--t-hdr-text-2)' }}
-          >
-            <MenuBarsIcon className="size-[22px]" />
-          </span>
-        </span>
-      </div>
-    </div>
   )
 }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -251,7 +251,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
           type="button"
           tabIndex={-1}
           data-menu-scrim
-          aria-label={t('Close navigation menu')}
+          aria-label="Close navigation menu"
           onClick={closeMenu}
           className="fixed inset-x-0 top-(--nav-h) bottom-0 bg-bg/40 sm:hidden"
         />

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "إضافة",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "إيقاف حركة الأخبار مؤقتًا",
+  "Resume news animation": "استئناف حركة الأخبار"
 }

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy সার্ভার 4.0",
   "Plugin": "প্লাগইন",
   "Rangers": "রেঞ্জার্স",
-  "Server - Omarchy": "সার্ভার - Omarchy"
+  "Server - Omarchy": "সার্ভার - Omarchy",
+  "Pause news animation": "সংবাদ অ্যানিমেশন বিরতি দিন",
+  "Resume news animation": "সংবাদ অ্যানিমেশন আবার চালু করুন"
 }

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Connector",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Servidor - Omarchy"
+  "Server - Omarchy": "Servidor - Omarchy",
+  "Pause news animation": "Pausa l’animació de notícies",
+  "Resume news animation": "Reprèn l’animació de notícies"
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Sæt nyhedsanimationen på pause",
+  "Resume news animation": "Genoptag nyhedsanimationen"
 }

--- a/src/i18n/messages/el.json
+++ b/src/i18n/messages/el.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Πρόσθετο",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Παύση κινούμενης εικόνας ειδήσεων",
+  "Resume news animation": "Συνέχιση κινούμενης εικόνας ειδήσεων"
 }

--- a/src/i18n/messages/es-MX.json
+++ b/src/i18n/messages/es-MX.json
@@ -342,5 +342,7 @@
   "Omakub - Omarchy": "Omakub - Omarchy",
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Pausar animación de noticias",
+  "Resume news animation": "Reanudar animación de noticias"
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Liitännäinen",
   "Rangers": "Rangerit",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Keskeytä uutisanimaatio",
+  "Resume news animation": "Jatka uutisanimaatiota"
 }

--- a/src/i18n/messages/fil.json
+++ b/src/i18n/messages/fil.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "I-pause ang animation ng balita",
+  "Resume news animation": "Ipagpatuloy ang animation ng balita"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Mettre l’animation des actualités en pause",
+  "Resume news animation": "Reprendre l’animation des actualités"
 }

--- a/src/i18n/messages/ga.json
+++ b/src/i18n/messages/ga.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Breiseán",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Cuir beochan na nuachta ar sos",
+  "Resume news animation": "Atosaigh beochan na nuachta"
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy सर्वर 4.0",
   "Plugin": "प्लगइन",
   "Rangers": "रेंजर्स",
-  "Server - Omarchy": "सर्वर - Omarchy"
+  "Server - Omarchy": "सर्वर - Omarchy",
+  "Pause news animation": "समाचार ऐनिमेशन रोकें",
+  "Resume news animation": "समाचार ऐनिमेशन फिर से चलाएँ"
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Bővítmény",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Híranimáció szüneteltetése",
+  "Resume news animation": "Híranimáció folytatása"
 }

--- a/src/i18n/messages/is.json
+++ b/src/i18n/messages/is.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Þjónn 4.0",
   "Plugin": "Viðbót",
   "Rangers": "Landverðir",
-  "Server - Omarchy": "Þjónn - Omarchy"
+  "Server - Omarchy": "Þjónn - Omarchy",
+  "Pause news animation": "Gera hlé á fréttahreyfingu",
+  "Resume news animation": "Halda fréttahreyfingu áfram"
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Metti in pausa l’animazione delle notizie",
+  "Resume news animation": "Riprendi l’animazione delle notizie"
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "プラグイン",
   "Rangers": "レンジャーズ",
-  "Server - Omarchy": "サーバー - Omarchy"
+  "Server - Omarchy": "サーバー - Omarchy",
+  "Pause news animation": "ニュースアニメーションを一時停止",
+  "Resume news animation": "ニュースアニメーションを再開"
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy 서버 4.0",
   "Plugin": "플러그인",
   "Rangers": "레인저스",
-  "Server - Omarchy": "서버 - Omarchy"
+  "Server - Omarchy": "서버 - Omarchy",
+  "Pause news animation": "뉴스 애니메이션 일시 정지",
+  "Resume news animation": "뉴스 애니메이션 다시 시작"
 }

--- a/src/i18n/messages/lt.json
+++ b/src/i18n/messages/lt.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Įskiepis",
   "Rangers": "Reindžeriai",
-  "Server - Omarchy": "Serveris - Omarchy"
+  "Server - Omarchy": "Serveris - Omarchy",
+  "Pause news animation": "Pristabdyti naujienų animaciją",
+  "Resume news animation": "Tęsti naujienų animaciją"
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Nieuwsanimatie pauzeren",
+  "Resume news animation": "Nieuwsanimatie hervatten"
 }

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Wtyczka",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Serwer - Omarchy"
+  "Server - Omarchy": "Serwer - Omarchy",
+  "Pause news animation": "Wstrzymaj animację wiadomości",
+  "Resume news animation": "Wznów animację wiadomości"
 }

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Pausar animação de notícias",
+  "Resume news animation": "Retomar animação de notícias"
 }

--- a/src/i18n/messages/si.json
+++ b/src/i18n/messages/si.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy සර්වරය 4.0",
   "Plugin": "ප්ලගිනය",
   "Rangers": "රේන්ජර්වරු",
-  "Server - Omarchy": "සර්වරය - Omarchy"
+  "Server - Omarchy": "සර්වරය - Omarchy",
+  "Pause news animation": "පුවත් සජීවිකරණය විරාම කරන්න",
+  "Resume news animation": "පුවත් සජීවිකරණය නැවත අරඹන්න"
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Pausa nyhetsanimation",
+  "Resume news animation": "Återuppta nyhetsanimation"
 }

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "செருகுநிரல்",
   "Rangers": "ரேஞ்சர்கள்",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "செய்தி அசைவூட்டத்தை இடைநிறுத்து",
+  "Resume news animation": "செய்தி அசைவூட்டத்தைத் தொடரு"
 }

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy เซิร์ฟเวอร์ 4.0",
   "Plugin": "ปลั๊กอิน",
   "Rangers": "เรนเจอร์ส",
-  "Server - Omarchy": "เซิร์ฟเวอร์ - Omarchy"
+  "Server - Omarchy": "เซิร์ฟเวอร์ - Omarchy",
+  "Pause news animation": "หยุดภาพเคลื่อนไหวข่าวชั่วคราว",
+  "Resume news animation": "เล่นภาพเคลื่อนไหวข่าวต่อ"
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Sunucu 4.0",
   "Plugin": "Eklenti",
   "Rangers": "Korucular",
-  "Server - Omarchy": "Sunucu - Omarchy"
+  "Server - Omarchy": "Sunucu - Omarchy",
+  "Pause news animation": "Haber animasyonunu duraklat",
+  "Resume news animation": "Haber animasyonunu sürdür"
 }

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy سرور 4.0",
   "Plugin": "پلگ ان",
   "Rangers": "رینجرز",
-  "Server - Omarchy": "سرور - Omarchy"
+  "Server - Omarchy": "سرور - Omarchy",
+  "Pause news animation": "خبروں کی اینیمیشن روکیں",
+  "Resume news animation": "خبروں کی اینیمیشن دوبارہ چلائیں"
 }

--- a/src/i18n/messages/uz.json
+++ b/src/i18n/messages/uz.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plagin",
   "Rangers": "Reynjerlar",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "Pause news animation": "Yangiliklar animatsiyasini pauza qilish",
+  "Resume news animation": "Yangiliklar animatsiyasini davom ettirish"
 }

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Máy chủ - Omarchy"
+  "Server - Omarchy": "Máy chủ - Omarchy",
+  "Pause news animation": "Tạm dừng hiệu ứng tin tức",
+  "Resume news animation": "Tiếp tục hiệu ứng tin tức"
 }

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy 服务器 4.0",
   "Plugin": "插件",
   "Rangers": "游侠",
-  "Server - Omarchy": "服务器 - Omarchy"
+  "Server - Omarchy": "服务器 - Omarchy",
+  "Pause news animation": "暂停新闻动画",
+  "Resume news animation": "继续新闻动画"
 }

--- a/src/lib/announcement-scramble.test.ts
+++ b/src/lib/announcement-scramble.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  SCRAMBLE_GLYPHS,
+  SCRAMBLE_IN_TICKS,
+  SCRAMBLE_TICK_MS,
+  announcementMarkup,
+  scrambleGlyph,
+} from './announcement-scramble.ts'
+
+test('emphasizes the current amount after translation without rewriting source copy', () => {
+  assert.equal(
+    announcementMarkup('Omacom Foundation launches with $15.5 million'),
+    'Omacom Foundation launches with <strong>$15.5 million</strong>',
+  )
+  assert.equal(
+    announcementMarkup(
+      'La Fondation Omacom démarre avec 15,5 millions de dollars',
+    ),
+    'La Fondation Omacom démarre avec 15,5 millions de dollars',
+  )
+  assert.equal(
+    announcementMarkup('Total: $15,5.'),
+    'Total: <strong>$15,5</strong>.',
+  )
+  const authored =
+    '<span title="$15.5 million">Authored <strong>$15.5 million</strong></span>'
+  assert.equal(announcementMarkup(authored), authored)
+})
+
+test('keeps the registry PR #10 glyph pool with a slower reveal cadence', () => {
+  assert.equal(
+    SCRAMBLE_GLYPHS,
+    '░▒▓/\\<>+=*#%&@$0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  )
+  assert.equal(SCRAMBLE_TICK_MS, 60)
+  assert.equal(SCRAMBLE_IN_TICKS, 26)
+})
+
+test('scrambles the amount and dollar sign, not just the announcement prefix', () => {
+  for (const character of '$14.95million') {
+    assert.equal(
+      scrambleGlyph(character, 0, 26, () => 0),
+      '░',
+    )
+    assert.equal(
+      scrambleGlyph(character, 25, 26, () => 0.999),
+      'Z',
+    )
+    assert.equal(
+      scrambleGlyph(character, 26, 26, () => 0),
+      character,
+    )
+  }
+})
+
+test('each position resolves at its own tick and stays resolved', () => {
+  assert.equal(
+    scrambleGlyph('O', 3, 4, () => 0),
+    '░',
+  )
+  assert.equal(
+    scrambleGlyph('O', 4, 4, () => 0),
+    'O',
+  )
+  assert.equal(
+    scrambleGlyph('O', 27, 4, () => 0),
+    'O',
+  )
+})
+
+test('whitespace and settled graphemes remain intact', () => {
+  for (const whitespace of [' ', '\n', '\u00a0']) {
+    assert.equal(
+      scrambleGlyph(whitespace, 0, 26, () => 0),
+      whitespace,
+    )
+  }
+  for (const grapheme of ['e\u0301', '👩‍💻']) {
+    assert.equal(scrambleGlyph(grapheme, 26, 26), grapheme)
+  }
+})

--- a/src/lib/announcement-scramble.test.ts
+++ b/src/lib/announcement-scramble.test.ts
@@ -17,7 +17,11 @@ test('emphasizes the current amount after translation without rewriting source c
     announcementMarkup(
       'La Fondation Omacom démarre avec 15,5 millions de dollars',
     ),
-    'La Fondation Omacom démarre avec 15,5 millions de dollars',
+    'La Fondation Omacom démarre avec <strong>15,5</strong> millions de dollars',
+  )
+  assert.equal(
+    announcementMarkup('Omacom Foundation USD මිලියන 15.5 සමඟ ආරම්භ වෙනවා'),
+    'Omacom Foundation USD මිලියන <strong>15.5</strong> සමඟ ආරම්භ වෙනවා',
   )
   assert.equal(
     announcementMarkup('Total: $15,5.'),

--- a/src/lib/announcement-scramble.ts
+++ b/src/lib/announcement-scramble.ts
@@ -7,10 +7,9 @@ export const SCRAMBLE_IN_TICKS = 26
 /** Decorate translated plain text, not the source lookup key or authored markup. */
 export function announcementMarkup(html: string): string {
   if (html.includes('<')) return html
-  return html.replace(
-    /\$\d+(?:[.,]\d+)*(?:\s+million\b)?/gu,
-    '<strong>$&</strong>',
-  )
+  const dollars = /\$\d+(?:[.,]\d+)*(?:\s+million\b)?/u
+  if (dollars.test(html)) return html.replace(dollars, '<strong>$&</strong>')
+  return html.replace(/\d+(?:[.,]\d+)*/u, '<strong>$&</strong>')
 }
 
 export function scrambleGlyph(

--- a/src/lib/announcement-scramble.ts
+++ b/src/lib/announcement-scramble.ts
@@ -1,0 +1,24 @@
+// Registry PR #10 glyph pool, with a slightly slower reveal cadence.
+export const SCRAMBLE_GLYPHS =
+  '░▒▓/\\<>+=*#%&@$0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+export const SCRAMBLE_TICK_MS = 60
+export const SCRAMBLE_IN_TICKS = 26
+
+/** Decorate translated plain text, not the source lookup key or authored markup. */
+export function announcementMarkup(html: string): string {
+  if (html.includes('<')) return html
+  return html.replace(
+    /\$\d+(?:[.,]\d+)*(?:\s+million\b)?/gu,
+    '<strong>$&</strong>',
+  )
+}
+
+export function scrambleGlyph(
+  character: string,
+  tick: number,
+  settlesAt: number,
+  random: () => number = Math.random,
+): string {
+  if (/\s/u.test(character) || tick >= settlesAt) return character
+  return SCRAMBLE_GLYPHS[Math.floor(random() * SCRAMBLE_GLYPHS.length)]
+}

--- a/src/lib/etch.ts
+++ b/src/lib/etch.ts
@@ -97,6 +97,8 @@ export const EFFECTS = [
 ] as const
 /** Fired with `{ detail: name }` to play an effect on the word now. */
 export const ETCH_EVENT = 'omarchy-etch'
+/** Fired on the hero section after the first resting wordmark is painted. */
+export const HERO_READY_EVENT = 'omarchy-hero-ready'
 
 /**
  * Runs in the head, before the first paint: when the effect is going to

--- a/src/styles.css
+++ b/src/styles.css
@@ -966,7 +966,14 @@ body,
 
 /* Shared height for the sticky bar, hero offset, and mobile menu. */
 :root {
-  --nav-h: calc(3.5rem + env(safe-area-inset-top, 0px));
+  --nav-row-h: 2rem;
+  --nav-h: calc(var(--nav-row-h) + 1px + env(safe-area-inset-top, 0px));
+}
+
+@media (width < 40rem), (any-pointer: coarse) {
+  :root {
+    --nav-row-h: 2.75rem;
+  }
 }
 
 body {
@@ -982,13 +989,10 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-/* Sticky stacking contexts prevent blending with the hero; labels blend inside the hero instead. */
 /* The hero field's cell size, derived in pure CSS: the wordmark slot is
    88% of the padded container capped at 896px, split into 81 columns,
    which is exactly the lattice the canvas draws. Elements sized with
-   --pxc multiples fit the grid with no runtime measurement at all. The
-   header and the hero section are both containers of the same width, so
-   the value agrees across them. */
+   --pxc multiples fit the grid with no runtime measurement at all. */
 .pixel-container {
   container-type: inline-size;
 }
@@ -1127,23 +1131,158 @@ h6 {
   }
 }
 
-/* Hide real labels while the blended copy is visible to avoid double painting. */
-[data-nav-blend] nav[aria-label='Main'] a,
-[data-nav-blend] [data-nav-glyph],
-[data-nav-blend] [data-nav-toggle] {
-  color: transparent;
+/* Omarchy's bar: an opaque theme surface, monospace labels, workspace-like
+   selection, and a right-aligned tray. The web row is a little taller than
+   the shell's 26px default; touch targets grow independently to 44px. */
+.site-bar {
+  padding-top: env(safe-area-inset-top, 0px);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: 400 12px/1 var(--font-mono);
 }
 
-/* No active or hover chip while labels are blended. The ghost's colour is compensated
-   against the field behind the bar; a chip is not the field, so a label
-   painted through one comes out near enough black. Hovering hands the labels
-   back to the real layer anyway - this is only here so that the two can never
-   be seen in the same frame. */
-[data-nav-blend] nav[aria-label='Main'] a,
-[data-nav-blend] [data-nav-glyph]:hover,
-[data-nav-blend] [data-nav-toggle]:hover {
-  background-color: transparent;
-  transition: none;
+.site-bar__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: var(--nav-row-h);
+  padding-inline: 10px;
+}
+
+.site-bar__home,
+.site-bar__page,
+.site-bar__icon,
+.site-bar__install,
+.site-bar__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: var(--nav-row-h);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  white-space: nowrap;
+  transition:
+    background-color 120ms ease-out,
+    color 120ms ease-out;
+}
+
+.site-bar__home,
+.site-bar__icon {
+  width: var(--nav-row-h);
+  padding: 0;
+}
+
+.site-bar__home {
+  color: var(--color-brand);
+}
+
+.site-bar__mark {
+  width: 18px;
+  height: 18px;
+}
+
+.site-bar__pages {
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+}
+
+.site-bar__page {
+  position: relative;
+  padding-inline: 11px;
+}
+
+.site-bar__home:hover,
+.site-bar__page:hover,
+.site-bar__icon:hover,
+.site-bar__install:hover,
+.site-bar__toggle:hover,
+.site-bar__menu-link:hover {
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
+  color: var(--color-text);
+}
+
+.site-bar__page[aria-current],
+.site-bar__menu-link[aria-current] {
+  background: color-mix(in srgb, var(--color-text) 18%, transparent);
+  color: var(--color-text);
+}
+
+.site-bar__page[aria-current]::after {
+  position: absolute;
+  right: 11px;
+  bottom: 3px;
+  left: 11px;
+  height: 1px;
+  background: var(--color-brand);
+  content: '';
+}
+
+.site-bar :is(a, button):focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: -2px;
+}
+
+.site-bar__tray {
+  align-items: center;
+  gap: 2px;
+}
+
+.site-bar__icon svg,
+.site-bar__install svg {
+  width: 15px;
+  height: 15px;
+}
+
+.site-bar__separator {
+  width: 1px;
+  height: 14px;
+  margin-inline: 7px;
+  background: var(--color-border-strong);
+}
+
+.site-bar__install {
+  gap: 7px;
+  padding-inline: 8px;
+  color: var(--color-text);
+}
+
+.site-bar__toggle {
+  display: none;
+  width: var(--nav-row-h);
+  padding: 0;
+}
+
+@media (width < 40rem) {
+  .site-bar__toggle {
+    display: inline-flex;
+  }
+}
+
+.site-bar__menu {
+  max-height: calc(100dvh - var(--nav-h));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.site-bar__menu-link {
+  min-height: 44px;
+  padding: 12px;
+  color: var(--color-text-secondary);
+  text-align: left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-bar :is(a, button) {
+    transition: none;
+  }
 }
 
 /* A full-bleed rail's own scrollbar would run the whole window width. These
@@ -2266,6 +2405,99 @@ h6 {
   }
   .team-named {
     animation: none;
+  }
+}
+
+/* A quiet terminal frame, matching the 40px hero actions on one line. */
+.hero-announcement-frame {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.hero-announcement {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 8px 13px;
+  border: 1px solid color-mix(in srgb, var(--color-brand) 42%, transparent);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--color-bg) 80%, transparent);
+  color: var(--color-text-secondary);
+  font: 500 14px/1.55 var(--font-mono);
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background-color 150ms ease-out,
+    border-color 150ms ease-out,
+    color 150ms ease-out;
+}
+
+.hero-announcement:hover {
+  border-color: var(--color-brand);
+  background: var(--color-brand);
+  color: var(--color-primary-foreground);
+}
+
+.hero-announcement:hover .hero-announcement__prompt,
+.hero-announcement:hover strong {
+  color: inherit;
+}
+
+.hero-announcement:focus-visible,
+.hero-announcement__pause:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 3px;
+}
+
+/* A focus-only control, not a permanent badge or another hero action. */
+.hero-announcement__pause:focus-visible {
+  z-index: 1;
+  bottom: calc(100% + 6px);
+  left: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 6px 10px;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  border: 1px solid var(--color-brand);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: 500 12px/1.5 var(--font-mono);
+  cursor: pointer;
+}
+
+.hero-announcement__prompt {
+  align-self: flex-start;
+  color: var(--color-brand);
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.hero-announcement__text {
+  min-width: 0;
+  font-variant-ligatures: none;
+}
+
+.hero-announcement__text strong {
+  color: var(--color-brand);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.hero-announcement__text s {
+  opacity: 0.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-announcement {
+    transition: none;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1223,7 +1223,18 @@ h6 {
   content: '';
 }
 
-.site-bar :is(a, button):focus-visible {
+/* Inset, because the bar's own controls are no taller than its row. The menu's
+   filled buttons keep the ring they ship with, outside their box: a brand
+   outline drawn inside a brand fill is the colour of the fill. */
+.site-bar
+  :is(
+    .site-bar__home,
+    .site-bar__page,
+    .site-bar__icon,
+    .site-bar__install,
+    .site-bar__toggle,
+    .site-bar__menu-link
+  ):focus-visible {
   outline: 2px solid var(--color-brand);
   outline-offset: -2px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1239,6 +1239,13 @@ h6 {
   outline-offset: -2px;
 }
 
+/* The text ink contrasts with the current-page fill; the accent does not
+   in every theme. Keep the compact inset geometry and the active fill. */
+.site-bar
+  :is(.site-bar__page, .site-bar__menu-link)[aria-current]:focus-visible {
+  outline-color: var(--color-text);
+}
+
 .site-bar__tray {
   align-items: center;
   gap: 2px;


### PR DESCRIPTION
## Summary

- Replace the layered, hero-blended header with an opaque, theme-aware Omarchy-style bar. Preserve navigation, search, theme switching, RSS, GitHub, installation, and mobile music controls.
- Preserve Astro's persistent header and route-aware active links; remove the obsolete duplicate navigation layer from the homepage and 404 hero.
- Move the Foundation announcement above the primary hero actions. Match their 40px single-line height, keep clean mobile wrapping, and use a neutral background with a full accent fill on hover. Omit extra badges and remove the trailing link icon.
- Scramble the complete announcement, including the current `$15.5 million` amount, using the [registry PR #10](https://github.com/omacom/omarchy-plugin-registry/pull/10) glyph pool. Resolve the text over approximately 1.6 seconds and repeat every six seconds while visible.

## Motion and accessibility

- Keep the complete authored message available to screen readers and without JavaScript.
- Pause for hover, focus, offscreen content, hidden tabs, and reduced motion.
- Retain a separate keyboard-accessible pause/resume action, revealed only on focus.
- Repeat indefinitely only where a fine pointer provides hover/pause feedback; touch-only devices play once and remain readable.
- Preserve the current language switcher and translate the two new pause actions across all 29 non-English catalogues.
- Use a text-colored focus outline for current-page links, clearing 3:1 in all 22 themes while retaining the external reviewer's mobile Install focus fix.
- Keep the article destination and current translated banner copy unchanged.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm test` — 31 Node tests and 26 Python tests passed
- `npm run check:translations` — no pending UI messages
- English, Danish, and Arabic production builds
- `npm run parity` against the complete working-tree export
- Production-browser checks: persistent Astro navigation, SSR/client active links, responsive header/menu, language and music controls, search/theme dialogs, 404 rendering, accessible/no-JS announcement, full accent hover, 40px height, five viewport widths, measured 1.6-second scramble / six-second desktop repeat interval, one-shot touch behavior, and 44 focused current-link checks across 22 themes (minimum 4.93:1)

The unchanged upstream site already emits `AbortError: Transition was skipped` during client navigation. The same warnings were reproduced on both builds; this PR introduces no additional navigation errors and leaves that upstream behavior untouched.

## Base

PR #198 has merged. This branch is rebased onto `master` at `83dbfa5748527737c37e468b1ee6eef5817e982a`, retaining the current localization, workstation, branding, content, download, and navigation updates.
