### PR TITLE
Fix broken GitHub link

### DIFF
--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -178,7 +178,7 @@ const communityCards = [
     icon: GithubIcon,
     title: t('Contribute'),
     body: t('File issues, fix bugs, and submit features.'),
-    href: 'https://github.com/omacom-io/omarchy',
+    href: 'https://github.com/omacom/omarchy',
     cta: t('Contribute on GitHub'),
   },
   {


### PR DESCRIPTION
The new omarchy.org site has a broken GitHub link. This updates it to the correct URL.