### PR TITLE
Wear the theme the machine is wearing

### DIFF
--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -12,7 +12,7 @@ import {
   OPEN_PICKER_EVENT,
   PICKER_STATE_EVENT,
   SITE_THEMES,
-  switchTheme,
+  chooseTheme,
   paintFavicon,
   watchChrome,
   readTheme,
@@ -105,7 +105,7 @@ export function ThemePicker() {
     // element that disappears mid-transition makes the browser drop the
     // whole wipe. Hence the flush, rather than letting React close it on
     // its own schedule a frame later.
-    switchTheme(next.id, () => flushSync(() => close()), { frosted: true })
+    chooseTheme(next.id, () => flushSync(() => close()), { frosted: true })
   }, [close])
 
   // The entry point is T. Omarchy's own chord still works for anyone not on

--- a/src/components/ThemeShowcase.tsx
+++ b/src/components/ThemeShowcase.tsx
@@ -1,6 +1,6 @@
 import { t } from '@/i18n/site'
 import { useEffect, useState } from 'react'
-import { SITE_THEMES, THEME_EVENT, switchTheme, readTheme } from '@/lib/theme'
+import { SITE_THEMES, THEME_EVENT, chooseTheme, readTheme } from '@/lib/theme'
 import { cn } from '@/lib/utils'
 
 /** A theme's desktop screenshot, the same one the picker shows. */
@@ -78,7 +78,7 @@ export function ThemeShowcase() {
               <button
                 type="button"
                 aria-pressed={selected}
-                onClick={() => switchTheme(theme.id)}
+                onClick={() => chooseTheme(theme.id)}
                 className={cn(
                   'whitespace-nowrap underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring',
                   selected

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -90,12 +90,15 @@ const url = `${SITE_URL}${path}`
     <PixelSnap client:load />
     <script>
       import type { TransitionBeforeSwapEvent } from 'astro:transitions/client'
-      import { readTheme } from '@/lib/theme'
+      import { followDesktopTheme, readTheme } from '@/lib/theme'
       import { watchOutbound } from '@/lib/outbound'
       import { watchBrandDownloads } from '@/lib/brand-downloads'
 
       watchBrandDownloads()
       watchOutbound()
+      // Wear the theme the machine is wearing, where a browser is offering it.
+      // Does nothing at all without omarchy-theme-sync installed.
+      followDesktopTheme()
       // Navigation should paint live text, not briefly rasterize it through
       // the snapshot animation used for palette changes.
       document.addEventListener('astro:before-swap', (event) => {

--- a/src/lib/desktop-theme.test.ts
+++ b/src/lib/desktop-theme.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { siteThemeFor } from './desktop-theme.ts'
+import { SITE_THEMES } from './site-themes.ts'
+
+const IDS = SITE_THEMES.map((t) => t.id)
+
+test('the theme the extension names is the theme this site ships', () => {
+  // What omarchy-theme-sync publishes is the directory name under
+  // /usr/share/omarchy/themes, which is what SITE_THEMES ids are.
+  for (const id of IDS) assert.equal(siteThemeFor(id, IDS), id)
+})
+
+test('a name is matched however it was spelled', () => {
+  assert.equal(siteThemeFor('Rose Pine', IDS), 'rose-pine')
+  assert.equal(siteThemeFor('  TOKYO-NIGHT  ', IDS), 'tokyo-night')
+  assert.equal(siteThemeFor('matte_black', IDS), 'matte-black')
+})
+
+test('an inexact match is not a match', () => {
+  // Somebody running a community theme is not running one of ours, and
+  // guessing would dress the site in colours their desktop is not wearing.
+  for (const name of [
+    'gruvbox-dark',
+    'gruvbox dark',
+    'tokyo',
+    'catppuccin-mocha',
+    'rose',
+  ]) {
+    assert.equal(siteThemeFor(name, IDS), null, name)
+  }
+})
+
+test('nothing published is nothing matched', () => {
+  for (const empty of [null, undefined, '', '   ', '-', '_']) {
+    assert.equal(siteThemeFor(empty, IDS), null, JSON.stringify(empty))
+  }
+})
+
+test('the whole list is matchable, so a new theme cannot quietly not sync', () => {
+  // The hinge of the feature: every id here is a directory name under
+  // `themes/` in omacom/omarchy, which is the name the extension publishes.
+  // A theme added with an id that is not its Omarchy directory would look
+  // fine on the site and silently never follow a desktop.
+  assert.equal(new Set(IDS).size, IDS.length, 'two themes share an id')
+  for (const id of IDS) {
+    assert.match(
+      id,
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      `${id} is not a directory name`,
+    )
+  }
+})

--- a/src/lib/desktop-theme.ts
+++ b/src/lib/desktop-theme.ts
@@ -1,0 +1,73 @@
+/**
+ * Which theme the machine is wearing, as the browser reports it.
+ *
+ * omacom/omarchy-theme-sync is a Chromium extension that reads the Omarchy
+ * theme a machine is actually running and publishes it to every page: the
+ * palette as `--omarchy-*` custom properties on <html>, and the theme's own
+ * name as `data-omarchy-theme`. It rewrites both when the desktop theme
+ * changes.
+ *
+ * None of that palette is wanted here, and that is the whole point. This
+ * site's themes are named after Omarchy's own and their values come from that
+ * theme's colors.toml — so the ids in SITE_THEMES and the directory names
+ * under `themes/` in omacom/omarchy are the same strings, and the name the
+ * extension publishes is that directory name. Twenty-two for twenty-two, no
+ * differences.
+ *
+ * So this is a name match onto a palette the site already ships, hand-authored
+ * with every in-between step already chosen. Nothing is derived from a foreign
+ * palette and there is no extra theme to maintain.
+ *
+ * Reading only. The extension does let one origin *set* the desktop's theme,
+ * and this site is that origin, but a website is not a thing that should
+ * change somebody's desktop, so nothing here asks it to.
+ *
+ * A leaf on purpose: no imports, so it can be read by a test.
+ */
+
+/** Where the extension puts the name: `<html data-omarchy-theme>`. */
+export const DESKTOP_ATTR = 'omarchyTheme'
+/** What it fires on `document` when the desktop's theme changes. */
+export const DESKTOP_EVENT = 'omarchythemechange'
+
+/**
+ * The site theme matching a name the extension published, or null.
+ *
+ * Tolerant about spelling and nothing else. The name arrives as a directory
+ * slug already, but a theme called "Rose Pine" should still find `rose-pine`.
+ * An inexact match is not a match: somebody running a community theme called
+ * "Gruvbox Dark" is not running `gruvbox`, and guessing would dress the site
+ * in colours their desktop is not wearing.
+ */
+export function siteThemeFor(
+  name: string | null | undefined,
+  ids: readonly string[],
+): string | null {
+  const slug = String(name ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+  return slug && ids.includes(slug) ? slug : null
+}
+
+/** The raw name on the document, if a browser is publishing one. */
+export function desktopThemeName(): string | null {
+  if (typeof document === 'undefined') return null
+  return document.documentElement.dataset[DESKTOP_ATTR] ?? null
+}
+
+/**
+ * Calls back whenever the desktop's theme changes, and once straight away.
+ *
+ * A subscription rather than a question: the extension gets the name from a
+ * native host over a port, so on a cold worker it lands after the first paint.
+ *
+ * @returns a function that stops listening.
+ */
+export function onDesktopTheme(fn: () => void): () => void {
+  if (typeof document === 'undefined') return () => {}
+  document.addEventListener(DESKTOP_EVENT, fn)
+  // Sometimes it is already there, a warm worker having beaten the paint.
+  fn()
+  return () => document.removeEventListener(DESKTOP_EVENT, fn)
+}

--- a/src/lib/site-themes.ts
+++ b/src/lib/site-themes.ts
@@ -1,0 +1,47 @@
+/* The palettes this site ships, and nothing else.
+ *
+ * Its own module so the list can be read without the machinery around it:
+ * theme.ts reaches for a canvas to resolve colours and for the brand mark's
+ * path to repaint the favicon, which makes it a module only a browser can
+ * load. The list is data, and data should be reachable from a test.
+ *
+ * Every id is the name of a directory under `themes/` in `omacom/omarchy`,
+ * and the values behind it are copied from that directory's colors.toml. That
+ * is not incidental: it is what lets omarchy-theme-sync tell this site which
+ * theme a machine is wearing by name alone, with no palette crossing over.
+ * See src/lib/desktop-theme.ts.
+ */
+
+export type SiteTheme = {
+  id: string
+  name: string
+  /** A light page: the theme's background is the lighter of its two inks. */
+  light?: true
+}
+
+export const SITE_THEMES: SiteTheme[] = [
+  { id: 'catppuccin', name: 'Catppuccin' },
+  { id: 'catppuccin-latte', name: 'Catppuccin Latte', light: true },
+  { id: 'ethereal', name: 'Ethereal' },
+  { id: 'everforest', name: 'Everforest' },
+  { id: 'flexoki-light', name: 'Flexoki Light', light: true },
+  { id: 'gruvbox', name: 'Gruvbox' },
+  { id: 'hackerman', name: 'Hackerman' },
+  { id: 'kanagawa', name: 'Kanagawa' },
+  { id: 'last-horizon', name: 'Last Horizon' },
+  { id: 'lumon', name: 'Lumon' },
+  { id: 'lupine', name: 'Lupine', light: true },
+  { id: 'matte-black', name: 'Matte Black' },
+  { id: 'miasma', name: 'Miasma' },
+  { id: 'nord', name: 'Nord' },
+  { id: 'osaka-jade', name: 'Osaka Jade' },
+  { id: 'retro-82', name: 'Retro 82' },
+  { id: 'ristretto', name: 'Ristretto' },
+  { id: 'rose-pine', name: 'Rosé Pine', light: true },
+  { id: 'solitude', name: 'Solitude' },
+  { id: 'tokyo-night', name: 'Tokyo Night' },
+  { id: 'vantablack', name: 'Vantablack' },
+  { id: 'white', name: 'White', light: true },
+]
+
+export const DEFAULT_THEME = 'tokyo-night'

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,42 +1,29 @@
 import { inlineJson } from './inline-json'
+import { DEFAULT_THEME, SITE_THEMES, type SiteTheme } from './site-themes.ts'
+import {
+  desktopThemeName,
+  onDesktopTheme,
+  siteThemeFor,
+} from './desktop-theme.ts'
 
 import { OMARCHY_MARK_PATH } from '@/components/Brand'
 import { runThemeViewTransition } from '@/lib/theme-transition'
 
-export type SiteTheme = {
-  id: string
-  name: string
-  /** A light page: the theme's background is the lighter of its two inks. */
-  light?: true
-}
+// Re-exported from here, which is where every caller already looks.
+export { DEFAULT_THEME, SITE_THEMES }
+export type { SiteTheme }
 
-export const SITE_THEMES: SiteTheme[] = [
-  { id: 'catppuccin', name: 'Catppuccin' },
-  { id: 'catppuccin-latte', name: 'Catppuccin Latte', light: true },
-  { id: 'ethereal', name: 'Ethereal' },
-  { id: 'everforest', name: 'Everforest' },
-  { id: 'flexoki-light', name: 'Flexoki Light', light: true },
-  { id: 'gruvbox', name: 'Gruvbox' },
-  { id: 'hackerman', name: 'Hackerman' },
-  { id: 'kanagawa', name: 'Kanagawa' },
-  { id: 'last-horizon', name: 'Last Horizon' },
-  { id: 'lumon', name: 'Lumon' },
-  { id: 'lupine', name: 'Lupine', light: true },
-  { id: 'matte-black', name: 'Matte Black' },
-  { id: 'miasma', name: 'Miasma' },
-  { id: 'nord', name: 'Nord' },
-  { id: 'osaka-jade', name: 'Osaka Jade' },
-  { id: 'retro-82', name: 'Retro 82' },
-  { id: 'ristretto', name: 'Ristretto' },
-  { id: 'rose-pine', name: 'Rosé Pine', light: true },
-  { id: 'solitude', name: 'Solitude' },
-  { id: 'tokyo-night', name: 'Tokyo Night' },
-  { id: 'vantablack', name: 'Vantablack' },
-  { id: 'white', name: 'White', light: true },
-]
-
-export const DEFAULT_THEME = 'tokyo-night'
 export const THEME_KEY = 'omarchy-site-theme'
+/**
+ * The theme somebody chose, as against the one the site last applied.
+ *
+ * THEME_KEY is written on every applyTheme, so everyone has one stored — a
+ * first visit is given a random palette and that gets stored too. Stored is
+ * not chosen, and the difference matters to anything deciding whether it may
+ * dress the site itself: src/lib/desktop-theme.ts wears the machine's theme
+ * until somebody says otherwise, and this is how they say it.
+ */
+export const PIN_KEY = 'omarchy-site-theme-pinned'
 /** Fired on <window> after a theme lands, for canvas renderers to re-read. */
 export const THEME_EVENT = 'omarchy-theme'
 /** Ask the mounted ThemePicker to open (footer link, welcome notice). */
@@ -64,6 +51,34 @@ export function readTheme(): string {
     /* storage unavailable */
   }
   return DEFAULT_THEME
+}
+
+/** The theme somebody picked out of the picker, if they ever picked one. */
+export function pinnedTheme(): string | null {
+  try {
+    const pinned = localStorage.getItem(PIN_KEY)
+    if (SITE_THEMES.some((t) => t.id === pinned)) return pinned
+  } catch {
+    /* storage unavailable */
+  }
+  return null
+}
+
+/**
+ * Applies a theme and records that it was chosen, so nothing else overrides
+ * it. Everywhere somebody picks one by hand goes through this.
+ */
+export function chooseTheme(
+  id: string,
+  after?: () => void,
+  options: { frosted?: boolean } = {},
+) {
+  try {
+    localStorage.setItem(PIN_KEY, id)
+  } catch {
+    /* storage unavailable */
+  }
+  switchTheme(id, after, options)
 }
 
 /** Replace the favicon link to invalidate browsers that cache it by element. */
@@ -266,4 +281,49 @@ export function switchTheme(
     undefined,
     options.frosted,
   )
+}
+
+/** The theme the desktop is wearing, if this site ships one to match it. */
+export function desktopTheme(): string | null {
+  return siteThemeFor(
+    desktopThemeName(),
+    SITE_THEMES.map((t) => t.id),
+  )
+}
+
+/**
+ * Wears the theme the machine is wearing, and keeps wearing it.
+ *
+ * Somebody who has chosen a theme keeps the one they chose: pinnedTheme() is
+ * what they picked, as against what the site last happened to apply. THEME_KEY
+ * is written on every applyTheme, so everyone has one stored — including the
+ * random palette a first visit is given — and stored is not chosen.
+ *
+ * The first name lands during load and is applied flat: the extension is
+ * always a moment behind the first paint, and there is nothing worth animating
+ * between two states nobody has looked at. A change after that is the desktop
+ * actually changing under an open tab, which earns the site's own wipe.
+ *
+ * Without the extension nothing is ever published, this never fires, and the
+ * site is the themes it always was.
+ *
+ * @returns a function that stops following.
+ */
+export function followDesktopTheme(): () => void {
+  // Whether a name has actually been published yet. onDesktopTheme calls back
+  // once on subscribe, when usually nothing has been, and that call must not
+  // count: it would leave the first real name taking the animated path, which
+  // is the one reserved for a desktop changing under an open tab.
+  let seen = false
+  return onDesktopTheme(() => {
+    const id = desktopTheme()
+    if (!id) return
+    const chosen = pinnedTheme()
+    if (chosen && chosen !== id) return
+    if (id !== readTheme()) {
+      if (seen) switchTheme(id)
+      else applyTheme(id)
+    }
+    seen = true
+  })
 }


### PR DESCRIPTION
[omarchy-theme-sync](https://github.com/omacom/omarchy-theme-sync) is a Chromium extension that reads the Omarchy theme a machine is running and publishes it to every page — the palette as `--omarchy-*` properties on `<html>`, and the theme's own name as `data-omarchy-theme`, rewritten whenever the desktop theme changes.

**No palette crosses over, and that is the whole point.**

This site's themes are named after Omarchy's own and their values come from that theme's `colors.toml`. So the ids in `SITE_THEMES` and the directory names under `themes/` in `omacom/omarchy` are the same strings — **twenty-two for twenty-two, no differences** — and the name the extension publishes is that directory name:

```
extension → data-omarchy-theme="osaka-jade" → applyTheme('osaka-jade')
                                              (a palette this site already ships)
```

A name match onto something hand-authored, with every in-between step already chosen. Nothing is derived from a foreign palette and there is no extra theme to maintain. A theme the site does not ship simply does not match, and the site's own theme is left alone rather than guessed at.

**Reading only.** The extension does let exactly one origin *set* the desktop's theme, and this site is that origin — but a website is not a thing that should change somebody's desktop, so nothing here asks it to.

## Three things it needed

**A distinction the site did not have.** `applyTheme()` writes `THEME_KEY` on every apply, so everybody has a theme stored — including the random palette `themeInitScript` gives a first visit. Stored is not chosen. `PIN_KEY` records what somebody picked out of the picker, and only that outranks the machine. `chooseTheme()` is where a pick goes, and both places somebody picks one now call it.

**The theme list moved to `src/lib/site-themes.ts`.** `theme.ts` reaches for a canvas to resolve colours and for the brand mark's path to repaint the favicon, which makes it a module only a browser can load. The list is data, and data should be reachable from a test. `theme.ts` re-exports it, so no other file changes.

**The first name is applied flat; a later one gets the wipe.** The extension takes the name from a native host over a port, so it always lands after the first paint — there is nothing worth animating between two states nobody has looked at. A change after that is the desktop changing under an open tab, which earns the transition.

## Verification

Driven against the real extension and native host through the DevTools protocol, in real time — virtual time never waits for a subprocess, which is why the first attempts at this measured nothing at all.

| | |
| --- | --- |
| a first visit | wears the machine's theme, and stores it so navigation keeps it |
| a stored theme nobody chose | does not outrank the machine |
| a theme picked by hand | is not overruled, across reloads |
| the desktop changing | repaints an open tab |
| a theme this site does not ship | leaves the site alone |

Plus 5 unit tests on the matcher, including that every id in `SITE_THEMES` is a well-formed Omarchy directory name — so a theme added with an id that is not its Omarchy directory cannot silently never sync.

```
npm run typecheck   clean
npm test            24 tests (19 before), 4 python
npm run lint        clean
npm run build       ok
```

`npm run check` (prettier) reports 129 files on `master` already; the files here are clean and none of those 129 are touched.

## Two things found the hard way

**`npm run typecheck` does not read `.astro` script blocks.** For a while `Base.astro` imported `followDesktopTheme` from the wrong module. `tsc --noEmit` and `eslint` were both green; the browser threw `SyntaxError: does not provide an export named 'followDesktopTheme'` and the feature silently did nothing. Only running it caught that. Worth considering `astro check` alongside `tsc` — it would have found it in a second.

**The first version marked itself settled too early.** `onDesktopTheme` calls back once on subscribe, when nothing has usually been published yet, and that no-op call was setting the flag — so the *first* real theme took the animated path instead of the flat one.

## To try it

With the extension installed: `npm run dev`, open it, then switch your desktop theme and watch the page follow. Pick a theme in the picker and it stops following. Without the extension nothing is ever published, `followDesktopTheme()` never fires, and the site is the themes it always was.

## Deliberately not here

- **Marking the desktop's theme in the picker.** `ThemePicker.tsx` is a carefully tuned card deck, and this is a behaviour change rather than a design one. Happy to add a marker if you want one.
- **Installing a theme from the gallery.** `installTheme()` exists in the extension, but `src/data/themes.json` carries only `{ repo, image, name }` for its 146 themes — no palettes to install. That would mean fetching 146 `colors.toml` files, and it is a separate concern from the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
