### PR TITLE
Put Teams in the bar, after Themes

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -55,6 +55,7 @@ const navLinks = [
   // Old /plugins/ addresses redirect to the standalone directory.
   { href: 'https://plugins.omarchy.org', label: 'Plugins' },
   { to: '/themes/', label: t('Themes') },
+  { to: '/teams/', label: t('Teams') },
 ] as const
 
 /** Observe the live hero sentinel; the header and blended labels share this state. */


### PR DESCRIPTION
The teams page had no way in from the bar. It joins the links on the left, on the phone menu too. The Danish site picks up its existing translation.