### PR TITLE
Paint the favicon with the brand bands

### DIFF
--- a/src/components/Brand.tsx
+++ b/src/components/Brand.tsx
@@ -35,7 +35,7 @@ const BRAND_BANDS: [color: string, rows: number][] = [
 const BAND_ROWS = BRAND_BANDS.reduce((sum, [, rows]) => sum + rows, 0)
 
 /** Band edges in percent of the height. */
-const BAND_STOPS = BRAND_BANDS.reduce<{
+export const BAND_STOPS = BRAND_BANDS.reduce<{
   stops: [string, number, number][]
   rows: number
 }>(

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,6 +1,6 @@
 import { inlineJson } from './inline-json'
 
-import { OMARCHY_MARK_PATH } from '@/components/Brand'
+import { BAND_STOPS, OMARCHY_MARK_PATH } from '@/components/Brand'
 import { runThemeViewTransition } from '@/lib/theme-transition'
 
 export type SiteTheme = {
@@ -68,11 +68,20 @@ export function readTheme(): string {
 
 /** Replace the favicon link to invalidate browsers that cache it by element. */
 export function paintFavicon() {
-  const brand = getComputedStyle(document.documentElement)
-    .getPropertyValue('--color-brand')
-    .trim()
-  if (!brand) return
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200"><path fill="${brand}" fill-rule="evenodd" clip-rule="evenodd" d="${OMARCHY_MARK_PATH}"/></svg>`
+  const style = getComputedStyle(document.documentElement)
+  const bands = BAND_STOPS.map(([token, from, to]) => ({
+    color: style.getPropertyValue(token.slice('var('.length, -1)).trim(),
+    from,
+    to,
+  }))
+  if (bands.some(({ color }) => !color)) return
+  const stops = bands
+    .map(
+      ({ color, from, to }) =>
+        `<stop offset="${from}%" stop-color="${color}"/><stop offset="${to}%" stop-color="${color}"/>`,
+    )
+    .join('')
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1200"><defs><linearGradient id="bands" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="0" y2="1200">${stops}</linearGradient></defs><path fill="url(#bands)" fill-rule="evenodd" clip-rule="evenodd" d="${OMARCHY_MARK_PATH}"/></svg>`
   const link = document.createElement('link')
   link.rel = 'icon'
   link.type = 'image/svg+xml'


### PR DESCRIPTION
The tab icon was still the flat brand colour after the mark in the nav took the gradient in #201.

- The favicon is painted with the same five bands as the wordmark and the nav mark, from the theme's field tokens, so it follows every theme like they do. The band list in Brand.tsx is now exported and is the one source for all three.
- The gradient sits in user space over the glyph's full height, as on the brand sheet.
- At 16 px the bands are still four, two, three, three and four pixels tall, so the glyph reads; checked in Nord and Catppuccin Latte.
- The static link in the head keeps pointing at the flat SVG for the frame before the script runs; the painted icon replaces it on arrival as before.