### PR TITLE
Homepage: Try in Browser, next to Mac and Windows

### DIFF
--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useState } from 'react'
 import {
   AppleIcon,
   ArrowRightIcon,
+  BrowserIcon,
   XIcon,
   ArrowUpRightIcon,
   BankIcon,
@@ -64,6 +65,11 @@ const TRY = {
     label: t('Try on Windows'),
     href: 'https://github.com/omacom/try-omarchy-windows',
     icon: WindowsIcon,
+  },
+  browser: {
+    label: t('Try in Browser'),
+    href: 'https://tryomarchy.dev',
+    icon: BrowserIcon,
   },
 } as const
 
@@ -567,12 +573,12 @@ export function HomePage({ data }: { data: HomeData }) {
               </div>
               <p className="mt-3 text-[15px] leading-relaxed text-text-secondary [text-wrap:pretty]">
                 {t(
-                  'All of Omarchy running in a virtual machine, so you can get a taste first.',
+                  'All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.',
                 )}
               </p>
               <div className="mt-auto pt-6">
                 <div className="flex flex-wrap gap-2">
-                  {(['mac', 'windows'] as const).map((key) => {
+                  {(['mac', 'windows', 'browser'] as const).map((key) => {
                     const Mark = TRY[key].icon
                     return (
                       <Button
@@ -592,7 +598,9 @@ export function HomePage({ data }: { data: HomeData }) {
                 <p className="mt-2.5 text-[13px] text-text-muted">
                   {t('Apple Silicon Macs, Windows 10 and 11.')}
                   <span className="block">
-                    {t('On Linux, the ISO is the way in.')}
+                    {t(
+                      'Anything with a browser tab: nothing to download, gone when you close it.',
+                    )}
                   </span>
                 </p>
               </div>

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -369,6 +369,20 @@ export function AppleIcon(props: IconProps) {
   )
 }
 
+/** A browser window: three dots in the title bar, the page below, cut out
+ *  so the icon works on any button colour. */
+export function BrowserIcon(props: IconProps) {
+  return (
+    <svg {...base(props)} shapeRendering="crispEdges">
+      <path
+        fillRule="evenodd"
+        d="M2 3h20v18H2zM4 9v10h16V9zM4 5h2v2H4zM7 5h2v2H7zM10 5h2v2h-2z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
 export function WindowsIcon(props: IconProps) {
   return (
     <svg {...base(props)} shapeRendering="crispEdges">

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -46,9 +46,7 @@
   "Verify the file:": "تحقّق من الملف:",
   "signature": "التوقيع",
   "Try it first": "جرّبه أولاً",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Omarchy بالكامل يعمل في جهاز افتراضي لتأخذ فكرة عنه أولاً.",
   "Apple Silicon Macs, Windows 10 and 11.": "أجهزة Mac بمعالجات Apple Silicon، وWindows 10 و11.",
-  "On Linux, the ISO is the way in.": "على لينكس، تبدأ بملف ISO.",
   "The manual also covers": "يغطي الدليل أيضاً",
   "dual booting beside Windows": "الإقلاع المزدوج بجانب Windows",
   "and": "و",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "عارض صور محطات العمل",
   "Close photo viewer": "أغلق عارض الصور",
   "Previous photo": "الصورة السابقة",
-  "Next photo": "الصورة التالية"
+  "Next photo": "الصورة التالية",
+  "Try in Browser": "جرّبه في المتصفح",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Omarchy بالكامل في آلة افتراضية على جهاز Mac أو PC، أو مبثوثًا إلى تبويب في المتصفح، لتتذوقه أولًا.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "أي جهاز به تبويب متصفح: لا شيء للتنزيل، ويختفي عند إغلاقه."
 }

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Kontrollér filen:",
   "signature": "signatur",
   "Try it first": "Prøv det først",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Hele Omarchy i en virtuel maskine, så du kan prøve det af først.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mac med Apple Silicon samt Windows 10 og 11.",
-  "On Linux, the ISO is the way in.": "På Linux er ISO-filen vejen ind.",
   "The manual also covers": "Håndbogen dækker også",
   "dual booting beside Windows": "dual boot sammen med Windows",
   "and": "og",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Visning af arbejdsstationsbilleder",
   "Close photo viewer": "Luk billedvisning",
   "Previous photo": "Forrige billede",
-  "Next photo": "Næste billede"
+  "Next photo": "Næste billede",
+  "Try in Browser": "Prøv i browseren",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Hele Omarchy i en virtuel maskine på din Mac eller pc, eller streamet til en browserfane, så du kan få en forsmag først.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Alt med en browserfane: intet at hente, væk når du lukker den."
 }

--- a/src/i18n/messages/el.json
+++ b/src/i18n/messages/el.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Επαλήθευση αρχείου:",
   "signature": "υπογραφή",
   "Try it first": "Δοκίμασέ το πρώτα",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Ολόκληρο το Omarchy σε εικονική μηχανή, για να πάρεις πρώτα μια γεύση.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mac με Apple Silicon, Windows 10 και 11.",
-  "On Linux, the ISO is the way in.": "Στο Linux, ξεκίνα με το ISO.",
   "The manual also covers": "Το εγχειρίδιο καλύπτει επίσης",
   "dual booting beside Windows": "διπλή εκκίνηση μαζί με Windows",
   "and": "και",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Προβολή φωτογραφιών σταθμών εργασίας",
   "Close photo viewer": "Κλείσιμο προβολής φωτογραφιών",
   "Previous photo": "Προηγούμενη φωτογραφία",
-  "Next photo": "Επόμενη φωτογραφία"
+  "Next photo": "Επόμενη φωτογραφία",
+  "Try in Browser": "Δοκιμή στο πρόγραμμα περιήγησης",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Ολόκληρο το Omarchy σε εικονική μηχανή στο Mac ή το PC σου, ή σε ροή σε μια καρτέλα του προγράμματος περιήγησης, για να πάρεις πρώτα μια γεύση.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Οτιδήποτε με μια καρτέλα προγράμματος περιήγησης: τίποτα για λήψη, εξαφανίζεται μόλις την κλείσεις."
 }

--- a/src/i18n/messages/es-MX.json
+++ b/src/i18n/messages/es-MX.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Verifica el archivo:",
   "signature": "firma",
   "Try it first": "Pruébalo primero",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Todo Omarchy en una máquina virtual, para que puedas probarlo primero.",
   "Apple Silicon Macs, Windows 10 and 11.": "Macs con Apple Silicon, Windows 10 y 11.",
-  "On Linux, the ISO is the way in.": "En Linux, entra con la imagen ISO.",
   "The manual also covers": "El manual también explica el",
   "dual booting beside Windows": "arranque dual junto a Windows",
   "and": "y las",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Visor de fotos de estaciones de trabajo",
   "Close photo viewer": "Cerrar visor de fotos",
   "Previous photo": "Foto anterior",
-  "Next photo": "Foto siguiente"
+  "Next photo": "Foto siguiente",
+  "Try in Browser": "Pruébalo en el navegador",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Todo Omarchy en una máquina virtual en tu Mac o PC, o transmitido a una pestaña del navegador, para que lo pruebes primero.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Cualquier cosa con una pestaña del navegador: nada que descargar, desaparece al cerrarla."
 }

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Tarkista tiedosto:",
   "signature": "allekirjoitus",
   "Try it first": "Kokeile ensin",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Koko Omarchy virtuaalikoneessa, jotta voit tutustua siihen ensin.",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon -Macit, Windows 10 ja 11.",
-  "On Linux, the ISO is the way in.": "Linuxissa pääset alkuun ISO-tiedostolla.",
   "The manual also covers": "Ohjekirja käsittelee myös",
   "dual booting beside Windows": "rinnakkaisasennuksen Windowsin kanssa",
   "and": "ja",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Työasemakuvien katselu",
   "Close photo viewer": "Sulje kuvien katselu",
   "Previous photo": "Edellinen kuva",
-  "Next photo": "Seuraava kuva"
+  "Next photo": "Seuraava kuva",
+  "Try in Browser": "Kokeile selaimessa",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Koko Omarchy virtuaalikoneessa Macilla tai PC:llä tai suoratoistona selaimen välilehteen, jotta saat ensin esimakua.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Mikä tahansa, jossa on selaimen välilehti: ei ladattavaa, katoaa kun suljet sen."
 }

--- a/src/i18n/messages/fil.json
+++ b/src/i18n/messages/fil.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Beripikahin ang file:",
   "signature": "lagda",
   "Try it first": "Subukan muna",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Buong Omarchy na tumatakbo sa virtual machine para matikman mo muna.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mga Mac na may Apple Silicon, Windows 10 at 11.",
-  "On Linux, the ISO is the way in.": "Sa Linux, ISO ang paraan para magsimula.",
   "The manual also covers": "Saklaw din ng manwal ang",
   "dual booting beside Windows": "dual boot kasama ng Windows",
   "and": "at",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Tagatingin ng larawan ng workstation",
   "Close photo viewer": "Isara ang tagatingin ng larawan",
   "Previous photo": "Naunang larawan",
-  "Next photo": "Susunod na larawan"
+  "Next photo": "Susunod na larawan",
+  "Try in Browser": "Subukan sa browser",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Buong Omarchy sa isang virtual machine sa iyong Mac o PC, o naka-stream sa isang browser tab, para matikman mo muna.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Kahit ano na may browser tab: walang ida-download, nawawala kapag isinara mo."
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Vérifier le fichier :",
   "signature": "signature",
   "Try it first": "Essayer d’abord",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Tout Omarchy dans une machine virtuelle, pour vous faire une première idée.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mac avec Apple Silicon, Windows 10 et 11.",
-  "On Linux, the ISO is the way in.": "Sous Linux, passez par l’ISO.",
   "The manual also covers": "Le manuel explique aussi",
   "dual booting beside Windows": "le double démarrage avec Windows",
   "and": "et",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Visionneuse de photos des postes de travail",
   "Close photo viewer": "Fermer la visionneuse",
   "Previous photo": "Photo précédente",
-  "Next photo": "Photo suivante"
+  "Next photo": "Photo suivante",
+  "Try in Browser": "Essayer dans le navigateur",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Tout Omarchy dans une machine virtuelle sur votre Mac ou PC, ou diffusé dans un onglet du navigateur, pour vous faire une première idée.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Tout ce qui a un onglet de navigateur : rien à télécharger, disparu dès que vous le fermez."
 }

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -46,9 +46,7 @@
   "Verify the file:": "फ़ाइल की जाँच करें:",
   "signature": "हस्ताक्षर",
   "Try it first": "पहले आज़माएँ",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "पूरा Omarchy एक वर्चुअल मशीन में चलता है, ताकि आप पहले इसका अनुभव ले सकें।",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon वाले Mac, Windows 10 और 11।",
-  "On Linux, the ISO is the way in.": "Linux पर शुरुआत ISO से होती है।",
   "The manual also covers": "मैनुअल में यह भी है:",
   "dual booting beside Windows": "Windows के साथ डुअल बूट",
   "and": "और",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "वर्कस्टेशन फ़ोटो दर्शक",
   "Close photo viewer": "फ़ोटो दर्शक बंद करें",
   "Previous photo": "पिछली फ़ोटो",
-  "Next photo": "अगली फ़ोटो"
+  "Next photo": "अगली फ़ोटो",
+  "Try in Browser": "ब्राउज़र में आज़माएँ",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "पूरा Omarchy आपके Mac या PC पर एक वर्चुअल मशीन में, या ब्राउज़र टैब में स्ट्रीम होकर, ताकि पहले एक झलक मिल सके।",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "ब्राउज़र टैब वाला कुछ भी: कुछ डाउनलोड नहीं, बंद करते ही गायब।"
 }

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -46,9 +46,7 @@
   "Verify the file:": "A fájl ellenőrzése:",
   "signature": "aláírás",
   "Try it first": "Először próbáld ki",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "A teljes Omarchy egy virtuális gépben, hogy előbb megismerhesd.",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon alapú Macek, Windows 10 és 11.",
-  "On Linux, the ISO is the way in.": "Linuxon az ISO-val kezdj.",
   "The manual also covers": "A kézikönyv ezekre is kitér:",
   "dual booting beside Windows": "kettős rendszerindítás Windows mellett",
   "and": "és",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Munkaállomás-fotónézegető",
   "Close photo viewer": "Fotónézegető bezárása",
   "Previous photo": "Előző fotó",
-  "Next photo": "Következő fotó"
+  "Next photo": "Következő fotó",
+  "Try in Browser": "Kipróbálás böngészőben",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "A teljes Omarchy egy virtuális gépben a Maceden vagy PC-den, vagy egy böngészőlapra streamelve, hogy először belekóstolhass.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Bármi, amin van böngészőlap: nincs mit letölteni, bezáráskor eltűnik."
 }

--- a/src/i18n/messages/is.json
+++ b/src/i18n/messages/is.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Staðfesta skrána:",
   "signature": "undirskrift",
   "Try it first": "Prófaðu fyrst",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Allt Omarchy keyrandi í sýndarvél svo þú getir prófað það fyrst.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mac-tölvur með Apple Silicon, Windows 10 og 11.",
-  "On Linux, the ISO is the way in.": "Á Linux er ISO-skráin leiðin inn.",
   "The manual also covers": "Handbókin fjallar líka um",
   "dual booting beside Windows": "samhliða uppsetningu með Windows",
   "and": "og",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Myndaskoðari fyrir vinnustöðvar",
   "Close photo viewer": "Loka myndaskoðara",
   "Previous photo": "Fyrri mynd",
-  "Next photo": "Næsta mynd"
+  "Next photo": "Næsta mynd",
+  "Try in Browser": "Prófa í vafra",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Allt Omarchy í sýndarvél á Mac eða PC, eða streymt í vafraflipa, svo þú getir fengið forsmekk fyrst.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Hvað sem er með vafraflipa: ekkert að sækja, horfið þegar þú lokar honum."
 }

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -46,9 +46,7 @@
   "Verify the file:": "ファイルを検証：",
   "signature": "署名",
   "Try it first": "まずは試してみる",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "仮想マシンでOmarchyを丸ごと動かし、使い心地を試せます。",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon搭載Mac、Windows 10と11に対応。",
-  "On Linux, the ISO is the way in.": "LinuxではISOから始めましょう。",
   "The manual also covers": "マニュアルでは、",
   "dual booting beside Windows": "Windowsとのデュアルブート",
   "and": "と",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "ワークステーション写真ビューアー",
   "Close photo viewer": "写真ビューアーを閉じる",
   "Previous photo": "前の写真",
-  "Next photo": "次の写真"
+  "Next photo": "次の写真",
+  "Try in Browser": "ブラウザで試す",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Mac や PC の仮想マシン、あるいはブラウザのタブへのストリーミングで、Omarchy のすべてをまず体験できます。",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "ブラウザのタブがあれば何でも。ダウンロード不要、閉じれば消えます。"
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -46,9 +46,7 @@
   "Verify the file:": "파일 검증:",
   "signature": "서명",
   "Try it first": "먼저 체험하기",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "가상 머신에서 Omarchy 전체를 실행해 먼저 경험해 보세요.",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon Mac, Windows 10 및 11.",
-  "On Linux, the ISO is the way in.": "Linux에서는 ISO로 시작하세요.",
   "The manual also covers": "매뉴얼에서는 다음도 다룹니다:",
   "dual booting beside Windows": "Windows와 듀얼 부팅",
   "and": "및",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "워크스테이션 사진 뷰어",
   "Close photo viewer": "사진 뷰어 닫기",
   "Previous photo": "이전 사진",
-  "Next photo": "다음 사진"
+  "Next photo": "다음 사진",
+  "Try in Browser": "브라우저에서 체험",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Mac이나 PC의 가상 머신에서, 또는 브라우저 탭으로 스트리밍하여 Omarchy 전체를 먼저 맛볼 수 있습니다.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "브라우저 탭만 있으면 어디서든: 다운로드 없음, 닫으면 사라집니다."
 }

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Verificar o ficheiro:",
   "signature": "assinatura",
   "Try it first": "Experimente primeiro",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Todo o Omarchy numa máquina virtual, para poder experimentá-lo primeiro.",
   "Apple Silicon Macs, Windows 10 and 11.": "Macs com Apple Silicon, Windows 10 e 11.",
-  "On Linux, the ISO is the way in.": "No Linux, a entrada faz-se pela imagem ISO.",
   "The manual also covers": "O manual também explica o",
   "dual booting beside Windows": "arranque duplo com o Windows",
   "and": "e as",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Visualizador de fotos de estações de trabalho",
   "Close photo viewer": "Fechar visualizador de fotos",
   "Previous photo": "Foto anterior",
-  "Next photo": "Próxima foto"
+  "Next photo": "Próxima foto",
+  "Try in Browser": "Experimentar no navegador",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Todo o Omarchy numa máquina virtual no seu Mac ou PC, ou transmitido para um separador do navegador, para provar primeiro.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Qualquer coisa com um separador do navegador: nada para descarregar, desaparece quando o fecha."
 }

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Verifiera filen:",
   "signature": "signatur",
   "Try it first": "Prova först",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Hela Omarchy i en virtuell maskin, så att du kan få ett smakprov först.",
   "Apple Silicon Macs, Windows 10 and 11.": "Mac med Apple Silicon, Windows 10 och 11.",
-  "On Linux, the ISO is the way in.": "På Linux använder du ISO-filen.",
   "The manual also covers": "Handboken tar också upp",
   "dual booting beside Windows": "dubbelstart med Windows",
   "and": "och",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Bildvisare för arbetsstationer",
   "Close photo viewer": "Stäng bildvisaren",
   "Previous photo": "Föregående bild",
-  "Next photo": "Nästa bild"
+  "Next photo": "Nästa bild",
+  "Try in Browser": "Prova i webbläsaren",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Hela Omarchy i en virtuell maskin på din Mac eller PC, eller strömmat till en webbläsarflik, så att du kan få ett smakprov först.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Allt med en webbläsarflik: inget att ladda ned, borta när du stänger den."
 }

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -46,9 +46,7 @@
   "Verify the file:": "Dosyayı doğrulayın:",
   "signature": "imza",
   "Try it first": "Önce deneyin",
-  "All of Omarchy running in a virtual machine, so you can get a taste first.": "Önce tadına bakabilmeniz için Omarchy'nin tamamı bir sanal makinede çalışır.",
   "Apple Silicon Macs, Windows 10 and 11.": "Apple Silicon Mac'ler, Windows 10 ve 11.",
-  "On Linux, the ISO is the way in.": "Linux'ta başlangıç noktası ISO dosyasıdır.",
   "The manual also covers": "Kılavuz ayrıca şunları da anlatır:",
   "dual booting beside Windows": "Windows yanında çift önyükleme",
   "and": "ve",
@@ -333,5 +331,8 @@
   "Workstation photo viewer": "Çalışma istasyonu fotoğraf görüntüleyicisi",
   "Close photo viewer": "Fotoğraf görüntüleyicisini kapat",
   "Previous photo": "Önceki fotoğraf",
-  "Next photo": "Sonraki fotoğraf"
+  "Next photo": "Sonraki fotoğraf",
+  "Try in Browser": "Tarayıcıda deneyin",
+  "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first.": "Omarchy'nin tamamı Mac veya PC'nizde bir sanal makinede ya da bir tarayıcı sekmesine aktarılmış olarak, önce bir tadına bakın.",
+  "Anything with a browser tab: nothing to download, gone when you close it.": "Tarayıcı sekmesi olan her şey: indirilecek bir şey yok, kapatınca gider."
 }


### PR DESCRIPTION
Hi team 👋 

Imagine being able to click "boot" in your browser and you get a real Omarchy running. Zero friction. 

https://tryomarchy.dev 
It runs the real Omarchy desktop (4.0.2, Hyprland, Quickshell) in a Cloudflare Container near the visitor, and streams it to a browser tab. 
<img width="2872" height="2236" alt="image" src="https://github.com/user-attachments/assets/e0b3d349-6423-47d6-86b8-d10a0ad98f39" />

For context: I worked as official Ubuntu developer 20 years ago on shipping Live CDs etc, so I am first-hand aware of the friction that goes in when people want to try out Linux. The entire point is that it should be super fast and super simple to try it out. If you like it, you decide to install it.

I'm so happy with the state of tech today and I put a few days in building this basically serverless-Omarchy-on-a-button. 
I think this is the easiest way to give curious users a taste of Omarchy without asking them do to anything. Nothing to download, they get a fresh machine in a few seconds. 

## What changes

- `HomePage.tsx`: a third entry in `TRY` (`browser` points to https://tryomarchy.dev), rendered after Mac and Windows. 
- The card's copy now covers both ways in: "All of Omarchy in a virtual machine on your Mac or PC, or streamed to a browser tab, so you can get a taste first." 
- `icons/index.tsx`: a `BrowserIcon` in the same filled, crisp-edge style as the Windows icon
- Message catalogues: the three new strings are in every locale

## How it works
Hyprland runs on a headless output with no GPU, rendered by Mesa's llvmpipe; a daemon captures the output over Wayland screencopy, encodes changed stripes with x264, and ships H.264 over one WebSocket to a WebCodecs decoder in the tab. Container start is about 1-2 seconds on a nearest Cloudflare PoP near you as Cloudflare Containers.

## Checks

`npm run lint`, `npm run typecheck`, `npm test` and `npm run check:translations` pass locally. 

Happy to change the wording, the icon, the button's position, ideally to have this added to `omacom` Github org and transfer the domain. 🐧

and yes it runs in any browser, cars included haha:
<img width="4096" height="3072" alt="HRoBeVobMAAvJ1k" src="https://github.com/user-attachments/assets/ae7d7946-ce94-412a-8b44-bfb08b1e3e72" />
