### PR TITLE
Add Chinese manual translation and per-locale manual support

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,6 +1,6 @@
 # Translations
 
-One site, shared components, separate static builds. English remains the source of truth. Each of the 30 languages has one primary address, either a registered domain or a language subdomain under omarchy.org. English uses omarchy.org. Manual links currently lead to the canonical English manual.
+One site, shared components, separate static builds. English remains the source of truth. Each of the 30 languages has one primary address, either a registered domain or a language subdomain under omarchy.org. English uses omarchy.org. Manual links lead to the canonical English manual until a language translates its manual; Simplified Chinese is the first edition with a translated manual.
 
 ## Build and preview
 
@@ -21,7 +21,7 @@ Each output contains its own domain, CNAME, canonical URLs, language metadata, l
 4. Add `src/i18n/<code>/news.json` with each article's translated title and `sourceHash`, plus the full article HTML in `news/<original-slug>.html`. Keep original slugs across languages so language switching lands on the same article. The source hash is SHA-256 of the English title, a newline, and the English HTML from `src/data/news-posts.json`.
 5. Run `npm run port`, `npm run check:translations`, and `npm run build:locale -- <code>`. Review the rendered pages at desktop and mobile widths before configuring the domain.
 
-Only register a language when its main pages and news are ready. The registry also controls the globe switcher beside the theme button, the footer language switch and search-engine alternate links. Translation builds include redirects from manual URLs to the English domain, preserving the chapter path. Once manual translation is implemented, the registry flag can be enabled for that language.
+Only register a language when its main pages and news are ready. The registry also controls the globe switcher beside the theme button, the footer language switch and search-engine alternate links. While `manual` is false, translation builds redirect manual URLs to the English domain, preserving the chapter path; the language menu keeps the reader on the same chapter only for languages with a translated manual.
 
 ## Updating copy
 
@@ -88,7 +88,7 @@ Cloudflare custom domains handle routing and TLS directly. Registered national d
 | Polski           | [pl.omarchy.org](https://pl.omarchy.org) |
 | Lietuvių         | [lt.omarchy.org](https://lt.omarchy.org) |
 | Gaeilge          | [ga.omarchy.org](https://ga.omarchy.org) |
-| Nederlands | [nl.omarchy.org](https://nl.omarchy.org) |
+| Nederlands       | [nl.omarchy.org](https://nl.omarchy.org) |
 
 ## Pointing a new domain to a language site
 
@@ -111,9 +111,9 @@ A domain owner can provide the new primary address for a language while keeping 
 
 A DNS CNAME pointing an arbitrary domain at an omarchy.org hostname is not sufficient: it does not configure Worker routing or provide a certificate for that domain. Use the zone and Worker custom-domain handoff above. Nameserver changes affect the whole domain, so preserving existing DNS records is part of the handoff, not an optional cleanup step.
 
-## Translating the manual next
+## Manual translations
 
-Keep English chapters in the existing source repository. Store translations separately using stable chapter paths and section IDs, with a hash of the English source beside each translated section. Preserve executable commands, filenames and the interface's actual menu labels. When the source changes, require review of only the affected sections. Until a section is translated, render its English source with a clear language notice; never leave installation instructions missing. Enable a locale's `manual` flag only after the translated routing, fallback and source-freshness checks are implemented.
+The English chapters stay in the source repository and are ported into `src/data/manual.json`. A translation lives beside the news translation: `src/i18n/<code>/manual.json` maps each chapter slug to its translated title and the SHA-256 of the English title, a newline, and the English HTML, and `manual/<slug>.html` holds the chapter body. Executable commands, filenames, hotkeys, and the interface's actual menu labels stay in English. When a chapter's source changes, `check:translations` flags only that chapter, and the hash is replaced after review. The check also requires links, images, and section ids to match, so cross-references and the search index keep working. A chapter without a current translation renders its English source behind a language notice, so a partly translated manual never hides installation instructions. Locale-specific manual copy (the manual's page title, description, and the notice) is required under `--strict-site` only for languages that set `manual: true`; the background workflow still translates it ahead of time.
 
 ## Publish English first, translate afterward
 
@@ -130,4 +130,4 @@ Configure these repository Actions settings:
 
 The repository must allow GitHub Actions to write commits to master (or grant the bot the appropriate ruleset bypass). The worker only runs on trusted master after the English workflow, never on pull-request code. Bot translation commits do not trigger the English workflow again; the same translation run publishes its own results.
 
-For a local catch-up, run `bin/build-news`, `npm run port`, then `npm run site:translate` and `npm run news:translate`. The Muse CLI must be installed and authenticated. `npm run site:pending` and `npm run news:pending` report remaining queues without invoking a model. Use `npm run check:translations -- --strict-site --strict-news` after a full catch-up. The manual remains English until the separate manual workflow is implemented.
+For a local catch-up, run `bin/build-news`, `npm run port`, then `npm run site:translate` and `npm run news:translate`. The Muse CLI must be installed and authenticated. `npm run site:pending` and `npm run news:pending` report remaining queues without invoking a model. Use `npm run check:translations -- --strict-site --strict-news` after a full catch-up. Manual chapters are translated by hand, as described under Manual translations.

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -5,6 +5,7 @@ import locales from '../src/i18n/locales.json' with { type: 'json' }
 
 const json = (file) => JSON.parse(readFileSync(file, 'utf8'))
 const posts = json('src/data/news-posts.json')
+const chapters = json('src/data/manual.json')
 const sources = collectSources()
 const messages = new Set(sources.messages)
 const problems = []
@@ -92,10 +93,26 @@ if (pendingNews || pendingSite) {
   })
   process.exit(0)
 }
+// Only rendered once a locale enables its manual; other locales redirect those pages.
+const MANUAL_MESSAGES = new Set([
+  'The Manual - Omarchy',
+  'The Omarchy manual: installation, navigation, hotkeys, themes, plugins, and everything else about running the OS.',
+  'Omarchy Manual',
+  'Answers to what comes up most: keyboard layouts, the clock format, timezones, DNS and Wi-Fi, printers, and where screenshots end up.',
+  'This chapter has not been translated yet. The English original follows.',
+])
 const references = (html, attribute) =>
   [...html.matchAll(new RegExp(`${attribute}="([^"]*)"`, 'g'))]
     .map((match) => match[1])
     .sort()
+const attributeValues = (text, attribute) =>
+  [
+    ...new Set(
+      [...text.matchAll(new RegExp(`${attribute}="([^"\\s]+)"`, 'g'))].map(
+        (match) => match[1],
+      ),
+    ),
+  ].sort()
 const same = (a, b) => JSON.stringify(a) === JSON.stringify(b)
 const domains = new Set()
 for (const [code, locale] of Object.entries(locales)) {
@@ -121,7 +138,8 @@ for (const [code, locale] of Object.entries(locales)) {
   const catalogue = existsSync(catalogueFile) ? json(catalogueFile) : {}
   for (const message of messages) {
     if (typeof catalogue[message] !== 'string' || !catalogue[message].trim()) {
-      if (strictSite) problems.push(`${code}: missing message: ${message}`)
+      if (strictSite && (locale.manual || !MANUAL_MESSAGES.has(message)))
+        problems.push(`${code}: missing message: ${message}`)
     } else {
       for (const attribute of ['href', 'src']) {
         if (
@@ -187,11 +205,41 @@ for (const [code, locale] of Object.entries(locales)) {
       }
     }
   }
+  if (locale.manual) {
+    const manualFile = `src/i18n/${contentLocale}/manual.json`
+    if (!existsSync(manualFile)) problems.push(`${code}: missing ${manualFile}`)
+    const manual = existsSync(manualFile) ? json(manualFile) : {}
+    for (const chapter of chapters) {
+      const translated = manual[chapter.slug]
+      const file = `src/i18n/${contentLocale}/manual/${chapter.slug}.html`
+      if (!translated?.title || !existsSync(file))
+        problems.push(`${code}: missing chapter: ${chapter.slug}`)
+      else if (translated.sourceHash !== sourceHash(chapter))
+        problems.push(
+          `${code}: source chapter changed; review translation: ${chapter.slug}`,
+        )
+      else {
+        const html = readFileSync(file, 'utf8')
+        // Links, images and section ids must survive translation so cross-references keep working.
+        for (const attribute of ['href', 'src', 'id']) {
+          if (
+            !same(
+              attributeValues(chapter.html, attribute),
+              attributeValues(html, attribute),
+            )
+          )
+            problems.push(
+              `${code}: chapter ${attribute} references differ: ${chapter.slug}`,
+            )
+        }
+      }
+    }
+  }
 }
 if (problems.length) {
   console.error(problems.join('\n'))
   process.exit(1)
 }
 console.log(
-  `Translations checked: ${(selected.length ? selected : Object.keys(locales)).join(', ')}; ${messages.size} UI messages, ${posts.length} news articles per language.`,
+  `Translations checked: ${(selected.length ? selected : Object.keys(locales)).join(', ')}; ${messages.size} UI messages, ${posts.length} news articles, ${chapters.length} manual chapters where enabled.`,
 )

--- a/scripts/verify-locales.py
+++ b/scripts/verify-locales.py
@@ -33,6 +33,7 @@ class Page(HTMLParser):
 
 registry = json.loads(Path('src/i18n/locales.json').read_text())
 posts = json.loads(Path('src/data/news-posts.json').read_text())
+manual = json.loads(Path('src/data/manual.json').read_text())
 ported = json.loads(Path('src/data/pages.json').read_text())
 paths = ['/', '/news/', '/themes/'] + [f'/{path}/' for path in ported]
 paths += [post['path'] for post in posts]
@@ -42,7 +43,10 @@ for code in codes:
     domain = locale['domain']
     output = Path('dist/client' if code == 'en' else f'dist/{code}')
     assert (output / 'CNAME').read_text().strip() == urlsplit(domain).hostname, code
-    for path in paths:
+    pages = list(paths)
+    if locale['manual']:
+        pages += ['/manual/'] + [f"/manual/{c['slug']}/" for c in manual if c['slug'] != 'index']
+    for path in pages:
         page = Page((output / path.strip('/') / 'index.html').read_text())
         assert page.root.get('lang') == code, (code, path, 'lang')
         assert page.root.get('dir') == locale.get('direction', 'ltr'), (code, path, 'dir')
@@ -51,9 +55,14 @@ for code in codes:
         assert page.meta.get('og:url') == domain + path, (code, path, 'og:url')
         assert page.meta.get('og:locale') == locale['ogLocale'], (code, path, 'og:locale')
         for other, destination in registry.items():
+            # Manual pages only point at editions that carry a translated manual.
+            if path.startswith('/manual') and not destination['manual']:
+                continue
             assert any(link.get('hreflang') == other and link.get('href') == destination['domain'] + path for link in page.links), (code, path, 'alternate', other)
         for destination in registry.values():
             navigation = destination['domain']
+            if path.startswith('/manual') and not destination['manual']:
+                continue
             assert navigation + path in page.anchors, (code, path, 'footer language destination', navigation)
         if not locale['manual']:
             assert not any(href == '/manual' or href.startswith(('/manual/', '/manual#', '/manual?')) for href in page.anchors), (code, path, 'local manual link')
@@ -64,4 +73,4 @@ for code in codes:
     for item, post in zip(items, posts):
         assert item.findtext('link', '').rstrip('/') == (domain + post['path']).rstrip('/'), (code, 'RSS link')
         assert parsedate_to_datetime(item.findtext('pubDate')) == datetime.fromisoformat(post['date']), (code, 'RSS date')
-    print(f'{code}: {len(paths)} pages and {len(items)} RSS articles verified')
+    print(f'{code}: {len(pages)} pages and {len(items)} RSS articles verified')

--- a/src/astro/data.ts
+++ b/src/astro/data.ts
@@ -1,4 +1,4 @@
-import { translateHtml } from '../i18n/content'
+import { translateHtml, translateManualChapter } from '../i18n/content'
 import { t } from '../i18n/site'
 import manualJson from '../data/manual.json'
 import pagesJson from '../data/pages.json'
@@ -12,8 +12,9 @@ export type ManualChapter = { slug: string; title: string; html: string }
 export type { NewsPost, NewsSummary }
 export type PortedPage = { title: string; html: string }
 
+// Tolerates the line breaks Prettier puts inside translated headings.
 const HEADING_LINK =
-  /<h([23])([^>]*)>([\s\S]*?)\s*<a class="manual__heading-link"([^>]*)>#<\/a><\/h\1>/g
+  /<h([23])([^>]*)>([\s\S]*?)\s*<a\s+class="manual__heading-link"([^>]*?)\s*>#<\/a\s*>\s*<\/h\1>/g
 
 function retargetContentsLink(html: string) {
   return html.replace(/href="\/manual\/toc\/?"/g, 'href="/manual/"')
@@ -28,7 +29,13 @@ function foldHeadingLinks(html: string) {
   )
 }
 
-const chapters = manualJson as Array<ManualChapter>
+const chapters = (manualJson as Array<ManualChapter>).map(
+  translateManualChapter,
+)
+
+export function getManualChapters() {
+  return chapters
+}
 
 export function getManualToc() {
   return chapters.map(({ slug, title }) => ({ slug, title }))

--- a/src/astro/page-seo.ts
+++ b/src/astro/page-seo.ts
@@ -1,4 +1,5 @@
 import { SITE_DESCRIPTION, excerptFromHtml, seo } from '../lib/seo'
+import { t } from '../i18n/site'
 import type { NewsPost } from '../lib/news'
 import type { getManualChapter } from './data'
 
@@ -33,22 +34,28 @@ export function newsPostSeo(post: NewsPost) {
 
 export function manualIndexSeo() {
   return seo({
-    title: 'The Manual - Omarchy',
-    description:
+    title: t('The Manual - Omarchy'),
+    description: t(
       'The Omarchy manual: installation, navigation, hotkeys, themes, plugins, and everything else about running the OS.',
+    ),
     path: '/manual',
   })
 }
 
-const WRITTEN: Partial<Record<string, string>> = {
-  faq: 'Answers to what comes up most: keyboard layouts, the clock format, timezones, DNS and Wi-Fi, printers, and where screenshots end up.',
+// Literal t() calls so the translation extractor sees the authored descriptions.
+function writtenDescription(slug: string) {
+  if (slug === 'faq')
+    return t(
+      'Answers to what comes up most: keyboard layouts, the clock format, timezones, DNS and Wi-Fi, printers, and where screenshots end up.',
+    )
+  return undefined
 }
 
 export function chapterSeo(data: ChapterData, slug: string) {
   return seo({
-    title: `${data.chapter?.title ?? 'Manual'} - Omarchy Manual`,
+    title: `${data.chapter?.title ?? t('Manual')} - ${t('Omarchy Manual')}`,
     description:
-      WRITTEN[slug] ??
+      writtenDescription(slug) ??
       ((data.chapter && excerptFromHtml(data.chapter.html)) ||
         SITE_DESCRIPTION),
     path: `/manual/${slug}`,

--- a/src/astro/search-index.ts
+++ b/src/astro/search-index.ts
@@ -1,4 +1,4 @@
-import manualJson from '../data/manual.json'
+import { getManualChapters } from './data'
 import pluginsJson from '../data/plugins.json'
 import themesJson from '../data/themes.json'
 import { loadNews } from '../lib/news'
@@ -102,11 +102,7 @@ function owner(repo: string) {
 export async function buildSearchIndex(): Promise<Array<SearchEntry>> {
   const news = newsEntries(await loadNews())
   const manualPart: SearchEntry[] = []
-  for (const chapter of manualJson as Array<{
-    slug: string
-    title: string
-    html: string
-  }>) {
+  for (const chapter of getManualChapters()) {
     manualPart.push(...manualSections(chapter))
   }
   const rest: SearchEntry[] = []

--- a/src/i18n/content.ts
+++ b/src/i18n/content.ts
@@ -1,4 +1,4 @@
-import { locale, localizedHref, contentLocale } from './site'
+import { locale, localizedHref, contentLocale, t } from './site'
 import {
   currentNewsTranslation,
   type NewsTranslation,
@@ -56,12 +56,36 @@ export function translateNews(post: NewsPost): NewsPost {
   }
 }
 
+const manualMeta = import.meta.glob<Record<string, NewsTranslation>>(
+  './*/manual.json',
+  { import: 'default', eager: true },
+)
+const manualHtml = import.meta.glob<string>('./*/manual/*.html', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+})
+
+export type ManualChapter = { slug: string; title: string; html: string }
+
+/** A chapter without a current translation keeps its English source behind a language notice. */
+export function translateManualChapter(chapter: ManualChapter): ManualChapter {
+  if (contentLocale === 'en') return chapter
+  const meta = manualMeta[`./${contentLocale}/manual.json`]?.[chapter.slug]
+  const html = manualHtml[`./${contentLocale}/manual/${chapter.slug}.html`]
+  if (!currentNewsTranslation(chapter, meta, html))
+    return {
+      ...chapter,
+      html: `<p class="manual__notice"><em>${t('This chapter has not been translated yet. The English original follows.')}</em></p>\n<div lang="en" dir="ltr">${chapter.html}</div>`,
+    }
+  return { ...chapter, title: meta.title, html }
+}
+
 const blockCatalogues = import.meta.glob<Record<string, string>>(
   './*/blocks.json',
   { import: 'default', eager: true },
 )
 const blocks = blockCatalogues[`./${contentLocale}/blocks.json`] ?? {}
-import { t } from './site'
 
 /** Translate authored prose blocks without copying live donor lists or asset markup. */
 export function translateHtml(html: string): string {

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -190,7 +190,7 @@
     "domain": "https://zh.omarchy.org",
     "formatLocale": "zh-CN",
     "ogLocale": "zh_CN",
-    "manual": false,
+    "manual": true,
     "flag": "CN"
   },
   "pl": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "News": "新闻",
-  "Manual": "手册（英文）",
+  "Manual": "手册",
   "Themes": "主题",
   "Install": "安装",
   "Beautiful, fun & agentic Linux": "美观、有趣，与智能体同行的 Linux",
@@ -342,5 +342,10 @@
   "Omarchy Server 4.0": "Omarchy 服务器 4.0",
   "Plugin": "插件",
   "Rangers": "游侠",
-  "Server - Omarchy": "服务器 - Omarchy"
+  "Server - Omarchy": "服务器 - Omarchy",
+  "The Manual - Omarchy": "手册 - Omarchy",
+  "The Omarchy manual: installation, navigation, hotkeys, themes, plugins, and everything else about running the OS.": "Omarchy手册：安装、导航、快捷键、主题、插件，以及运行这个系统的其他一切。",
+  "Omarchy Manual": "Omarchy手册",
+  "Answers to what comes up most: keyboard layouts, the clock format, timezones, DNS and Wi-Fi, printers, and where screenshots end up.": "最常见的问题：键盘布局、时钟格式、时区、DNS和Wi-Fi、打印机，以及截图保存在哪里。",
+  "This chapter has not been translated yet. The English original follows.": "本章尚未翻译，下面是英文原文。"
 }

--- a/src/i18n/zh-CN/manual.json
+++ b/src/i18n/zh-CN/manual.json
@@ -1,0 +1,206 @@
+{
+  "index": {
+    "title": "欢迎使用Omarchy！",
+    "sourceHash": "b99cb9eda4b2c62310e89d4717cb4fce1b45226feab86da502930c873388ddcc"
+  },
+  "getting-started": {
+    "title": "入门指南",
+    "sourceHash": "bea3c78eb9786b8c96c89db07e9fbca8e085a6585dc92a8c0cecaac07fbface0"
+  },
+  "coming-from-mac-or-windows": {
+    "title": "迁移自Mac或Windows",
+    "sourceHash": "55ae48e6c106dfbd5e9fc8e8a0808f54b06b39d40333b9a0a3ea75bb23a16357"
+  },
+  "navigation": {
+    "title": "窗口导航",
+    "sourceHash": "af666079d7a64eed0f352ecd84411e416dfb249a64a80ff8b6fec002ff5972ea"
+  },
+  "the-top-bar": {
+    "title": "状态栏",
+    "sourceHash": "a8753919f8534020b4639a548bdb1ef6b4e28612b39db2badd69036e41a64c91"
+  },
+  "themes": {
+    "title": "主题",
+    "sourceHash": "ad725ac7a2fc583a12cd6ddac21d96fbe3dfd934916e50355a570c2aaee50528"
+  },
+  "hotkeys": {
+    "title": "快捷键",
+    "sourceHash": "f1edcc17178c328cd4806d6dfa5b7051a152bea633872d72ea9021d153069b85"
+  },
+  "unified-clipboard-history": {
+    "title": "统一剪贴板与历史记录",
+    "sourceHash": "9e3b214f149bf3dc2e62d004a6aca6af1be9440ac2c92d098ec8af570c2391a5"
+  },
+  "reminders": {
+    "title": "提醒事项",
+    "sourceHash": "53fee389707f38f771045f7c7de7d08be9c39fc2815bd2bac84c5afb216af390"
+  },
+  "notices": {
+    "title": "快捷通知",
+    "sourceHash": "cdf2a8f5aba35b717c3a6ae33884e510b33c2ab5c2bdea1139b5ac94cc9ca7f4"
+  },
+  "text-extraction-dictation": {
+    "title": "文字提取与语音听写",
+    "sourceHash": "bf7d2ae464273ce8135c33fe351572847c19ba8b7a7ebf7a2f195eff4fc6ae3a"
+  },
+  "screenshots-recording": {
+    "title": "截图与录屏",
+    "sourceHash": "b55bd5856207a1e0c96c7bd7160786736b6fb994aef56b539310338e1142014d"
+  },
+  "toggles-idle-screensaver": {
+    "title": "开关、空闲与屏保",
+    "sourceHash": "be7b04464844658903f2a089648c713473f405d1bef27227615e3816b1a87298"
+  },
+  "omarchy-cli": {
+    "title": "Omarchy命令行",
+    "sourceHash": "ced3975ba80c6f8035bec59c715f5b34bab9d15ccbea62a5381b00910c009a4e"
+  },
+  "terminal": {
+    "title": "终端",
+    "sourceHash": "49167cb5abded582beace080e901121206364ccce23093a458246be63aed52ee"
+  },
+  "neovim": {
+    "title": "Neovim",
+    "sourceHash": "d953dff5afe64bd5a0c8c556babe5f04baff76ee471cca5c86548461c915c39f"
+  },
+  "ai": {
+    "title": "AI",
+    "sourceHash": "4bcfc7244618601ec0a3ee453aa453b05d3423e5860e2bef6d55078312333ba7"
+  },
+  "development-tools": {
+    "title": "开发工具",
+    "sourceHash": "934e3b11ed513e97bd9735d56f05503f064e6563bad1f8f8c6ed93913ac1ee29"
+  },
+  "shell-tools": {
+    "title": "Shell工具",
+    "sourceHash": "35be288ac9ae2fd08fa50ee2a34327dbdb44090a874d23b78d0c86dd7d405b13"
+  },
+  "shell-functions": {
+    "title": "Shell函数",
+    "sourceHash": "1e82b21d866086b4c2de2f5871e59f22df5fd54257320f5ebde0263b4ee2ce10"
+  },
+  "tuis": {
+    "title": "终端应用（TUI）",
+    "sourceHash": "4c226afb09d8804cf784b5cdb5109636c79d2085ccb523bc3223efb156ce0068"
+  },
+  "guis": {
+    "title": "图形应用（GUI）",
+    "sourceHash": "2dbc83c21d67f67c655cda18bfbb493dc55583304bd03f9f04c4778c3bea3bb1"
+  },
+  "browsers": {
+    "title": "浏览器",
+    "sourceHash": "83661356f5aee3ad3f110351d86bff40193146acd5a40c4f20a1e42cfa5d92b2"
+  },
+  "commercial-apps-services": {
+    "title": "商业应用与服务",
+    "sourceHash": "b359fab312a5eaf8fbd0aacb24902f3e8b0cc2919e1754fd07f99fc52134c5f9"
+  },
+  "web-apps": {
+    "title": "Web应用",
+    "sourceHash": "f60c9476cb173f0dbedff63d6d4dc132f220eb11dae05130b6b843b24e9d933b"
+  },
+  "gaming": {
+    "title": "游戏",
+    "sourceHash": "2d33006c75c73f14f7a236a17fffc8e3a79af3552339e11e4e72010b0e87b1b7"
+  },
+  "filling-out-pdfs": {
+    "title": "填写PDF",
+    "sourceHash": "208e29248f38285929d9f09b656310ff60ec37b7281d78d828d8e8efd5a50ce8"
+  },
+  "windows-vm": {
+    "title": "Windows虚拟机",
+    "sourceHash": "f307f9e48094bc7b58b111ad9d260aea7ed343533af0577062db8170298c6e50"
+  },
+  "other-packages": {
+    "title": "其他软件包",
+    "sourceHash": "78c28aff9219ac4f4b16526f75ca5f46c38d8024020df1545aca27126f6181f1"
+  },
+  "updates": {
+    "title": "系统更新",
+    "sourceHash": "62f0de0949af0bb7b8484c05c6d6d4cfd6730de8b923e73ebd62b1b63c1f3241"
+  },
+  "dotfiles": {
+    "title": "配置文件（Dotfiles）",
+    "sourceHash": "101c4023caa765660ce08b7ad09cd48c3c402f38da8a5cd897f04d71a95b6f28"
+  },
+  "shell-plugins": {
+    "title": "Shell插件",
+    "sourceHash": "04741f5d4dfcc3575e458513f47a80fca0e7f17ba340a6ca3188d4cc3a853e19"
+  },
+  "monitors": {
+    "title": "显示器",
+    "sourceHash": "1996a604ac374d574740ea754b85ac16824a092ee251c6ab587dc2d7cbece7a2"
+  },
+  "keyboard-mouse-trackpad": {
+    "title": "键盘、鼠标与触控板",
+    "sourceHash": "31d452095005f26e913d160bfe27c1fdce96e58360f633ad7d76b5971f2ba987"
+  },
+  "networking": {
+    "title": "网络",
+    "sourceHash": "e135e95c22ebb0b04ba3f1786e6421b4fe69be42c8c0b5836c083df805f7f3d6"
+  },
+  "system-sleep": {
+    "title": "系统睡眠",
+    "sourceHash": "1e61930dc043ba2b891aa92ca568587171c07092866afe6070581ab827b33332"
+  },
+  "hardware-authentication": {
+    "title": "硬件认证",
+    "sourceHash": "1a81a8020e115e9b090857b85b0e34c6274566b5651ac4c6dd81d05a507e9b2c"
+  },
+  "fonts": {
+    "title": "字体",
+    "sourceHash": "aad256ca66f2f89955282ff162589ae2cac509a33b11a745a73f7ca7b59d6948"
+  },
+  "backgrounds": {
+    "title": "背景图片",
+    "sourceHash": "d144207a98a8f3af78c3bf329cb1a03e95aadb334cc014cae05f0359125568c3"
+  },
+  "prompt": {
+    "title": "命令提示符",
+    "sourceHash": "5657e6632b138985313cab9c4b807edc9527820bad0ce1c43c3feb3ada510644"
+  },
+  "branding": {
+    "title": "品牌定制",
+    "sourceHash": "b9950416f0cdaa01fcb86e53dd4d4753e57ab731d3ebabc02fd54d2c7e65105b"
+  },
+  "common-tweaks": {
+    "title": "常见调整",
+    "sourceHash": "63b4ffac0d881a704bfa8c7660a5aa9d4b366d87616f524e04cfb9b87b8699bf"
+  },
+  "making-your-own-theme": {
+    "title": "制作自己的主题",
+    "sourceHash": "c174db83caa2f98c0f5eb8d0db828456da0b044c86102142cbc114937b991472"
+  },
+  "mac-support": {
+    "title": "Mac支持",
+    "sourceHash": "284af474bd7277b9f720e7f3a40522f9b8029e550aeebc6f4c291264e483bed3"
+  },
+  "troubleshooting": {
+    "title": "故障排除",
+    "sourceHash": "c971b6281ded232d608cf23f2ace1c93e0e51fed5fba722750df4958908b99ed"
+  },
+  "faq": {
+    "title": "常见问题",
+    "sourceHash": "d818964c5750b40d0f04d84aa81b18663579a7e4a9c26dccc0960f6173ba0079"
+  },
+  "system-snapshots": {
+    "title": "系统快照",
+    "sourceHash": "a2e468b4caa528dda43387b44940cfb658acf9bade537d0aed320dea1b837816"
+  },
+  "security": {
+    "title": "安全",
+    "sourceHash": "ce9d2081843325f4c6927772733cbe66f114d87565c23d7c43997919336d76bb"
+  },
+  "omarchy-on": {
+    "title": "在其他平台运行Omarchy",
+    "sourceHash": "96e09d63b190cbd77d00bbe99e76dd86d268f891d1648d7d49cce6fe2d02e0cf"
+  },
+  "dual-boot-install": {
+    "title": "双系统安装",
+    "sourceHash": "81eaf5ab80dc36670fdaa3947a210b19eeae4237996e95c9c26d134e3a8ac122"
+  },
+  "unattended-installs": {
+    "title": "无人值守安装",
+    "sourceHash": "2b787299c8ed3ff2036783f5fe65a002da5b0e8a44bc26954438ba43383a3041"
+  }
+}

--- a/src/i18n/zh-CN/manual/ai.html
+++ b/src/i18n/zh-CN/manual/ai.html
@@ -1,0 +1,218 @@
+<p>
+  Omarchy将AI编程智能体视为一等公民，但不替你选定偏好。相反，每个主要的编程智能体CLI都预先接入，作为按需加载的启动器提供。这些启动器是<code>~/.local/bin/</code>中由<a
+    href="https://mise.jdx.dev/"
+    >mise</a
+  >管理的小型存根，在首次真正运行之前不会下载任何东西。运行其中任意一个，并按提示完成认证：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>命令</th>
+      <th>智能体</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>claude</code></td>
+      <td>
+        <a href="https://code.claude.com/docs/en/overview">Claude Code</a>
+      </td>
+    </tr>
+    <tr>
+      <td><code>codex</code></td>
+      <td><a href="https://github.com/openai/codex">OpenAI Codex</a></td>
+    </tr>
+    <tr>
+      <td><code>opencode</code></td>
+      <td><a href="https://opencode.ai/">OpenCode</a></td>
+    </tr>
+    <tr>
+      <td><code>agy</code></td>
+      <td>
+        <a href="https://github.com/google-antigravity/antigravity-cli"
+          >Google Antigravity CLI</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td><code>copilot</code></td>
+      <td>
+        <a href="https://github.com/github/copilot-cli">GitHub Copilot CLI</a>
+      </td>
+    </tr>
+    <tr>
+      <td><code>crush</code></td>
+      <td><a href="https://github.com/charmbracelet/crush">Crush</a></td>
+    </tr>
+    <tr>
+      <td><code>grok</code></td>
+      <td>xAI的Grok CLI</td>
+    </tr>
+    <tr>
+      <td><code>pi</code></td>
+      <td>
+        <a href="https://github.com/badlogic/pi-mono">Mario Zechner的Pi</a>
+      </td>
+    </tr>
+    <tr>
+      <td><code>omp</code></td>
+      <td><a href="https://github.com/can1357/oh-my-pi">Oh My Pi</a></td>
+    </tr>
+    <tr>
+      <td><code>ori</code></td>
+      <td>
+        <a href="https://openrouter.ai/docs/guides/ori/harness">Ori</a
+        >，OpenRouter的运行环境
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <code>ori</code
+  >比较特别：它让其他运行环境跑在OpenRouter的整个模型目录上。<code
+    >ori claude</code
+  >、<code>ori codex</code>或<code>ori opencode</code
+  >会用你指定的模型启动对应智能体，<code>ori code</code>则是Ori自己的智能体。
+</p>
+
+<p>
+  要以同样方式包装其他CLI，运行<code
+    >omarchy-mise-install &lt;package&gt; [command-name]</code
+  >。运行<code>omarchy update</code
+  >（或<code>mup</code>别名）时，这些存根会与mise管理的其他内容一同更新。
+</p>
+
+<h3 id="the-default-agent">
+  默认智能体<a
+    class="manual__heading-link"
+    href="#the-default-agent"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  用<code>omarchy default agent &lt;name&gt;</code>或Omarchy菜单（<code
+    >Super + Space</code
+  >）中的<em>Setup &gt; Defaults &gt; Agent</em
+  >选择默认智能体。如果尚未安装，选择时会先安装。新装的Omarchy会通过一次性通知邀请你做出选择。
+</p>
+
+<p>
+  选定后，<code>Super + Shift + Ctrl + A</code
+  >会在专用终端窗口中启动默认智能体（尚未选择时则打开选择器）。也可以直接带任务启动：<code
+    >omarchy agent prompt "Review this project"</code
+  >。这样启动的智能体以各自的免确认模式无人值守运行，所以要有心理准备——它们真的会动手！另外，由于智能体拒绝记住对家目录的信任，从<code>$HOME</code>启动会改为在<code>~/Work</code>中启动。
+</p>
+
+<p>
+  终端中也有快捷方式：<code>a</code>在当前终端内联运行默认智能体，<code>c</code>、<code>cx</code>和<code>cy</code>分别直接启动OpenCode、Claude
+  Code和Codex（同样是自动批准模式）。主题变化也会同步到智能体：切换Omarchy主题时，Claude
+  Code、Pi和OpenCode都会跟着变。
+</p>
+
+<h3 id="the-agents-panel">
+  智能体面板<a
+    class="manual__heading-link"
+    href="#the-agents-panel"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy首次在这台机器上发现AI编程用量时，状态栏会出现智能体图标（在此之前它不会现身）。图标背后的面板集中追踪每个订阅：套餐、5小时会话与每周限额的已用百分比（或预付余额），以及按天和按模型统计的token用量。Claude
+  Code、Codex和Fireworks开箱即支持。
+</p>
+
+<p>
+  左键点击状态栏图标打开面板，右键启动默认智能体。背后的用量记录每15分钟由<code
+    >omarchy agent usage-update</code
+  >重新生成，面板还能通过同步文件夹合并其他机器的用量。完整设置参见<code>$OMARCHY_PATH/shell/plugins/agents/</code>下的README。
+</p>
+
+<h3 id="crash-diagnosis">
+  崩溃诊断<a
+    class="manual__heading-link"
+    href="#crash-diagnosis"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy监视systemd-coredump以捕获进程崩溃。某个程序段错误时，你会收到“Process
+  crashed”通知——点击它，崩溃信息就会连同Omarchy的diagnose-crash技能一起交给默认智能体。该技能引导智能体从核心转储中确认事实，并判断是否值得向上游报告。也可以针对<code
+    >coredumpctl list</code
+  >中的任意PID手动运行：<code>omarchy agent crash &lt;pid&gt;</code>。
+</p>
+
+<p>
+  监视默认开启。在<em>Trigger &gt; Toggle &gt; Crash Capture</em>下（或用<code
+    >omarchy toggle crash-capture</code
+  >）关闭后，通知即停止；<code>omarchy agent crash &lt;pid&gt;</code
+  >仍可手动使用。
+</p>
+
+<p>
+  崩溃通知也可以按程序逐个静音，诊断结束时会提供这个选项。<code
+    >omarchy crash mute hyprland</code
+  >仅停止该程序的通知，<code>omarchy crash mute hyprland off</code
+  >恢复，单独运行<code>omarchy crash mute</code
+  >则列出已静音的程序。它同时接受二进制路径和名称，<code
+    >omarchy crash mute /usr/bin/hyprland</code
+  >效果相同；名称含空格时需加引号，如<code>omarchy crash mute 'Some App'</code
+  >。其他程序照常通知，被静音的程序也照常崩溃——这只是隐藏了提醒，并没有修复任何问题。
+</p>
+
+<h3 id="desktop-apps">
+  桌面应用<a
+    class="manual__heading-link"
+    href="#desktop-apps"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <em>Install &gt; AI</em
+  >菜单还提供几款图形化AI应用：ChatGPT桌面应用，以及用于与xAI模型对话的Grok
+  Bot。
+</p>
+
+<h3 id="local-llms">
+  本地大模型<a
+    class="manual__heading-link"
+    href="#local-llms"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy推荐两种运行本地大模型的方式：LM Studio和Ollama。LM
+  Studio提供图形界面，用于查找、安装和运行开放权重模型，是轻松上手的好途径；Ollama则以CLI完成类似工作。如果你是本地模型的新手，建议从LM
+  Studio开始。两者都可以在Omarchy菜单的<em>Install &gt; AI</em>下安装。
+</p>
+
+<h3 id="the-omarchy-skill">
+  Omarchy技能<a
+    class="manual__heading-link"
+    href="#the-omarchy-skill"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  智能体技能帮助AI以特定方式使用特定工具。Omarchy自带一个用于定制系统的默认技能，涵盖调整Hyprland配置、修改状态栏，乃至从零创建新主题。它被符号链接到Claude
+  Code（<code>~/.claude/skills</code>）、Codex（<code>~/.codex/skills</code>）、Pi（<code>~/.pi/agent/skills</code>）、Antigravity（<code>~/.gemini/config/skills</code>）的技能目录以及通用的<code>~/.agents/skills</code>位置，因此大多数运行环境会自动识别。
+</p>
+
+<p>
+  但请把这个技能视为实验性功能，不同模型的使用效果各异。最好先在计划模式下运行，了解智能体打算改动什么；同时做好回滚准备，万一智能体把一切搞乱，可以运行<code
+    >omarchy reinstall configs</code
+  >。
+</p>

--- a/src/i18n/zh-CN/manual/backgrounds.html
+++ b/src/i18n/zh-CN/manual/backgrounds.html
@@ -1,0 +1,13 @@
+<p>
+  每个主题都自带一组背景图片，你可以在<code>~/.config/omarchy/backgrounds/[theme]</code>中添加自己的。比如想给nord主题加一张背景，把文件放进<code>~/.config/omarchy/backgrounds/nord</code>即可。
+</p>
+
+<p>
+  最简单的做法是在Omarchy菜单中进入<em>Install &gt; Style &gt; Background</em
+  >，它会打开当前主题存放背景的文件夹。按<code>Super + Shift + F</code
+  >再开一个文件管理器，找到你的背景图片，复制过去。之后它就会出现在<code
+    >Super + Ctrl + Space</code
+  >可切换的背景列表中。
+</p>
+
+<p>https://github.com/dharmx/walls上有大量精选的漂亮背景图片。</p>

--- a/src/i18n/zh-CN/manual/branding.html
+++ b/src/i18n/zh-CN/manual/branding.html
@@ -1,0 +1,129 @@
+<p>Omarchy允许你为开机解锁、屏保和关于界面设置公司logo或个人图片。</p>
+
+<h3 id="boot-unlock">
+  开机解锁<a
+    class="manual__heading-link"
+    href="#boot-unlock"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  用<code>omarchy plymouth preview</code
+  >可以预览自定义logo和配色的效果。它接受背景色、文字颜色、logo
+  png和预览图片的保存路径：
+</p>
+
+<pre><code>omarchy plymouth preview '#1d2021' '#ebdbb2' logo.png preview.png
+</code></pre>
+
+<p>
+  然后用<code>omarchy plymouth set '#1d2021' '#ebdbb2' logo.png</code
+  >应用，SDDM登录界面也会使用同样的配色和logo。想恢复原样，用<code
+    >omarchy plymouth reset</code
+  >。
+</p>
+
+<p>
+  <img
+    src="/manual/images/branding-plymouth-shopify.webp"
+    alt="branding-plymouth-shopify"
+  />
+</p>
+
+<h3 id="screensaver">
+  屏保<a class="manual__heading-link" href="#screensaver" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在<em>Style &gt; Screensaver</em>下可以更换屏保使用的logo。它是ASCII
+  logo，所以可以直接编辑文本，也可以给它一张png或svg图片，我们会将其转换为ASCII。效果相当酷。
+</p>
+
+<p>
+  <img
+    src="/manual/images/branding-screensaver.webp"
+    alt="branding-screensaver"
+  />
+</p>
+
+<p>该菜单有三个条目：</p>
+
+<ul>
+  <li>
+    <strong>Edit Text</strong
+    >在编辑器中打开<code>~/.config/omarchy/branding/screensaver.txt</code>。想写什么就写什么——ASCII艺术、你的名字、一句粗话。保存退出后屏保立即启动，让你看看效果。
+  </li>
+  <li>
+    <strong>Set From Image</strong
+    >打开文件选择器选一张png或svg，转换为ASCII并显示结果。轮廓清晰的logo效果远胜于照片。
+  </li>
+  <li><strong>Restore Default</strong>恢复Omarchy logo。</li>
+</ul>
+
+<h3 id="about-screen">
+  关于界面<a
+    class="manual__heading-link"
+    href="#about-screen"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy菜单中<em>About</em>界面的同样三个选项位于<em>Style &gt; About</em
+  >下，用法完全相同——文件是<code>~/.config/omarchy/branding/about.txt</code>，每次修改后About窗口都会弹出。About的图案会转换成比屏保更小的尺寸，因为它要放进一个窗口，而不是铺满整块屏幕。
+</p>
+
+<p>
+  窗口打开期间，每隔几秒会有一道绿色微光斜掠过图案，然后归于静止。你自己的图案也会有这个效果，只要其中每个字符都是单列宽——<em
+    >Set From Image</em
+  >生成的图案都满足这一点。由表情或双宽字符组成的图案则保持静止，你保留了自己的fastfetch配置时也一样：这些情况下的静止logo是动画在主动避让，而非失效，因为让微光滑过它们会把行的其余部分挤到错误的位置。
+</p>
+
+<p><img src="/manual/images/branding-about.webp" alt="branding-about" /></p>
+
+<h3 id="converting-images-yourself">
+  自行转换图片<a
+    class="manual__heading-link"
+    href="#converting-images-yourself"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  两个<em>Set From Image</em>选项调用的都是<code>omarchy transcode ascii</code
+  >，想控制转换细节时可以直接运行它：
+</p>
+
+<pre><code>omarchy transcode ascii ~/logo.svg ~/.config/omarchy/branding/screensaver.txt --width 100
+</code></pre>
+
+<p>
+  它接受以终端列数和行数计的<code>--width</code>和<code>--height</code>；<code>--mode</code>可选<code>braille</code>（默认，精细得多）或<code>block</code>；<code>--threshold</code>是判定哪些像素属于logo的百分比；logo是深底浅色时用<code>--invert</code>。转换结果糊成一团时，通常该调的就是阈值。
+</p>
+
+<h3 id="words-instead-of-a-logo">
+  用文字代替logo<a
+    class="manual__heading-link"
+    href="#words-instead-of-a-logo"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>omarchy ascii</code>用Delta Corps Priest
+  1绘制文字，这正是Omarchy字标所用的FIGlet字体，因此屏保可以说一句话，而不只是展示图片：
+</p>
+
+<pre><code>omarchy ascii "Back in five" &gt; ~/.config/omarchy/branding/screensaver.txt
+</code></pre>
+
+<p>
+  它把参数作为文字，没有参数时则从管道读取。这款字体只有字母和空格——绘制时没有数字和标点——所以其他字符会被丢弃，并在stderr中列出，而不是悄悄吞掉。
+</p>

--- a/src/i18n/zh-CN/manual/browsers.html
+++ b/src/i18n/zh-CN/manual/browsers.html
@@ -1,0 +1,108 @@
+<p>
+  Omarchy以<a href="https://www.chromium.org/">Chromium</a
+  >作为默认浏览器。它是纯开源构建，主题与系统其余部分一致；<code
+    >Super + Shift + Return</code
+  >打开的就是它，每个<a href="/manual/web-apps/">Web应用</a>也都运行在其中。
+</p>
+
+<p>
+  如果Chromium不合口味，你并非别无选择。Omarchy菜单的<em
+    >Install &gt; Browser</em
+  >下有Chrome、Edge、Brave、Brave Origin、Firefox和<a
+    href="https://zen-browser.app/"
+    >Zen</a
+  >。选定后，Omarchy会安装它、配置策略目录，并应用当前主题。
+</p>
+
+<h2 id="making-one-the-default">
+  设为默认<a
+    class="manual__heading-link"
+    href="#making-one-the-default"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  安装浏览器并不会将其设为默认。安装完成后，前往<em
+    >Setup &gt; Defaults &gt; Browser</em
+  >选择——该菜单只列出已安装的浏览器，并用勾标记当前默认。
+</p>
+
+<p>终端中则是：</p>
+
+<pre><code class="language-bash">omarchy default browser firefox
+</code></pre>
+
+<p>
+  不带参数运行会显示当前默认。这会设置XDG处理程序，所以不只Omarchy的快捷键随之改变——从聊天应用到终端命令，任何打开链接的操作都会交给你选定的浏览器。
+</p>
+
+<h2 id="copy-url-and-download-video">
+  复制URL与下载视频<a
+    class="manual__heading-link"
+    href="#copy-url-and-download-video"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Chromium系浏览器（Chromium本身、Chrome、Edge和Brave）自带两个Omarchy扩展，把浏览器与系统其余部分连接起来。
+</p>
+
+<p>
+  <strong>Copy URL</strong>用<code>Alt + Shift + L</code
+  >把当前标签页的地址放到剪贴板。这比点进地址栏再复制更快，而且因为走的是系统剪贴板而非浏览器剪贴板，你会收到Omarchy的确认通知，URL也会立即出现在<a
+    href="/manual/unified-clipboard-history/"
+    >剪贴板历史</a
+  >和所有其他应用中。偏好点击的话，也有工具栏按钮。
+</p>
+
+<p>
+  <strong>Download Video</strong>用<code>Alt + Shift + D</code
+  >抓取当前页面正在播放的视频。它把URL交给<a
+    href="https://github.com/yt-dlp/yt-dlp"
+    >yt-dlp</a
+  >，因此支持的远不止YouTube，下载会存入<code>~/Videos</code>。进度显示在音量和亮度共用的屏幕提示中，原地更新而不是堆积通知。想把文件放到别处，设置<code>OMARCHY_YTDLP_DIR</code>——环境变量放在哪里参见<a
+    href="/manual/faq/"
+    >常见问题</a
+  >。
+</p>
+
+<p>
+  两个扩展都通过一个小型原生消息主机与Omarchy通信，它会随浏览器一起安装。正是这个组件让网页视频得以落入你的家目录、URL得以进入剪贴板管理器，普通扩展自身做不到这些。
+</p>
+
+<p>以上仅限Chromium系。Firefox和Zen没有这些扩展。</p>
+
+<h2 id="firefox-and-zen">
+  Firefox与Zen<a
+    class="manual__heading-link"
+    href="#firefox-and-zen"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Firefox和Zen属于另一个家族，待遇也不同：Omarchy会安装一份提供合理默认值的策略文件，并将它们切换到原生Wayland模式——分数缩放和顺滑的触控板滚动都需要它。
+</p>
+
+<p>
+  它们没有上述Chromium扩展，Omarchy也不会为它们设置主题，这部分体验需要你自行配置。
+</p>
+
+<h2 id="removing-one-again">
+  移除浏览器<a
+    class="manual__heading-link"
+    href="#removing-one-again"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在此安装的任何浏览器都可以在<em>Remove &gt; Browser</em
+  >下移除。Chromium不在列表中——它是基础系统的一部分。
+</p>

--- a/src/i18n/zh-CN/manual/coming-from-mac-or-windows.html
+++ b/src/i18n/zh-CN/manual/coming-from-mac-or-windows.html
@@ -1,0 +1,220 @@
+<p>
+  在macOS或Windows上用了多年，你的手指记住了上百个大脑早已忘记学过的动作。本章就是这两者之间的转换层：告诉你这些本能在Omarchy中对应什么。各项功能本身在其他章节有详细介绍，这里只是一张地图。
+</p>
+
+<h3 id="super-is-the-center-of-everything">
+  一切以Super为中心<a
+    class="manual__heading-link"
+    href="#super-is-the-center-of-everything"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  你围绕Cmd或Windows键建立的所有肌肉记忆，都转移到了同一个键：Super。在PC键盘上它就是Windows键，也是Omarchy几乎所有快捷键的锚点。
+</p>
+
+<p>
+  按Spotlight、Raycast或开始菜单的反射动作，变成了<code>Super + Space</code
+  >。它打开Omarchy菜单：启动应用、修改设置、安装软件、截取屏幕，几乎什么都能做。开始输入即可筛选。另有一个只列出应用的菜单，快捷键是<code
+    >Super + Alt + Space</code
+  >。参见<a href="/manual/navigation/">窗口导航</a>。
+</p>
+
+<h3 id="theres-no-dock-and-no-desktop-icons">
+  没有Dock，也没有桌面图标<a
+    class="manual__heading-link"
+    href="#theres-no-dock-and-no-desktop-icons"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  没有可点击启动程序的东西，也没有可在桌面上排列的图标。应用通过快捷键启动（<code
+    >Super + Return</code
+  >打开终端，<code>Super + Shift + Return</code>打开浏览器，<code
+    >Super + K</code
+  >列出所有已绑定的快捷键），或从菜单启动。唯一常驻的界面元素是<a
+    href="/manual/the-top-bar/"
+    >状态栏</a
+  >，它承担了以往菜单栏、系统托盘和通知中心的职责，而且上面几乎每个部件在左键、右键、中键点击时都有各自的动作。
+</p>
+
+<h3 id="windows-place-themselves">
+  窗口自动就位<a
+    class="manual__heading-link"
+    href="#windows-place-themselves"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  最大的观念转变：你不再拖动窗口，也不再把它们贴到半边屏幕。打开一个窗口，它占满整个屏幕；再打开一个，两者平分。窗口从不重叠，所以你永远不必从另一个窗口下面把它翻出来。
+</p>
+
+<p>
+  确实需要浮动窗口时，<code>Super + T</code
+  >可以把当前窗口从平铺中切出来（再切回去）。但请先给平铺一个真正的机会——它是整个系统的核心。<a
+    href="/manual/navigation/"
+    >窗口导航</a
+  >会带你熟悉它。
+</p>
+
+<p>
+  工作区会让你感到熟悉：它们就是macOS的Spaces或Windows的虚拟桌面，只不过你会真正用起来，因为<code
+    >Super + 1/2/3/4</code
+  >直接跳到对应工作区，<code>Super + Shift + 1/2/3/4</code
+  >把当前窗口发送过去。没有动画延迟，只有即时切换。如果你以前习惯多显示器，现在可能根本不需要了。
+</p>
+
+<h3 id="copy-and-paste-just-work">
+  复制粘贴开箱即用<a
+    class="manual__heading-link"
+    href="#copy-and-paste-just-work"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在Mac上，你到处使用Cmd + C；在Windows上，到处使用Ctrl +
+  C——除了终端，在那里它会终止程序。Omarchy提供<code>Super + C</code>、<code
+    >Super + X</code
+  >和<code>Super + V</code
+  >，它们在任何地方都有效，包括终端。不必为shell单独学一套反射。
+</p>
+
+<p>
+  Windows用户：你的Win + V剪贴板历史对应<code>Super + Ctrl + V</code
+  >，而且图片和文本都保存。参见<a href="/manual/unified-clipboard-history/"
+    >统一剪贴板与历史记录</a
+  >。
+</p>
+
+<h3 id="the-translation-table">
+  对照表<a
+    class="manual__heading-link"
+    href="#the-translation-table"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>你习惯的</th>
+      <th>在Omarchy中</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Spotlight / Raycast /开始菜单</td>
+      <td><code>Super + Space</code>，即Omarchy菜单</td>
+    </tr>
+    <tr>
+      <td>AirDrop</td>
+      <td>
+        LocalSend，通过<code>Super + Ctrl + S</code>，参见<a
+          href="/manual/guis/"
+          >图形应用</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>Cmd + Shift + 4 / Win + Shift + S</td>
+      <td>
+        <code>Print Screen</code>，参见<a href="/manual/screenshots-recording/"
+          >截图与录屏</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>通知中心</td>
+      <td>通知历史，快捷键<code>Super + Shift + Alt + ,</code></td>
+    </tr>
+    <tr>
+      <td>Time Machine（针对系统）</td>
+      <td>每次更新自动创建<a href="/manual/system-snapshots/">系统快照</a></td>
+    </tr>
+    <tr>
+      <td>App Store /下载安装程序</td>
+      <td>
+        菜单中的<em>Install</em>，或<code>omarchy pkg add</code>，参见<a
+          href="/manual/other-packages/"
+          >其他软件包</a
+        >
+      </td>
+    </tr>
+    <tr>
+      <td>系统设置/控制面板</td>
+      <td>
+        菜单中的<em>Setup</em>，编辑的是纯文本配置文件，参见<a
+          href="/manual/dotfiles/"
+          >配置文件</a
+        >
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="some-things-really-are-different">
+  有些地方确实不同<a
+    class="manual__heading-link"
+    href="#some-things-really-are-different"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  许多设置存放在你编辑的文本文件里，而不是逐层点击的面板中。这听起来原始，直到你意识到：每一处调整都看得见、能复制到下一台机器、能纳入版本控制。<em>Setup</em>菜单会直接带你进入对应文件，编辑完成后自动重启需要重启的进程。
+</p>
+
+<p>
+  更新只有一条命令——<em>Update &gt; Omarchy</em
+  >——它会更新Omarchy本身和系统中的每个软件包，并先创建快照。没有各个应用随时冒出来的更新提示。参见<a
+    href="/manual/updates/"
+    >系统更新</a
+  >。
+</p>
+
+<p>软件来自包管理器，而不是下载的安装程序。</p>
+
+<p>
+  而且关闭窗口时，应用就真的退出了。没有macOS那种程序没有窗口却仍在运行的中间状态。<code
+    >Super + W</code
+  >——或者<code>Super + Q</code>，如果这是你带来的手指记忆——意味着彻底关闭。
+</p>
+
+<h3 id="on-mac-hardware">
+  在Mac硬件上<a
+    class="manual__heading-link"
+    href="#on-mac-hardware"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy在Intel Mac上运行良好，参见<a href="/manual/mac-support/">Mac支持</a
+  >。键盘也对你很友好：Omarchy不重映射任何按键，Linux把Command键视为Super，所以Super就在Cmd一直所在的位置。你的拇指察觉不到变化。
+</p>
+
+<h3 id="give-it-two-weeks">
+  给它两周时间<a
+    class="manual__heading-link"
+    href="#give-it-two-weeks"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  本能的迁移比你想的更快。把<a href="/manual/hotkeys/">快捷键</a
+  >一章快速浏览一遍，想不起某个绑定时就按<code>Super + K</code
+  >，它会列出全部快捷键。这是你唯一真正需要记住的一个。
+</p>

--- a/src/i18n/zh-CN/manual/commercial-apps-services.html
+++ b/src/i18n/zh-CN/manual/commercial-apps-services.html
@@ -1,0 +1,120 @@
+<p>
+  Omarchy主要致力于提供免费的开源软件，但并不教条。有时最好的方案就是商业产品，这没什么问题。以下是我们提供便捷安装的一些选项。
+</p>
+
+<h2 id="1password">
+  1Password<a
+    class="manual__heading-link"
+    href="#1password"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  把密码交给密码管理器是最佳实践，团队协作时更是如此。<a
+    href="https://1password.com/"
+    >1password</a
+  >是一款出色的方案，还附带命令行工具，可在脚本中集成密钥查询。
+</p>
+
+<p>
+  用<code>Super + Shift + /</code
+  >启动1Password。尚未安装时，这个快捷键会先启动安装（也可使用Omarchy菜单的<em
+    >Install &gt; Service &gt; 1Password</em
+  >）。安装程序还会为Chromium配置1Password扩展。
+</p>
+
+<h2 id="bitwarden">
+  Bitwarden<a
+    class="manual__heading-link"
+    href="#bitwarden"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://bitwarden.com/">Bitwarden</a
+  >是密码管理器领域的开源替代品，免费版足以覆盖大多数个人需求。通过Omarchy菜单的<em
+    >Install &gt; Service &gt; Bitwarden</em
+  >安装，Bitwarden命令行工具也会一并安装。
+</p>
+
+<h2 id="spotify">
+  Spotify<a class="manual__heading-link" href="#spotify" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://spotify.com/">Spotify</a
+  >是全球最流行的流媒体音乐服务，Linux应用提供了你期待的一切，包括离线播放。
+</p>
+
+<p>
+  用<code>Super + Shift + M</code
+  >启动Spotify。与1Password一样，尚未安装时快捷键会先启动安装（也可使用Omarchy菜单的<em
+    >Install &gt; Service &gt; Spotify</em
+  >）。
+</p>
+
+<h2 id="dropbox">
+  Dropbox<a class="manual__heading-link" href="#dropbox" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://www.dropbox.com/">Dropbox</a
+  >可以在多台机器间同步文件，同时在云端保留备份。在Omarchy菜单中选择<em
+    >Install &gt; Service &gt; Dropbox</em
+  >进行安装。运行后，将鼠标悬停在状态栏右上角的托盘上，右键点击Dropbox图标完成设置。
+</p>
+
+<h2 id="tailscale">
+  Tailscale<a
+    class="manual__heading-link"
+    href="#tailscale"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://tailscale.com/">Tailscale</a
+  >是一款网状VPN，让你通过互联网安全访问所有电脑和服务器变得极为简单。在Omarchy菜单中选择<em
+    >Install &gt; Service &gt; Tailscale</em
+  >进行安装。
+</p>
+
+<p>
+  它会在状态栏中获得一个面板、一个管理控制台Web应用，以及在你的机器之间传送文件的Taildrop——参见<a
+    href="/manual/networking/"
+    >网络</a
+  >。
+</p>
+
+<h2 id="once">
+  ONCE<a class="manual__heading-link" href="#once" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://once.com/">ONCE</a
+  >是37signals推出的一次性购买、自行托管的软件产品线，例如Campfire聊天系统。在Omarchy菜单中选择<em
+    >Install &gt; Service &gt; ONCE</em
+  >进行安装，这会启用其后台服务，并把你带入ONCE终端界面继续操作。
+</p>
+
+<h2 id="nordvpn">
+  NordVPN<a class="manual__heading-link" href="#nordvpn" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://nordvpn.com/">NordVPN</a
+  >是一款标准的VPN服务，可让流量从全球大多数地区出口。在Omarchy菜单中选择<em
+    >Install &gt; Service &gt; NordVPN</em
+  >进行安装。按提示重启后，运行<code>nordvpn login</code>完成认证。
+</p>

--- a/src/i18n/zh-CN/manual/common-tweaks.html
+++ b/src/i18n/zh-CN/manual/common-tweaks.html
@@ -1,0 +1,68 @@
+<p>
+  这里收集了一些对Omarchy的常见调整。请注意，系统更新偶尔需要把某些配置恢复为原始状态。发生这种情况时，你的修改不会丢失，而是存入同一目录下的<code>.bak</code>文件。
+</p>
+
+<p>
+  要是改坏了什么，可以通过Omarchy菜单的<em>Update &gt; Config</em
+  >把单个配置恢复为原始设置。要是<em>真的</em>全搞砸了，可以用<code>omarchy-reinstall</code>重置所有配置。
+</p>
+
+<h3 id="reveal-all-tray-icons-all-the-time">
+  始终显示所有托盘图标<a
+    class="manual__heading-link"
+    href="#reveal-all-tray-icons-all-the-time"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  默认情况下，Dropbox、1password、Steam之类的托盘图标藏在托盘展开箭头后面，鼠标悬停时才显示。想让它们一直可见，右键点击展开箭头打开托盘图标管理器，然后固定想保持可见的图标（也可以把永远不想看到的隐藏掉）。
+</p>
+
+<h3 id="rounded-window-corners">
+  圆角窗口<a
+    class="manual__heading-link"
+    href="#rounded-window-corners"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy的默认设计是直角，想柔和一点的话，可以修改<code>~/.config/hypr/looknfeel.lua</code>，把圆角设置的注释去掉：
+</p>
+
+<pre><code>hl.config({
+  decoration = {
+    -- Use round window corners.
+    rounding = 8,
+  },
+})
+</code></pre>
+
+<h3 id="remove-window-gaps">
+  去掉窗口间隙<a
+    class="manual__heading-link"
+    href="#remove-window-gaps"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在笔记本屏幕上，有些人不想把任何像素浪费在窗口间隙上（甚至连状态栏也不要，可以用<code
+    >Super + Shift + Space</code
+  >关掉）。用<code>Super + Shift + Backspace</code
+  >可以临时关闭所有间隙和边框；要永久去掉，把<code>~/.config/hypr/looknfeel.lua</code>中这一段的注释去掉：
+</p>
+
+<pre><code>hl.config({
+  general = {
+    -- No gaps between windows or borders.
+    gaps_in = 0,
+    gaps_out = 0,
+    border_size = 0,
+  },
+})
+</code></pre>

--- a/src/i18n/zh-CN/manual/development-tools.html
+++ b/src/i18n/zh-CN/manual/development-tools.html
@@ -1,0 +1,117 @@
+<h2 id="alternative-editors">
+  其他编辑器<a
+    class="manual__heading-link"
+    href="#alternative-editors"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Omarchy默认内置<a href="https://neovim.io/">Neovim</a
+  >，但如果你想要更主流、更熟悉的编辑器，可以打开Omarchy菜单（<code
+    >Super + Space</code
+  >），查看<em>Install &gt; Editor</em>下的选项：VSCode、Cursor、Zed、Sublime
+  Text、Helix、Vim和Emacs都在其中。没找到想要的，可以去<em
+    >Install &gt; Package</em
+  >看看是否有对应的Arch软件包（若没有，再试试<em>Install &gt; AUR</em
+  >查一下AUR）。
+</p>
+
+<p>
+  <code>VSCode</code
+  >、<code>Cursor</code>、<code>VSCodium</code>和<code>Helix</code>支持主题同步。
+</p>
+
+<p>全系统默认编辑器在<code>Setup &gt; Defaults &gt; Editor</code>下设置。</p>
+
+<h2 id="environment">
+  开发环境<a
+    class="manual__heading-link"
+    href="#environment"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  通过Omarchy菜单（<code>Super + Space</code>）的<em
+    >Install &gt; Development</em
+  >，可以配置大量开发环境。<em>Ruby on Rails</em
+  >自然在列，还有JavaScript的三大运行时（Node.js、Bun、Deno），以及Laravel、Symfony等流行的PHP框架。此外还有Go、Rust、Python、Java、Elixir（含Phoenix）、.NET、OCaml、Zig、Clojure和Scala。选择非常丰富！
+</p>
+
+<p>
+  这些环境大多由<a href="https://mise.jdx.dev/">Mise</a
+  >管理。它可以在同一台机器上安装并运行同一编程语言的多个版本，类似Ruby的rbenv或rvm、Python的virtualenv，但适用于许多不同的环境。
+</p>
+
+<p>
+  比如要安装Ruby，运行<code>mise use -g ruby</code
+  >，它会安装Ruby并设为全局默认。如果项目中有
+  .ruby-version文件，在项目根目录运行<code>mise i</code>即可。
+</p>
+
+<h2 id="docker">
+  Docker<a class="manual__heading-link" href="#docker" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://www.docker.com/">Docker</a
+  >无需多作介绍。它用于运行隔离的容器，Omarchy安装了运行它所需的一切，包括Docker本身和<a
+    href="https://docs.docker.com/compose/"
+    >Docker Compose</a
+  >。
+</p>
+
+<p>
+  默认情况下，你的用户<em>不在</em>
+  <code>docker</code
+  >组中。该组实际上等同于免密码的root——组内任何程序都可以通过<code
+    >docker run -v /:/host</code
+  >接管整台机器，否则一个以你身份运行的恶意脚本或依赖，离root就只差一条命令。因此命令行中需要用<code>sudo</code>运行Docker（<code
+    >sudo docker ps</code
+  >、<code>sudo docker compose up</code>），而与守护进程通信的图形工具——<code
+    >Super + Shift + D</code
+  >上的Docker
+  TUI和Windows虚拟机——会在需要时请求授权。如果你理解其中取舍，仍想要回免组的便利，可以在<strong
+    >Setup &gt; Security &gt; Sudoless Docker</strong
+  >中启用（或运行<code>omarchy-setup-security-sudoless-docker</code>），它会在警告后把你加入<code>docker</code>组；此后<code>docker</code>和<code>d</code>别名无需<code>sudo</code>即可使用。
+</p>
+
+<p>
+  别忘了试试Lazydocker，用<code>Super + Shift + D</code
+  >在一个漂亮的TUI中管理容器；除非启用了免sudo的Docker，否则它首次运行会请求授权。
+</p>
+
+<p>
+  通过Omarchy菜单的<em>Install &gt; Development &gt; Docker DB</em
+  >，可以在Docker中配置本地开发常用的数据库。
+</p>
+
+<h2 id="github-cli">
+  GitHub CLI<a
+    class="manual__heading-link"
+    href="#github-cli"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://cli.github.com/">GitHub CLI</a
+  >可以用GitHub账户认证并克隆私有仓库。它是按需加载的mise存根之一，首次运行<code>gh</code>时会自行安装。运行<code
+    >gh auth login</code
+  >完成认证，然后就可以用<code>gh repo clone org/repo</code>检出私有仓库。
+</p>
+
+<p>这个命令还能完成许多其他GitHub操作，运行<code>gh</code>即可查看全部功能。</p>
+
+<p>
+  另有一个按需安装的<code>ghui</code>存根，用于在TUI中管理拉取请求。如果也想在TUI中操作git本身，<a
+    href="https://github.com/jesseduffield/lazygit"
+    >lazygit</a
+  >已经预装。
+</p>

--- a/src/i18n/zh-CN/manual/dotfiles.html
+++ b/src/i18n/zh-CN/manual/dotfiles.html
@@ -1,0 +1,229 @@
+<p>
+  Omarchy主要通过存放在<code>~/.config</code>中的所谓dotfiles进行配置。这些文件属于你，供你修改；而<code>/usr/share/omarchy</code>中的文件属于Omarchy本身，不应去动。如果需要更改<code>/usr/share/omarchy</code>中的任何内容，应改为在<code>~/.config</code>中覆盖对应的值。
+</p>
+
+<p>
+  关键配置可以直接从Omarchy菜单（<code>Super + Space</code>）编辑，如<em
+    >Setup &gt; Monitors</em
+  >、<em>Setup &gt; Keybindings</em>、<em>Setup &gt; Input</em>和<em
+    >Setup &gt; Config &gt; [file]</em
+  >。通过这种方式编辑，退出编辑器后需要重启的进程会自动重启（默认编辑器是Neovim——记得<code>:wq</code>！也可以在<em
+    >Setup &gt; Defaults &gt; Editor</em
+  >中更换）。
+</p>
+
+<p>以下是<code>~/.config</code>中的关键文件及各自的作用：</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>文件</th>
+      <th>作用</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>~/.config/hypr/hyprland.lua</code></td>
+      <td>
+        Hyprland主配置。加载Omarchy默认值和下列覆盖文件。<a
+          href="https://wiki.hypr.land/Configuring/"
+          >了解更多Hyprland配置</a
+        >。
+      </td>
+    </tr>
+    <tr>
+      <td><code>~/.config/hypr/bindings.lua</code></td>
+      <td>你自己的键绑定，以及对默认绑定的覆盖。</td>
+    </tr>
+    <tr>
+      <td><code>~/.config/hypr/monitors.lua</code></td>
+      <td>控制显示器、分辨率和位置。</td>
+    </tr>
+    <tr>
+      <td><code>~/.config/hypr/input.lua</code></td>
+      <td>控制键盘布局、鼠标和触控板设置。</td>
+    </tr>
+    <tr>
+      <td><code>~/.config/hypr/looknfeel.lua</code></td>
+      <td>控制间隙、边框、动画等外观。</td>
+    </tr>
+    <tr>
+      <td><code>~/.config/hypr/autostart.lua</code></td>
+      <td>控制随会话启动的额外进程。</td>
+    </tr>
+    <tr>
+      <td><code>~/.config/omarchy/shell.json</code></td>
+      <td>
+        控制Omarchy shell：状态栏位置、布局和部件，以及屏保、锁定和空闲计时。
+      </td>
+    </tr>
+    <tr>
+      <td><code>~/.config/foot/foot.ini</code></td>
+      <td>控制终端（默认为foot）。</td>
+    </tr>
+    <tr>
+      <td><code>~/.XCompose</code></td>
+      <td>
+        定义快速表情和姓名/邮箱自动补全。修改后请运行<code>omarchy-restart-xcompose</code>。
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  如果为了打磨自己的配置做了大量修改，最好把这些dotfiles备份起来。<a
+    href="https://www.youtube.com/watch?v=NoFiYOqnC4o"
+    >Stow是个不错的办法</a
+  >。
+</p>
+
+<h3 id="starting-your-own-apps-with-the-session">
+  随会话启动自己的应用<a
+    class="manual__heading-link"
+    href="#starting-your-own-apps-with-the-session"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  希望某个程序在每次登录时运行——同步守护进程、聊天应用、你自己的脚本——就把它加到<code>~/.config/hypr/autostart.lua</code>：
+</p>
+
+<pre><code class="language-lua">o.launch_on_start("my-service")
+</code></pre>
+
+<p>该命令会作为会话的一部分启动，退出登录时也会被正确清理。</p>
+
+<h3 id="running-scripts-on-system-events">
+  在系统事件上运行脚本<a
+    class="manual__heading-link"
+    href="#running-scripts-on-system-events"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy会在几个时刻触发钩子，你可以把自己的脚本挂上去。它们位于<code>~/.config/omarchy/hooks/&lt;event&gt;.d/</code>，每个事件一个目录，事件发生时其中的每个可执行文件都会运行：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>事件</th>
+      <th>触发时机</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>post-boot</code></td>
+      <td>桌面启动后立即触发</td>
+    </tr>
+    <tr>
+      <td><code>post-update</code></td>
+      <td><code>omarchy update</code>期间，软件包与迁移完成之后</td>
+    </tr>
+    <tr>
+      <td><code>pre-refresh-pacman</code></td>
+      <td><code>omarchy refresh pacman</code>重新同步软件包配置之前</td>
+    </tr>
+    <tr>
+      <td><code>theme-set</code></td>
+      <td>更换主题之后（主题名在<code>$1</code>）</td>
+    </tr>
+    <tr>
+      <td><code>font-set</code></td>
+      <td>更换字体之后（字体名在<code>$1</code>）</td>
+    </tr>
+    <tr>
+      <td><code>battery-low</code></td>
+      <td>电池电量不足时（百分比在<code>$1</code>）</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  每个目录中都已有一个<code>.sample</code>文件展示钩子的写法，去掉文件名中的<code>.sample</code>即可启用。要安装写在别处的脚本，运行<code
+    >omarchy hook install post-boot ~/my-hook</code
+  >，它会复制进去并设为可执行。
+</p>
+
+<h3 id="adding-your-own-menu-entries">
+  添加自己的菜单项<a
+    class="manual__heading-link"
+    href="#adding-your-own-menu-entries"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  编辑<code>~/.config/omarchy/extensions/omarchy-menu.jsonc</code>，可以为Omarchy菜单（<code
+    >Super + Space</code
+  >）添加自己的条目。条目以点分id为键，id决定其在菜单树中的位置：<code>personal</code>出现在根菜单，<code>personal.notes</code>出现在它之下：
+</p>
+
+<pre><code class="language-jsonc">"personal": {"icon":"","label":"Personal"},
+"personal.notes": {"icon":"󰎞","label":"Notes","action":"omarchy-launch-editor ~/notes"},
+</code></pre>
+
+<p>重用已有的id会覆盖该条目而非新增。文件中以注释形式记录了所有可用字段。</p>
+
+<h3 id="adding-your-own-shell-exports-functions-and-aliases">
+  添加自己的shell导出、函数和别名<a
+    class="manual__heading-link"
+    href="#adding-your-own-shell-exports-functions-and-aliases"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy内置了一批顺手的别名和实用函数，但想添加自己的东西很常见。别名、函数和导出都应写在<code>~/.bashrc</code>中，该文件在更新时不会被覆盖。想更改Omarchy的任何默认值，也可以放心地写在这里。
+</p>
+
+<h3 id="changing-internal-omarchy-files">
+  修改Omarchy内部文件<a
+    class="manual__heading-link"
+    href="#changing-internal-omarchy-files"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  当然，这是你的电脑，想怎么改都可以，但我不建议直接修改<code>/usr/share/omarchy</code>中的文件。它们属于Omarchy的pacman软件包，下次更新时你的修改会被直接覆盖。更好的做法是在<code>~/.config/*</code>中覆盖你不喜欢的默认值。
+</p>
+
+<p>
+  几乎一切都能这样修改，包括默认键绑定。比如编辑<code>~/.config/hypr/bindings.lua</code>，把<a
+    href="https://obsidian.md/"
+    >Obsidian</a
+  >换成<a href="https://joplinapp.org/">Joplin</a>（用<code
+    >omarchy-pkg-add joplin-bin</code
+  >安装）：
+</p>
+
+<pre><code>hl.unbind("SUPER + SHIFT + O")
+o.bind("SUPER + SHIFT + O", "Joplin", "joplin-desktop")
+</code></pre>
+
+<p>
+  如果坚持要修改Omarchy内部文件，通过<em>Update &gt; Channel &gt; Dev</em
+  >切换到dev通道。它把Omarchy链接到<code>~/omarchy</code>中源代码的git检出，你可以随心所欲地修改。这里没人管你！
+</p>
+
+<h3 id="resetting-any-changes">
+  重置所有修改<a
+    class="manual__heading-link"
+    href="#resetting-any-changes"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  如果把配置改乱了，随时可以通过Omarchy菜单的<em>Update &gt; Config</em
+  >恢复默认，或运行<code>omarchy reinstall configs</code>重置一切。
+</p>

--- a/src/i18n/zh-CN/manual/dual-boot-install.html
+++ b/src/i18n/zh-CN/manual/dual-boot-install.html
@@ -1,0 +1,91 @@
+<p>Omarchy可以安装到单个分区，与Windows或其他系统共存。</p>
+
+<p>
+  这种安装方式默认同样对分区启用LUKS加密，所以实际上与全盘安装没有区别，只需要磁盘上有可用的空闲空间。
+</p>
+
+<h2 id="making-space-on-windows">
+  在Windows上腾出空间<a
+    class="manual__heading-link"
+    href="#making-space-on-windows"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  要与Windows共存安装，在开始菜单中输入<code>disk management</code>，选择<strong
+    >Create and format hard disk partitions</strong
+  >。
+</p>
+
+<p><img src="/manual/images/dual-boot-1.webp" alt="dual-boot-1" /></p>
+
+<p>找到对应的分区，右键选择<strong>Shrink Volume</strong>。</p>
+
+<p><img src="/manual/images/dual-boot-2.webp" alt="dual-boot-2" /></p>
+
+<p>输入要压缩的容量。注意，这将是未来Omarchy安装（含启动分区）的大小。</p>
+
+<p><img src="/manual/images/dual-boot-3.webp" alt="dual-boot-3" /></p>
+
+<p>完成后应该会看到类似下图的结果，本例中50GB的区域就是Omarchy的安装位置。</p>
+
+<p><img src="/manual/images/dual-boot-4.webp" alt="dual-boot-4" /></p>
+
+<h2 id="installing-omarchy">
+  安装Omarchy<a
+    class="manual__heading-link"
+    href="#installing-omarchy"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Omarchy的安装过程与平常基本相同。选择磁盘后会出现<strong
+    >Free space install</strong
+  >选项，选择它以避免抹掉整块磁盘。
+</p>
+
+<p><img src="/manual/images/dual-boot-5.webp" alt="dual-boot-5" /></p>
+
+<p>
+  确认一切无误后，像平常一样等待安装完成。和全盘安装一样，这里也可以选择不加密安装（不推荐）。
+  <img src="/manual/images/dual-boot-6.webp" alt="dual-boot-6" />
+</p>
+
+<h2 id="adding-other-installs-to-the-bootloader">
+  把其他系统加入启动加载器<a
+    class="manual__heading-link"
+    href="#adding-other-installs-to-the-bootloader"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Omarchy安装完成后，你会发现Limine启动加载器已成为默认。借此也可以把Windows等其他系统作为选项加入Limine。
+</p>
+
+<p>
+  运行<code>limine-scan</code>，按提示把想要的条目加入limine配置。之后启动时，除了Omarchy的常规选项，还会看到Windows
+  Boot Manager或其他系统。
+</p>
+
+<h2 id="bitlocker">
+  Bitlocker<a
+    class="manual__heading-link"
+    href="#bitlocker"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  需要注意，这种安装方式与Bitlocker不兼容，因为它加密的是整块驱动器而非单个分区。如果遇到提示Bitlocker已启用的错误，启动进Windows，前往<strong
+    >Settings -&gt; Privacy &amp; Security -&gt; Device encryption</strong
+  >关闭Bitlocker。解密驱动器可能需要一些时间。
+</p>
+
+<p><img src="/manual/images/dual-boot-7.webp" alt="dual-boot-7" /></p>

--- a/src/i18n/zh-CN/manual/faq.html
+++ b/src/i18n/zh-CN/manual/faq.html
@@ -1,0 +1,198 @@
+<h3 id="how-do-i-switch-between-keyboard-layouts">
+  如何切换键盘布局？<a
+    class="manual__heading-link"
+    href="#how-do-i-switch-between-keyboard-layouts"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  编辑<code>~/.config/hypr/input.lua</code>，加入下面的内容，即可用<code
+    >Left Alt + Right Alt</code
+  >在布局之间切换：
+</p>
+
+<pre><code>hl.config({
+  input = {
+    -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
+    kb_layout = "us,fr",
+    kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+  },
+})
+</code></pre>
+
+<p>配置了多个布局后，状态栏会自动显示当前键盘布局（点击它也能切换）。</p>
+
+<h3 id="how-do-i-change-the-clock-format-to-12-hour">
+  如何把时钟改为12小时制？<a
+    class="manual__heading-link"
+    href="#how-do-i-change-the-clock-format-to-12-hour"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  右键点击状态栏中的时钟，可在常用格式（包括12小时制）之间循环切换。也可以直接设置格式：
+</p>
+
+<pre><code>omarchy bar set omarchy.clock format "dddd h:mm AP"
+</code></pre>
+
+<p>这会显示为Sunday 10:55 AM。</p>
+
+<h3 id="how-do-i-change-my-timezone">
+  如何修改时区？<a
+    class="manual__heading-link"
+    href="#how-do-i-change-my-timezone"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在Omarchy菜单中运行<em>Update &gt; Timezone</em
+  >，从列表中选择。如果时区正确但时钟本身走偏了，<em>Update &gt; Time</em
+  >会重新启动时间同步。
+</p>
+
+<h3 id="how-do-i-change-my-dns-share-my-wi-fi-or-check-my-connection-speed">
+  如何修改DNS、分享Wi-Fi或测试网速？<a
+    class="manual__heading-link"
+    href="#how-do-i-change-my-dns-share-my-wi-fi-or-check-my-connection-speed"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>这些都在<a href="/manual/networking/">网络</a>一章。</p>
+
+<h3 id="how-do-i-check-how-fast-my-disk-is">
+  如何测试磁盘速度？<a
+    class="manual__heading-link"
+    href="#how-do-i-check-how-fast-my-disk-is"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <em>Trigger &gt; Speed Test &gt; Disk Speed Test</em
+  >会实时测量驱动器的读写速度，终端中则是<code>omarchy disk speedtest</code>。
+</p>
+
+<h3 id="why-cant-i-sign-into-my-google-account-in-chromium">
+  为什么无法在Chromium中登录Google账户？<a
+    class="manual__heading-link"
+    href="#why-cant-i-sign-into-my-google-account-in-chromium"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  纯开源的Chromium构建不附带Google登录所需的OAuth凭据。在Omarchy菜单中运行<em
+    >Install &gt; Service &gt; Chromium Account</em
+  >添加它们，重启浏览器后即可登录。
+</p>
+
+<h3 id="how-do-i-add-a-printer">
+  如何添加打印机？<a
+    class="manual__heading-link"
+    href="#how-do-i-add-a-printer"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  打印功能开箱即用，每台打印机由你自己在应用启动器（<code>Super + Space</code
+  >）的<em>Print Settings</em>中添加。
+</p>
+
+<p>
+  选择<em>Add</em>，稍等片刻让它搜索：通过USB连接的打印机和大多数网络打印机都会被自动找到。如果你的不在列表中，选择<em
+    >Network Printer &gt; Internet Printing Protocol (ipp)</em
+  >并输入地址——打印机自己的屏幕或网页会告诉你地址，通常类似<code>192.168.1.50</code>，队列为<code>ipp/print</code>。接着<em>Forward</em>会提供驱动，新款打印机用免驱动的<em
+    >IPP Everywhere</em
+  >配置效果最好，老机型则需要对应型号的驱动。
+</p>
+
+<p>
+  右键点击打印机，选择<em>Set as Default</em
+  >决定应用优先使用哪一台，选择<em>Properties</em>设置纸张大小、双面和质量。
+</p>
+
+<p>
+  自动发现——网络上的打印机无需添加自动出现——在重做期间暂时关闭，所以上面的第一步需要你手动完成。打印到PDF文件不需要任何打印机。
+</p>
+
+<h3 id="how-do-i-change-where-screenshots-or-screenrecordings-are-saved">
+  如何修改截图或录屏的保存位置？<a
+    class="manual__heading-link"
+    href="#how-do-i-change-where-screenshots-or-screenrecordings-are-saved"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  想把截图保存到<code>~/Pictures/Screenshots</code>而不是<code>~/Pictures</code>，可以把下面这行加到<code>~/.config/uwsm/env.d/</code>下的某个文件中（如<code>~/.config/uwsm/env.d/capture</code>）：
+</p>
+
+<pre><code>export OMARCHY_SCREENSHOT_DIR="$HOME/Pictures/Screenshots"
+</code></pre>
+
+<p>录屏同理，使用<code>OMARCHY_SCREENRECORD_DIR</code>。</p>
+
+<p>记得先创建目标目录，并重启Omarchy使其生效。</p>
+
+<h3 id="how-do-i-get-the-speakers--webcam-working-on-my-apple-studio-display">
+  如何让Apple Studio Display的扬声器和摄像头工作？<a
+    class="manual__heading-link"
+    href="#how-do-i-get-the-speakers--webcam-working-on-my-apple-studio-display"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  你可能以为插上USB-C就万事大吉，可惜并非如此。我找到的可靠办法是使用<a
+    href="https://www.amazon.com/WJESOG-DisplayPort-Adapter-Converter-Thunderbolt/dp/B0BNX7MS6N/"
+    >WJESOG DisplayPort + USB-A转USB-C线</a
+  >，之后扬声器和摄像头都能正常工作。
+</p>
+
+<p>
+  记住，Omarchy内置了Apple显示器（Studio和XDR）的亮度控制，用常规的键盘亮度键即可。
+</p>
+
+<h3 id="how-do-i-get-rid-of-all-the-extra-software">
+  如何清掉所有额外的软件？<a
+    class="manual__heading-link"
+    href="#how-do-i-get-rid-of-all-the-extra-software"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>不想要Obsidian、LibreOffice或其他预装软件的话，移除起来很容易。</p>
+
+<p>
+  运行<em>Remove &gt; Package</em
+  >查看所有已安装的软件包，用Tab选中想移除的，再按回车开始移除选中的全部。
+</p>
+
+<p>
+  在Omarchy菜单中用<em>Remove &gt; Web App</em>可以移除不需要的预装Web应用。
+</p>
+
+<p>
+  也可以运行<em>Remove &gt; Preinstalls</em
+  >，一次清掉所有预装的额外内容——Web应用、TUI和可选应用。启动它们的快捷键也会随之消失，留给你一套干净的键绑定，在<code>~/.config/hypr/bindings.lua</code>中填上自己的。
+</p>
+
+<hr />
+
+<p>报错和故障请参见<a href="/manual/troubleshooting/">故障排除</a>。</p>

--- a/src/i18n/zh-CN/manual/filling-out-pdfs.html
+++ b/src/i18n/zh-CN/manual/filling-out-pdfs.html
@@ -1,0 +1,18 @@
+<p>
+  Omarchy内置了一款不错的基础PDF阅读器Document
+  Viewer。双击任何PDF，打开的就是它。
+</p>
+
+<p>
+  但Document
+  Viewer只能填写已设置为表单的PDF。如果需要填写未设置为表单的PDF，或需要签署PDF，请右键点击文件，选择<em
+    >Open With…</em
+  >，然后选择Xournal++。
+</p>
+
+<p>
+  Xournal++
+  允许用T工具在PDF的任意位置书写。需要签署文档时，准备一张签名图片，用Image工具插入并调整大小即可。
+</p>
+
+<p>填写完成后，用<em>File &gt; Export as PDF</em>保存最终版本。</p>

--- a/src/i18n/zh-CN/manual/fonts.html
+++ b/src/i18n/zh-CN/manual/fonts.html
@@ -1,0 +1,21 @@
+<p>Omarchy默认以JetBrainsMono Nerd Font作为终端字体和系统字体。</p>
+
+<p>
+  <img
+    src="/manual/images/fonts-jetbrainsmono.webp"
+    alt="fonts-jetbrainsmono"
+  />
+</p>
+
+<p>
+  通过Omarchy菜单（<code>Super + Space</code>）的<em>Style &gt; Font</em
+  >可以更换。它会设置所有地方的等宽字体：终端、状态栏，以及其他任何需要它的地方。
+</p>
+
+<p>
+  通过Omarchy菜单的<em>Install &gt; Style &gt; Font</em
+  >可以安装其他流行的编程字体：Cascadia Mono、Meslo LG Mono、Fira Code、Victor
+  Code、Bitstream Vera Mono和Iosevka都一键可装，而且是Nerd
+  Font版本，状态栏和终端中的图标字形照常可用。安装后在<em>Style &gt; Font</em
+  >下选择即可。
+</p>

--- a/src/i18n/zh-CN/manual/gaming.html
+++ b/src/i18n/zh-CN/manual/gaming.html
@@ -1,0 +1,237 @@
+<p>
+  Omarchy不只为了<em>效率</em>，也为了乐趣，还有什么比游戏更有趣？Omarchy内置了一整套游戏方案：Steam和RetroArch用于原生与复古游戏，Battle.net、Lutris和Heroic用于非Steam商店，Moonlight用于PC串流，Xbox
+  Cloud Gaming和NVIDIA GeForce NOW用于云游戏，还有长盛不衰的Minecraft。
+</p>
+
+<p>
+  多亏Valve在<a href="https://en.wikipedia.org/wiki/Proton_(software)"
+    >proton兼容层</a
+  >上的出色工作，如今Linux上已有数万款可玩的现代游戏。对了，你知道<a
+    href="https://store.steampowered.com/steamdeck/"
+    >Steam Deck</a
+  >运行的正是Arch吗！
+</p>
+
+<p>
+  所有游戏安装项都位于Omarchy菜单（<code>Super + Space</code>）的<em
+    >Install &gt; Gaming</em
+  >下。想撤销某项安装，使用<em>Remove &gt; Gaming</em>。
+</p>
+
+<h2 id="steam">
+  Steam<a class="manual__heading-link" href="#steam" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Steam</em
+  >安装<a href="https://store.steampowered.com/">Steam</a>。
+</p>
+
+<p>安装后即可通过<code>Super + Space</code>启动Steam。</p>
+
+<p>注意Steam启动可能需要10到20秒，期间不会有任何加载提示。</p>
+
+<p><img src="/manual/images/gaming-steam.webp" alt="gaming-steam" /></p>
+
+<h2 id="retroarch">
+  RetroArch<a
+    class="manual__heading-link"
+    href="#retroarch"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; RetroArch</em
+  >安装<a href="https://www.retroarch.com/">RetroArch</a
+  >。它附带完整的libretro核心，覆盖所有经典平台。
+</p>
+
+<p>RetroArch已预先配置好精美的CRT Royale着色器，呈现完美的复古效果。</p>
+
+<p>开始使用：</p>
+
+<ol>
+  <li>
+    把BIOS文件放入<code>~/Games/bios</code>，ROM放入<code>~/Games/roms</code>。
+  </li>
+  <li>按<code>Super + Space</code>并输入<code>retro</code>启动RetroArch。</li>
+  <li>扫描<code>~/Games/roms</code>目录，就可以开玩了。</li>
+</ol>
+
+<p>
+  通过<em>Install &gt; Gaming &gt; RetroArch Game Launcher</em
+  >，还可以为心爱的游戏在应用启动器中单独建一个条目：选好核心和ROM，之后从<code
+    >Super + Space</code
+  >直接进入游戏。
+</p>
+
+<p><img src="/manual/images/gaming-retroarch.webp" alt="gaming-retroarch" /></p>
+
+<h2 id="xbox-cloud-gaming">
+  Xbox Cloud Gaming<a
+    class="manual__heading-link"
+    href="#xbox-cloud-gaming"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Xbox Cloud Gaming</em
+  >安装Xbox Cloud Gaming
+  Web应用。它“只是”该服务的Web应用，但启动迅速，1080p下运行流畅。
+</p>
+
+<p>
+  如果你已有Xbox Game
+  Pass，这是畅玩Fortnite等无法在Linux上原生运行的游戏的可靠方式。
+</p>
+
+<p>
+  <img src="/manual/images/gaming-xbox-cloud.webp" alt="gaming-xbox-cloud" />
+</p>
+
+<h2 id="nvidia-geforce-now">
+  NVIDIA GeForce Now<a
+    class="manual__heading-link"
+    href="#nvidia-geforce-now"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; NVIDIA GeForce NOW</em
+  >安装云游戏服务<a href="https://www.nvidia.com/en-us/geforce-now/"
+    >NVIDIA GeForce NOW</a
+  >。这是游玩Linux上没有原生版本的游戏的另一个好办法。
+</p>
+
+<p>
+  <img src="/manual/images/gaming-geforce-now.webp" alt="gaming-geforce-now" />
+</p>
+
+<h2 id="minecraft">
+  Minecraft<a
+    class="manual__heading-link"
+    href="#minecraft"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Minecraft</em
+  >安装Minecraft。
+</p>
+
+<p>
+  与Steam一样，登录或启动后可能要等一会儿下一个界面才会出现，等待期间没有任何提示。
+</p>
+
+<p><img src="/manual/images/gaming-minecraft.webp" alt="gaming-minecraft" /></p>
+
+<h2 id="xbox-controllers">
+  Xbox手柄<a
+    class="manual__heading-link"
+    href="#xbox-controllers"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Xbox Controllers</em
+  >安装蓝牙Xbox手柄支持。通过蓝牙（<code>Super + Ctrl + B</code
+  >）配对后，手柄就能在所有游戏中使用。如果只用USB-C线连接手柄，则不需要这一步。
+</p>
+
+<h2 id="moonlight-game-streaming-from-a-pc">
+  Moonlight（从PC串流游戏）<a
+    class="manual__heading-link"
+    href="#moonlight-game-streaming-from-a-pc"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/moonlight-stream/moonlight-qt">Moonlight客户端</a
+  >随Omarchy预装，可以立即从运行<a href="https://app.lizardbyte.dev/Sunshine/"
+    >Sunshine</a
+  >的Windows PC串流游戏。通过<code>Super + Space</code>启动Moonlight。
+</p>
+
+<p>
+  如果Omarchy机器与远程游戏PC都是有线连接，体验与本地游玩别无二致。把分辨率调到原生，刷新率设为120Hz，码率拉满——这是在Linux上玩Fortnite等竞技射击游戏的最佳方式。
+</p>
+
+<p>
+  也可以运行<code>omarchy install service sunshine</code
+  >把Omarchy机器变成串流主机，它会安装Sunshine，并为局域网和Tailscale开放Moonlight串流端口。
+</p>
+
+<h2 id="battlenet">
+  Battle.net<a
+    class="manual__heading-link"
+    href="#battlenet"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Battle.net</em
+  >安装<a href="https://eu.shop.battle.net/en-us">Battle.net</a
+  >。这样就能以独立安装的方式在GE-Proton下运行Diablo、Starcraft和World of
+  Warcraft等游戏，无需Steam、Lutris或Heroic。
+</p>
+
+<p><img src="/manual/images/gaming-starcraft.webp" alt="gaming-starcraft" /></p>
+
+<h2 id="lutris-windows-games">
+  Lutris（Windows游戏）<a
+    class="manual__heading-link"
+    href="#lutris-windows-games"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Lutris</em
+  >安装<a href="https://lutris.net/">Lutris</a>。EA、Ubisoft
+  Connect等商店的Windows游戏在上面没有专门的安装项，Lutris就是游玩它们的途径。
+</p>
+
+<p>安装过程有些粗糙，有时看起来毫无动静——耐心等待，它正在后台工作。</p>
+
+<h2 id="heroic-launcher-epic-games">
+  Heroic Launcher（Epic Games）<a
+    class="manual__heading-link"
+    href="#heroic-launcher-epic-games"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  在Omarchy菜单（<code>Super + Space</code>）中选择<em
+    >Install &gt; Gaming &gt; Heroic (Epic Games)</em
+  >安装<a href="https://heroicgameslauncher.com/">Heroic Launcher</a
+  >。Heroic可运行不依赖反作弊的Epic Games游戏（如OddSparks），以及GOG和Amazon
+  Prime Gaming的游戏。遗憾的是，这意味着没有Fortnite，也没有Rocket League——在Tim
+  Sweeney拥抱Linux之前，这已是最接近的方案。
+</p>
+
+<p>与Lutris一样，安装游戏时可能感觉又慢又粗糙。给它一点时间。</p>

--- a/src/i18n/zh-CN/manual/getting-started.html
+++ b/src/i18n/zh-CN/manual/getting-started.html
@@ -1,0 +1,116 @@
+<p>
+  Omarchy通过ISO安装。你可以选择全盘安装，占用整个硬盘；也可以选择空闲空间安装，把Omarchy装进硬盘上未分配的空间——这就是与Windows或其他系统双启动的方式（参见<a
+    href="/manual/dual-boot-install/"
+    >双系统安装</a
+  >，注意需要先在Windows中关闭BitLocker）。无论哪种方式，安装默认启用全盘加密，而全盘安装会清空所选硬盘，所以在已有硬盘上安装前务必先备份！
+</p>
+
+<p>
+  先<a href="/">下载Omarchy ISO</a>，写入U盘（Mac/Windows上使用<a
+    href="https://etcher.balena.io/"
+    >balenaEtcher</a
+  >，Linux上使用<a href="https://github.com/ifd3f/caligula">caligula</a
+  >），然后从U盘启动。
+</p>
+
+<p>
+  <em
+    >必须在BIOS中关闭Secure
+    Boot和/或TPM，否则无法安装Omarchy。它们是微软为Windows及微软系Linux发行版设计的安全机制。</em
+  >
+</p>
+
+<p>接着回答配置问题，并像这样确认：</p>
+
+<p><img src="/manual/images/install-config.webp" alt="install-config" /></p>
+
+<p>
+  然后选择安装目标硬盘，坐下来看安装过程跑完。在最快的现代机器上不到一分钟即可完成，即使是较老的电脑也不应超过5分钟。
+</p>
+
+<p><img src="/manual/images/install-done.webp" alt="install-done" /></p>
+
+<p>现在，可以开始使用Omarchy了！</p>
+
+<h3 id="use-a-wired-or-24ghz-keyboard">
+  请使用有线或2.4GHz键盘！<a
+    class="manual__heading-link"
+    href="#use-a-wired-or-24ghz-keyboard"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  全盘加密无法在开机时通过蓝牙键盘输入密码，就像PC上无法用蓝牙键盘进入BIOS一样。你需要一把通过2.4GHz接收器或线缆连接的键盘（后者延迟本来也低得多！）。我个人很喜欢<a
+    href="https://www.lofree.co/products/lofree-flow-the-smoothest-mechanical-keyboard"
+    >Lofree Flow84</a
+  >！
+</p>
+
+<h3 id="installing-for-another-owner">
+  为他人安装<a
+    class="manual__heading-link"
+    href="#installing-for-another-owner"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  如果你是替别人配置机器——家人、新同事、买家——就不该代他们回答个人信息问题。在安装程序的第一个界面（键盘选择）按下<code
+    >Ctrl + C</code
+  >，Omarchy会转而为另一位使用者准备这台机器：系统立即安装，但键盘布局、用户名、密码等个人设置推迟到机器首次启动时进行。硬盘仍默认加密，新使用者在首次启动时设置的密码也将成为加密密码。（已经在用的机器同样可以不重装就交给他人，参见<a
+    href="/manual/security/"
+    >重置电脑</a
+  >。）
+</p>
+
+<h3 id="unattended-installs">
+  无人值守安装<a
+    class="manual__heading-link"
+    href="#unattended-installs"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  只要把配置放在第二块驱动器上，ISO也能完全自动安装：不需要键盘，不需要向导。这是把Omarchy用作虚拟机和批量机器基础镜像的方法，参见<a
+    href="/manual/unattended-installs/"
+    >无人值守安装</a
+  >。
+</p>
+
+<h3 id="no-encryption-installations">
+  不加密安装<a
+    class="manual__heading-link"
+    href="#no-encryption-installations"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy默认加密安装。对任何可能丢失或被盗的电脑来说，这都是安全、负责的选择——你不会希望接触到你硬件的人拿到你的数据！
+</p>
+
+<p>
+  但在特殊情况下，比如在受保护的电脑上远程安装，或没有敏感数据的一次性安装，你可能希望不加密。在磁盘格式化确认界面按下<code
+    >Ctrl + C</code
+  >，即可切换为不加密安装。
+</p>
+
+<h3 id="help-if-youre-stuck">
+  遇到问题？<a
+    class="manual__heading-link"
+    href="#help-if-youre-stuck"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  如果卡住了，通常可以在<a href="/discord/">社区Discord</a
+  >的<em>#omarchy-help</em>频道找到愿意帮忙的人。
+</p>

--- a/src/i18n/zh-CN/manual/guis.html
+++ b/src/i18n/zh-CN/manual/guis.html
@@ -1,0 +1,238 @@
+<h2 id="files">
+  Files<a class="manual__heading-link" href="#files" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  Files（Nautilus）是图形文件管理器。<code>Super + Shift + F</code>打开它，<code
+    >Super + Shift + Alt + F</code
+  >则在终端当前所在目录打开，能省不少点击。<code>Ctrl + L</code
+  >可输入路径，在任意文件上按<code>Space</code>即可快速预览而无需打开。
+</p>
+
+<p>
+  插入U盘或SD卡会自动挂载，直接出现在侧边栏中。更复杂的操作——格式化驱动器、检查SMART健康状态、创建分区——请从应用启动器（<code
+    >Super + Space</code
+  >）启动<em>Disks</em>。
+</p>
+
+<p>
+  双击遵循合理的默认关联：图片用imv打开，视频用mpv，PDF用Document
+  Viewer，纯文本用Neovim。
+</p>
+
+<h2 id="obsidian">
+  Obsidian<a class="manual__heading-link" href="#obsidian" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://obsidian.md/">Obsidian</a
+  >是一款免费、高度可扩展的笔记应用，以普通Markdown文件存储。
+</p>
+
+<p>Obsidian对个人、商业和非营利等所有用途免费。</p>
+
+<p>
+  Obsidian还提供<a href="https://obsidian.md/sync">商业同步附加服务</a
+  >，用于与iOS和Android移动应用同步。（https://obsidian.md/pricing）
+</p>
+
+<p>
+  用<code>Super + Shift + O</code
+  >启动Obsidian。要使用主题同步，需在设置中选择<code>Omarchy</code>主题。
+</p>
+
+<h2 id="omawrite">
+  Omawrite<a class="manual__heading-link" href="#omawrite" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/omacom-io/omawrite">Omawrite</a
+  >是Omarchy自家的极简Markdown写作应用。没有库，没有插件，只有你和文字。
+</p>
+
+<p>用<code>Super + Shift + W</code>启动Omawrite。</p>
+
+<h2 id="pinta">
+  Pinta<a class="manual__heading-link" href="#pinta" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://www.pinta-project.com/">Pinta</a
+  >是一款基础的图片编辑工具，适合裁剪、缩放等简单处理。别指望它替代Photoshop，但它也有魔棒和图层！
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Pinta。</p>
+
+<h2 id="aether">
+  Aether<a class="manual__heading-link" href="#aether" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/bjarneo/aether">Aether</a
+  >是一款主题应用，能从背景图片提取颜色并生成完整、协调的主题，是<a
+    href="/manual/making-your-own-theme/"
+    >制作自己的主题</a
+  >最简单的方式。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Aether。</p>
+
+<h2 id="localsend">
+  LocalSend<a
+    class="manual__heading-link"
+    href="#localsend"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://localsend.org/">LocalSend</a
+  >可向同一网络中运行该应用的其他设备发送文件，类似Apple的AirDrop，但它是跨平台的：Windows、macOS、Android、iOS，当然还有Linux，都能互传。
+</p>
+
+<p>
+  用<code>Super + Ctrl + S</code>或Omarchy菜单的<em>Trigger &gt; Share</em
+  >打开分享菜单，其中有四个选项：
+</p>
+
+<ul>
+  <li>
+    <strong>Clipboard</strong
+    >将复制的内容作为文本文件发送。把链接或片段传到手机上，再也不用给自己发邮件。
+  </li>
+  <li><strong>File</strong>打开文件选择器，可一次选择多个。</li>
+  <li><strong>Folder</strong>发送整个目录。</li>
+  <li><strong>Receive</strong>打开完整的LocalSend，让其他设备向你发送内容。</li>
+</ul>
+
+<p>
+  终端中同样可用：<code>omarchy share clipboard</code>、<code
+    >omarchy share file [path]</code
+  >和<code>omarchy share folder [path]</code>。省略路径则会打开选择器。
+</p>
+
+<p>
+  也可以直接从文件管理器发送：在Nautilus中右键任意选中项，选择<em
+    >Send via LocalSend</em
+  >。
+</p>
+
+<p>
+  Omarchy的防火墙默认关闭，仅开放LocalSend的端口，所以新装系统上开箱即可使用。参见<a
+    href="/manual/security/"
+    >安全</a
+  >。
+</p>
+
+<h2 id="libreoffice">
+  LibreOffice<a
+    class="manual__heading-link"
+    href="#libreoffice"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://www.libreoffice.org/">LibreOffice</a
+  >是一套完整的办公软件，包含文字处理、电子表格、演示、绘图等应用。它兼容Microsoft
+  Office文件，打开Word文档很方便。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动LibreOffice。</p>
+
+<h2 id="omacalc">
+  Omacalc<a class="manual__heading-link" href="#omacalc" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/omacom-io/omacalc">Omacalc</a
+  >是Omarchy自家的极简计算器，以浮动窗口打开。
+</p>
+
+<p>
+  用<code>Super + Ctrl + Q</code>（或键盘上的计算器键，如果有的话）启动Omacalc。
+</p>
+
+<h2 id="signal">
+  Signal<a class="manual__heading-link" href="#signal" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://signal.org/">Signal</a
+  >是端到端加密通讯的先驱，对于不想依赖科技巨头的人来说，是极好的通讯选择。
+</p>
+
+<p>
+  用<code>Super + Shift + G</code
+  >启动Signal。它不在基础安装中，首次按下快捷键时，Omarchy会提议为你安装（也可在Omarchy菜单的<em
+    >Install &gt; Service</em
+  >下安装）。
+</p>
+
+<h2 id="mpv">
+  mpv<a class="manual__heading-link" href="#mpv" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://mpv.io/">mpv</a
+  >是一款简洁、快速的媒体播放器，几乎能播放任何来源的任何内容，看视频很合适。
+</p>
+
+<p>
+  通过应用启动器（<code>Super + Space</code
+  >）启动mpv，或直接在文件管理器中双击视频。
+</p>
+
+<h2 id="obs-studio">
+  OBS Studio<a
+    class="manual__heading-link"
+    href="#obs-studio"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://obsproject.com/">OBS Studio</a
+  >可从多路输入录制或直播视频，把屏幕录制、摄像头和麦克风混合在一起。Omarchy的演示视频就是用它录制的。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动OBS Studio。</p>
+
+<h2 id="kdenlive">
+  Kdenlive<a class="manual__heading-link" href="#kdenlive" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://kdenlive.org/">Kdenlive</a
+  >是一款出色的视频编辑器，非常适合在分享前处理OBS Studio录制的视频。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Kdenlive。</p>
+
+<h2 id="omacut">
+  Omacut<a class="manual__heading-link" href="#omacut" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/omacom-io/omacut">Omacut</a
+  >是Omarchy自家的极简视频剪辑器。只需裁掉片段首尾时，它比打开完整的视频编辑器方便得多。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Omacut。</p>

--- a/src/i18n/zh-CN/manual/hardware-authentication.html
+++ b/src/i18n/zh-CN/manual/hardware-authentication.html
@@ -1,0 +1,49 @@
+<h3 id="fingerprint-authentication">
+  指纹认证<a
+    class="manual__heading-link"
+    href="#fingerprint-authentication"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  许多笔记本配有用于认证的指纹传感器。在Omarchy菜单（<code>Super + Space</code
+  >）中运行<em>Setup &gt; Security &gt; Fingerprint</em>即可使用。
+</p>
+
+<p>
+  它会安装指纹软件包、采集并验证你的指纹，之后就可以用指纹解锁锁屏（<code
+    >Super + Ctrl + L</code
+  >触发）、进入sudo模式，以及授权系统提示。
+</p>
+
+<p>
+  笔记本盖子合上时会自动跳过指纹提示，直接进入密码提示，而不是等待一个够不着的传感器。如果需要在没有传感器的外接键盘上工作，<code>sudo</code>提示输入指纹时按<code
+    >CTRL + C</code
+  >即可。
+</p>
+
+<p>
+  在Omarchy菜单的<em>Remove &gt; Security &gt; Fingerprint</em
+  >下可以移除指纹认证。
+</p>
+
+<h3 id="fido2-authentication">
+  Fido2认证<a
+    class="manual__heading-link"
+    href="#fido2-authentication"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  使用Fido2设备的话，可以通过Omarchy菜单（<code>Super + Space</code>）的<em
+    >Setup &gt; Security &gt; Fido2</em
+  >将其设置为<code>sudo</code>认证方式。它覆盖<code>sudo</code>和系统授权提示，但不包括解锁电脑。
+</p>
+
+<p>
+  在Omarchy菜单的<em>Remove &gt; Security &gt; Fido2</em>下可以移除fido2认证。
+</p>

--- a/src/i18n/zh-CN/manual/hotkeys.html
+++ b/src/i18n/zh-CN/manual/hotkeys.html
@@ -1,0 +1,1431 @@
+<p>
+  用<code>Super + K</code>可以查看所有主要键盘绑定（Tmux绑定用<code
+    >Super + Alt + K</code
+  >，Herdr绑定用<code>Super + Ctrl + K</code>）。
+</p>
+
+<h2 id="navigating">
+  窗口导航<a
+    class="manual__heading-link"
+    href="#navigating"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Space</code></td>
+      <td>Omarchy菜单（应用及其他一切）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Space</code></td>
+      <td>应用菜单</td>
+    </tr>
+    <tr>
+      <td><code>Super + Escape</code></td>
+      <td>系统菜单（挂起、重启等）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + L</code></td>
+      <td>锁定电脑</td>
+    </tr>
+    <tr>
+      <td><code>Super + W</code>或<code>Super + Q</code></td>
+      <td>关闭窗口</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Del</code></td>
+      <td>关闭所有窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + T</code></td>
+      <td>切换窗口平铺/浮动</td>
+    </tr>
+    <tr>
+      <td><code>Super + J</code></td>
+      <td>切换窗口排列方向（水平/垂直）</td>
+    </tr>
+    <tr>
+      <td><code>Super + O</code></td>
+      <td>将窗口弹出为固定浮动窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + L</code></td>
+      <td>在dwindle与滚动布局之间切换</td>
+    </tr>
+    <tr>
+      <td><code>Super + P</code></td>
+      <td>切换伪平铺窗口样式（自然/拉伸）</td>
+    </tr>
+    <tr>
+      <td><code>Super + F</code></td>
+      <td>全屏</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + F</code></td>
+      <td>占满宽度</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + F</code></td>
+      <td>窗口内全屏</td>
+    </tr>
+    <tr>
+      <td><code>Super + 1/2/3/4</code></td>
+      <td>跳转到指定工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Tab</code></td>
+      <td>跳转到下一个工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Tab</code></td>
+      <td>跳转到上一个工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Tab</code></td>
+      <td>跳转到之前所在的工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + 1/2/3/4</code></td>
+      <td>将窗口移到工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + 1/2/3/4</code></td>
+      <td>将窗口移到工作区但不跟随</td>
+    </tr>
+    <tr>
+      <td><code>Super + S</code> / <code>Super + Grave</code></td>
+      <td>切换便签工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + S</code> / <code>Super + Shift + Grave</code></td>
+      <td>将窗口移到便签工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + Arrows</code></td>
+      <td>将工作区移到对应方向的显示器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Arrow</code></td>
+      <td>将焦点移到方向键所指的窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Arrow</code></td>
+      <td>与方向键所指的窗口交换位置</td>
+    </tr>
+    <tr>
+      <td><code>Super + Minus</code></td>
+      <td>向左扩展窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Equal</code></td>
+      <td>向左收缩窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Minus</code></td>
+      <td>向上收缩窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Equal</code></td>
+      <td>向下扩展窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Minus/Equal</code></td>
+      <td>同样的缩放，步长更小</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Minus/Equal</code></td>
+      <td>同样的缩放，步长更大</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Home</code></td>
+      <td>保存窗口宽度</td>
+    </tr>
+    <tr>
+      <td><code>Super + Home</code></td>
+      <td>恢复已保存的窗口宽度</td>
+    </tr>
+    <tr>
+      <td><code>Super + Left Mouse</code></td>
+      <td>拖动窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Right Mouse</code></td>
+      <td>调整窗口大小</td>
+    </tr>
+    <tr>
+      <td><code>Super + Scroll Wheel</code></td>
+      <td>滚动切换工作区</td>
+    </tr>
+    <tr>
+      <td><code>Super + G</code></td>
+      <td>切换窗口分组</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + G</code></td>
+      <td>将窗口移出分组</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Tab</code></td>
+      <td>在分组内的窗口间循环</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Shift + Tab</code></td>
+      <td>在分组内的窗口间反向循环</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + 1/2/3/4/5</code></td>
+      <td>跳转到分组内的指定窗口</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Arrow</code></td>
+      <td>将窗口移入方向键所指的分组</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Left/Right</code></td>
+      <td>在平铺分组内的窗口间移动</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Z</code></td>
+      <td>放大屏幕（重复按可继续放大）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + Z</code></td>
+      <td>完全缩小屏幕</td>
+    </tr>
+    <tr>
+      <td><code>Super + /</code></td>
+      <td>向前切换显示器缩放档位</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + /</code></td>
+      <td>向后切换显示器缩放档位</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Tab</code></td>
+      <td>在当前工作区的窗口间向前循环</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + Tab</code></td>
+      <td>在当前工作区的窗口间向后循环</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Tab</code></td>
+      <td>在显示器间向前切换焦点</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Shift + Tab</code></td>
+      <td>在显示器间向后切换焦点</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="system-controls">
+  系统控制<a
+    class="manual__heading-link"
+    href="#system-controls"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + A</code></td>
+      <td>音频面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + B</code></td>
+      <td>蓝牙面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + W</code></td>
+      <td>Wi-Fi/网络面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + D</code></td>
+      <td>显示面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + P</code></td>
+      <td>电源面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + D</code></td>
+      <td>日历面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + 1-9</code></td>
+      <td>按位置切换状态栏面板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + S</code></td>
+      <td>分享菜单（通过LocalSend）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + T</code></td>
+      <td>活动监视器（btop）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + C</code></td>
+      <td>捕获控制（截图/录屏/取色）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + O</code></td>
+      <td>开关菜单</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + H</code></td>
+      <td>硬件菜单</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Q</code></td>
+      <td>计算器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + E</code></td>
+      <td>表情选择器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + .</code></td>
+      <td>媒体转码</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Ctrl + A</code></td>
+      <td>选择AI智能体</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="adjustments">
+  调节<a class="manual__heading-link" href="#adjustments" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Shift + Brightness Up</code></td>
+      <td>屏幕最大亮度</td>
+    </tr>
+    <tr>
+      <td><code>Shift + Brightness Down</code></td>
+      <td>屏幕最小亮度</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Brightness Up/Down</code></td>
+      <td>以1% 为步长精确调节亮度</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Volume Up/Down</code></td>
+      <td>以1% 为步长精确调节音量</td>
+    </tr>
+    <tr>
+      <td><code>Keyboard Brightness Up/Down</code></td>
+      <td>键盘背光调亮/调暗</td>
+    </tr>
+    <tr>
+      <td><code>Keyboard Backlight</code></td>
+      <td>循环切换键盘背光档位</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Play</code></td>
+      <td>下一曲</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + Play</code></td>
+      <td>上一曲</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="launching-apps">
+  启动应用<a
+    class="manual__heading-link"
+    href="#launching-apps"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Return</code></td>
+      <td>终端</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + Return</code></td>
+      <td>Tmux终端</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Return</code></td>
+      <td>Herdr（智能体管理器）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Return</code></td>
+      <td>浏览器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + B</code></td>
+      <td>浏览器（隐私/无痕模式）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + F</code></td>
+      <td>文件管理器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + F</code></td>
+      <td>在终端当前目录打开文件管理器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + M</code></td>
+      <td>音乐（Spotify）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + M</code></td>
+      <td>音乐（cliamp）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + /</code></td>
+      <td>密码管理器（1password）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + N</code></td>
+      <td>编辑器（Neovim）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + C</code></td>
+      <td>日历（<a href="https://hey.com/">HEY</a>）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + E</code></td>
+      <td>邮件（<a href="https://hey.com/">HEY</a>）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + E</code></td>
+      <td>新邮件（<a href="https://hey.com/">HEY</a>）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + A</code></td>
+      <td>AI（ChatGPT）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + A</code></td>
+      <td>AI（Grok）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + G</code></td>
+      <td>即时通讯（Signal）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + P</code></td>
+      <td>Google Photos</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + S</code></td>
+      <td>Google Maps</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + G</code></td>
+      <td>即时通讯（WhatsApp）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Ctrl + G</code></td>
+      <td>即时通讯（Google）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + D</code></td>
+      <td>Docker（LazyDocker）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + O</code></td>
+      <td>Obsidian</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + W</code></td>
+      <td>写作（Omawrite）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + X</code></td>
+      <td>X</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + X</code></td>
+      <td>在X上发帖</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Y</code></td>
+      <td>YouTube</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>在<code>~/.config/hypr/bindings.lua</code>中修改或添加绑定。</p>
+
+<h2 id="universal-clipboard">
+  统一剪贴板<a
+    class="manual__heading-link"
+    href="#universal-clipboard"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + C</code></td>
+      <td>复制</td>
+    </tr>
+    <tr>
+      <td><code>Super + X</code></td>
+      <td>剪切（终端内不可用）</td>
+    </tr>
+    <tr>
+      <td><code>Super + V</code></td>
+      <td>粘贴</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + V</code></td>
+      <td>剪贴板管理器</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  在Linux上，通常终端内要用<code>Ctrl + Shift + C/V</code
+  >复制粘贴，其他地方则用<code>Ctrl + C/V</code
+  >。Omarchy的统一剪贴板快捷键在任何地方都有效。
+</p>
+
+<h2 id="capture">
+  捕获<a class="manual__heading-link" href="#capture" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + C</code></td>
+      <td>捕获菜单（适用于没有PrintScr键的键盘）</td>
+    </tr>
+    <tr>
+      <td><code>Print Screen</code></td>
+      <td>截图</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Print Screen</code></td>
+      <td>录屏</td>
+    </tr>
+    <tr>
+      <td><code>Super + Print Screen</code></td>
+      <td>取色器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Print Screen</code></td>
+      <td>提取文字到剪贴板</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + [</code></td>
+      <td>录屏时缩小摄像头画面</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + ]</code></td>
+      <td>录屏时放大摄像头画面</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + L</code></td>
+      <td>从Web应用或Chromium复制当前URL</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + D</code></td>
+      <td>将当前页面的视频下载到<code>~/Videos</code></td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + X</code></td>
+      <td>开始/停止语音听写（需要<em>Install &gt; AI &gt; Dictation</em>）</td>
+    </tr>
+    <tr>
+      <td><code>F9</code></td>
+      <td>按住说话式听写（需要<em>Install &gt; AI &gt; Dictation</em>）</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  录屏时，快捷键会先询问要录制哪路音频，然后开始录制；再按一次即停止。详情参见<a
+    href="/manual/screenshots-recording/"
+    >截图与录屏</a
+  >。
+</p>
+
+<p>
+  所有捕获功能也都可以在Omarchy菜单（<code>Super + Space</code>）的<em
+    >Trigger &gt; Capture</em
+  >下找到。
+</p>
+
+<h2 id="notifications">
+  通知<a
+    class="manual__heading-link"
+    href="#notifications"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + ,</code></td>
+      <td>关闭最新通知</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + ,</code></td>
+      <td>关闭所有通知</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + ,</code></td>
+      <td>切换通知静音</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + ,</code></td>
+      <td>调出最近一条通知</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Alt + ,</code></td>
+      <td>打开通知历史</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="style">
+  样式<a class="manual__heading-link" href="#style" aria-label="本节链接">#</a>
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + Shift + Space</code></td>
+      <td>选择新主题</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Space</code></td>
+      <td>选择主题背景</td>
+    </tr>
+    <tr>
+      <td><code>Super + Backspace</code></td>
+      <td>切换窗口透明度</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Backspace</code></td>
+      <td>切换单窗口方形比例</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  额外的背景图片存放在<code
+    >~/.config/omarchy/backgrounds/&lt;theme name&gt;</code
+  >，也可通过Omarchy菜单的<em>Install &gt; Style &gt; Background</em>添加。
+</p>
+
+<p>
+  所有样式选项也都可以在Omarchy菜单（<code>Super + Space</code
+  >）的<em>Style</em>下找到。
+</p>
+
+<h2 id="toggles">
+  开关<a class="manual__heading-link" href="#toggles" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + I</code></td>
+      <td>切换空闲锁定</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + N</code></td>
+      <td>切换夜间模式色温</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Delete</code></td>
+      <td>开关笔记本屏幕</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + Delete</code></td>
+      <td>切换笔记本屏幕镜像</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Space</code></td>
+      <td>切换状态栏</td>
+    </tr>
+    <tr>
+      <td><code>Shift + Mute</code></td>
+      <td>切换到下一个音频输出</td>
+    </tr>
+    <tr>
+      <td><code>Shift + Play</code></td>
+      <td>切换到下一个媒体源</td>
+    </tr>
+    <tr>
+      <td><code>Super + Shift + Backspace</code></td>
+      <td>切换窗口间隙</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="reminders">
+  提醒事项<a
+    class="manual__heading-link"
+    href="#reminders"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + R</code></td>
+      <td>设置提醒</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + R</code></td>
+      <td>查看所有提醒</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Shift + R</code></td>
+      <td>清除所有提醒</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="notices">
+  快捷通知<a class="manual__heading-link" href="#notices" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + Alt + T</code></td>
+      <td>以通知显示时间</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + B</code></td>
+      <td>以通知显示电量</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + W</code></td>
+      <td>以通知显示天气</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="tmux">
+  Tmux<a class="manual__heading-link" href="#tmux" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  前缀键是<code>Ctrl + Space</code>（<code>Ctrl + B</code
+  >也可以）。可在<code>~/.config/tmux/tmux.conf</code>中修改这些绑定。
+</p>
+
+<h3 id="panes">
+  窗格<a class="manual__heading-link" href="#panes" aria-label="本节链接">#</a>
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Prefix + v</code></td>
+      <td>在旁边分割窗格（垂直）</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + h</code></td>
+      <td>在下方分割窗格（水平）</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + x</code></td>
+      <td>关闭窗格</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + z</code></td>
+      <td>切换窗格缩放（全屏）</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Enter</code></td>
+      <td>在下方分割窗格（无需前缀）</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + Enter</code></td>
+      <td>在旁边分割窗格（无需前缀）</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Escape</code></td>
+      <td>关闭窗格（无需前缀）</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Arrows</code></td>
+      <td>在窗格间移动</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Shift + Arrows</code></td>
+      <td>调整窗格大小</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="windows">
+  窗口<a class="manual__heading-link" href="#windows" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Prefix + c</code></td>
+      <td>新建窗口</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + k</code></td>
+      <td>关闭窗口</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + r</code></td>
+      <td>重命名窗口</td>
+    </tr>
+    <tr>
+      <td><code>Alt + 1-9</code></td>
+      <td>跳转到指定窗口</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Arrow Left/Right</code></td>
+      <td>在窗口间移动</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Shift + Arrow Left/Right</code></td>
+      <td>向左/右移动窗口</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="sessions">
+  会话<a class="manual__heading-link" href="#sessions" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Prefix + C</code></td>
+      <td>新建会话</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + K</code></td>
+      <td>关闭会话</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + R</code></td>
+      <td>重命名会话</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + N</code></td>
+      <td>下一个会话</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + P</code></td>
+      <td>上一个会话</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Arrow Up/Down</code></td>
+      <td>在会话间移动</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + s</code></td>
+      <td>列出会话</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + d</code></td>
+      <td>脱离会话</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="copy-mode-vi-style">
+  复制模式（vi风格）<a
+    class="manual__heading-link"
+    href="#copy-mode-vi-style"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Prefix + [</code></td>
+      <td>进入复制模式</td>
+    </tr>
+    <tr>
+      <td><code>v</code></td>
+      <td>开始选择（复制模式内）</td>
+    </tr>
+    <tr>
+      <td><code>y</code></td>
+      <td>复制选区（复制模式内）</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="general">
+  通用<a class="manual__heading-link" href="#general" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Prefix + q</code></td>
+      <td>重新加载配置</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + ?</code></td>
+      <td>显示Tmux键绑定</td>
+    </tr>
+    <tr>
+      <td><code>Prefix + :</code></td>
+      <td>命令提示符</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="tmux-layout-functions">
+  Tmux布局函数<a
+    class="manual__heading-link"
+    href="#tmux-layout-functions"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>这些函数必须在Tmux会话内运行。</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>命令</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>tdl &lt;ai&gt; [&lt;second_ai&gt;]</code></td>
+      <td>创建包含编辑器、AI和终端的开发布局</td>
+    </tr>
+    <tr>
+      <td><code>tdlm &lt;ai&gt; [&lt;second_ai&gt;]</code></td>
+      <td>为每个子目录创建开发布局</td>
+    </tr>
+    <tr>
+      <td><code>tsl &lt;count&gt; &lt;command&gt;</code></td>
+      <td>创建多窗格集群布局</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="ghostty-terminal">
+  Ghostty终端<a
+    class="manual__heading-link"
+    href="#ghostty-terminal"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>Ghostty终端通过Omarchy菜单的<em>Install &gt; Terminal</em>安装。</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Ctrl + Shift + E</code></td>
+      <td>在下方新建分屏</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Shift + O</code></td>
+      <td>在旁边新建分屏</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Alt + Arrows</code></td>
+      <td>在分屏间移动</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Shift + Arrows</code></td>
+      <td>以10行为步长调整分屏</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Shift + Alt + Arrows</code></td>
+      <td>以100行为步长调整分屏</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Shift + T</code></td>
+      <td>新建标签页</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Shift + Arrows</code></td>
+      <td>在标签页间移动</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Numbers</code></td>
+      <td>跳转到指定标签页</td>
+    </tr>
+    <tr>
+      <td><code>Shift + Pg Up/Down</code></td>
+      <td>滚动历史输出</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Left mouse</code></td>
+      <td>在浏览器中打开链接</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="file-manager">
+  文件管理器<a
+    class="manual__heading-link"
+    href="#file-manager"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Ctrl + L</code></td>
+      <td>跳转到路径</td>
+    </tr>
+    <tr>
+      <td><code>Space</code></td>
+      <td>预览文件（方向键切换）</td>
+    </tr>
+    <tr>
+      <td><code>Backspace</code></td>
+      <td>返回上一级文件夹</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="neovim-w-lazyvim">
+  Neovim（配合lazyvim）<a
+    class="manual__heading-link"
+    href="#neovim-w-lazyvim"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<h3 id="navigation">
+  导航<a class="manual__heading-link" href="#navigation" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Space</code></td>
+      <td>显示命令选项</td>
+    </tr>
+    <tr>
+      <td><code>Space Space</code></td>
+      <td>模糊搜索并打开文件</td>
+    </tr>
+    <tr>
+      <td><code>Space E</code></td>
+      <td>切换侧边栏</td>
+    </tr>
+    <tr>
+      <td><code>Space G G</code></td>
+      <td>显示git控制</td>
+    </tr>
+    <tr>
+      <td><code>Space S G</code></td>
+      <td>搜索文件内容</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + W W</code></td>
+      <td>在侧边栏与编辑器间跳转</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Left/right arrow</code></td>
+      <td>调整侧边栏宽度</td>
+    </tr>
+    <tr>
+      <td><code>Shift + H</code></td>
+      <td>切换到左侧文件标签</td>
+    </tr>
+    <tr>
+      <td><code>Shift + L</code></td>
+      <td>切换到右侧文件标签</td>
+    </tr>
+    <tr>
+      <td><code>Space B D</code></td>
+      <td>关闭文件标签</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 id="while-in-sidebar">
+  侧边栏内<a
+    class="manual__heading-link"
+    href="#while-in-sidebar"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>A</code></td>
+      <td>在上级目录新建文件</td>
+    </tr>
+    <tr>
+      <td><code>Shift + A</code></td>
+      <td>在上级目录新建子目录</td>
+    </tr>
+    <tr>
+      <td><code>D</code></td>
+      <td>删除高亮的文件/目录</td>
+    </tr>
+    <tr>
+      <td><code>M</code></td>
+      <td>移动高亮的文件/目录</td>
+    </tr>
+    <tr>
+      <td><code>R</code></td>
+      <td>重命名高亮的文件/目录</td>
+    </tr>
+    <tr>
+      <td><code>?</code></td>
+      <td>显示所有命令的帮助</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <a href="https://www.lazyvim.org/keymaps">查看LazyVim配置的全部Neovim快捷键</a
+  >。
+</p>
+
+<h2 id="quick-emojis">
+  快速表情<a
+    class="manual__heading-link"
+    href="#quick-emojis"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <code>Super + Ctrl + E</code
+  >可以打开完整的表情选择器，把所选表情放到剪贴板；也可以使用下面这些快速输入方式。
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>表情</th>
+      <th>提示</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>CapsLock M S</code></td>
+      <td>😄</td>
+      <td>smile</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M C</code></td>
+      <td>😂</td>
+      <td>cry</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M L</code></td>
+      <td>😍</td>
+      <td>love</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M V</code></td>
+      <td>✌️</td>
+      <td>victory</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M H</code></td>
+      <td>❤️</td>
+      <td>heart</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M Y</code></td>
+      <td>👍</td>
+      <td>yes</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M N</code></td>
+      <td>👎</td>
+      <td>no</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M F</code></td>
+      <td>🖕</td>
+      <td>fuck</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M W</code></td>
+      <td>🤞</td>
+      <td>wish</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M R</code></td>
+      <td>🤘</td>
+      <td>rock</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M K</code></td>
+      <td>😘</td>
+      <td>kiss</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M E</code></td>
+      <td>🙄</td>
+      <td>eyeroll</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M I</code></td>
+      <td>😉</td>
+      <td>wink</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M P</code></td>
+      <td>🙏</td>
+      <td>pray</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M D</code></td>
+      <td>🤤</td>
+      <td>drool</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M M</code></td>
+      <td>💰</td>
+      <td>money</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M X</code></td>
+      <td>🎉</td>
+      <td>xellebrate</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M 1</code></td>
+      <td>💯</td>
+      <td>100%</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M T</code></td>
+      <td>🥂</td>
+      <td>toast</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M O</code></td>
+      <td>👌</td>
+      <td>ok</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M G</code></td>
+      <td>👋</td>
+      <td>greeting</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M A</code></td>
+      <td>💪</td>
+      <td>arm</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock M B</code></td>
+      <td>🤯</td>
+      <td>blowing</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="quick-completions">
+  快速补全<a
+    class="manual__heading-link"
+    href="#quick-completions"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>补全内容</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>CapsLock Space Space</code></td>
+      <td>- （破折号）</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock Space N</code></td>
+      <td>你的姓名（安装时填写）</td>
+    </tr>
+    <tr>
+      <td><code>CapsLock Space E</code></td>
+      <td>你的邮箱（安装时填写）</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  编辑<code>~/.XCompose</code>可以添加更多自定义补全，然后在终端运行<code>omarchy-restart-xcompose</code>让改动生效。
+</p>

--- a/src/i18n/zh-CN/manual/index.html
+++ b/src/i18n/zh-CN/manual/index.html
@@ -1,0 +1,32 @@
+<p>
+  Omarchy是一款<a
+    href="https://manuals.omamix.org/3/omacom/76/omakase-computing"
+    >omakase</a
+  >风格的Linux发行版，基于<a href="https://archlinux.org/">Arch</a
+  >、平铺窗口管理器<a href="https://hypr.land/">Hyprland</a>和桌面构建工具包<a
+    href="https://quickshell.org/"
+    >Quickshell</a
+  >。它内置了现代、懂行的电脑用户即刻投入工作所需的一切：从<a
+    href="https://neovim.io/"
+    >Neovim</a
+  >（顺便一提）到Chromium，从<a href="https://obsidian.md/">Obsidian</a
+  >到LibreOffice，从Kdenlive到OBS
+  Studio。甚至还有一款复古的Winamp风格音乐播放器！
+</p>
+
+<p>
+  但这并不只是一堆预装软件的拼盘，而是一个兼顾美感与效率的完整系统。因为<em>美观</em>的系统能<em>激发动力</em>，而效率向来<a
+    href="https://world.hey.com/dhh/beautiful-motivations-6fef7c73"
+    >源自动力</a
+  >。这里没有任何冗余，只有我自己每天在用的东西。
+</p>
+
+<p>
+  诚然，要欣赏Omarchy这种大量使用TUI、主题丰富、以平铺方式管理窗口的系统之美，需要一点时间培养。但你来到这里，不正是为此吗？体验一些舒适区之外的东西，在一种全新的电脑使用方式上来一场小小的冒险？我希望是。
+</p>
+
+<p>
+  Omarchy既不像Windows，也不像macOS。它无意让你感到熟悉，只想做到美观，并且<em>更好</em>。请拥抱它彻头彻尾的Linux气质：手动编辑一些配置文件，当然会有；重度使用终端，那是必然。
+</p>
+
+<p>让我们从基础开始。</p>

--- a/src/i18n/zh-CN/manual/keyboard-mouse-trackpad.html
+++ b/src/i18n/zh-CN/manual/keyboard-mouse-trackpad.html
@@ -1,0 +1,120 @@
+<p>
+  Hyprland允许你对所有输入设备做非常细致的配置：可以把键盘重复速度调到飞快，也可以让触控板使用自然滚动。这一切都在<code>~/.config/hypr/input.lua</code>中修改，该文件也可通过Omarchy菜单（<code
+    >Super + Space</code
+  >）的<em>Setup &gt; Input</em
+  >打开。在这里设置的任何内容都会替换Omarchy的默认值。
+</p>
+
+<p>示例如下：</p>
+
+<pre><code class="language-lua">hl.config({
+  input = {
+    -- Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
+    kb_layout = "us,dk",
+    kb_options = "compose:caps,shift:both_capslock_cancel,grp:alts_toggle",
+
+    -- Change speed of keyboard repeat
+    repeat_rate = 40,
+    repeat_delay = 600,
+
+    -- Increase sensitivity for mouse/trackpad (default: 0)
+    sensitivity = 0.35,
+
+    touchpad = {
+      -- Use natural (inverse) scrolling
+      natural_scroll = true,
+
+      -- Use two-finger clicks for right-click instead of lower-right corner
+      clickfinger_behavior = true,
+
+      -- Control the speed of your scrolling
+      scroll_factor = 0.3,
+    },
+  },
+})
+
+-- Scroll faster in the terminal
+o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
+</code></pre>
+
+<p>
+  Hyprland wiki上可以<a
+    href="https://wiki.hypr.land/Configuring/Basics/Variables/#input"
+    >查看全部输入选项</a
+  >。
+</p>
+
+<p>
+  Omarchy默认把CapsLock用作组合键，用于<a href="/manual/hotkeys/#quick-emojis"
+    >快速表情</a
+  >和<a href="/manual/hotkeys/#quick-completions">其他补全</a
+  >。如果你更想让CapsLock就是大写锁定，修改<code>kb_options</code>中的<code>compose:caps</code>，把组合键挪到别处。比如下面把组合键移到右Alt：
+</p>
+
+<pre><code class="language-lua">hl.config({
+  input = {
+    kb_options = "compose:ralt",
+  },
+})
+</code></pre>
+
+<h3 id="trackpad-gestures">
+  触控板手势<a
+    class="manual__heading-link"
+    href="#trackpad-gestures"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  还可以开启<a
+    href="https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/"
+    >触控板手势</a
+  >，比如三指滑动切换工作区：
+</p>
+
+<pre><code class="language-lua">hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+</code></pre>
+
+<p>
+  配备触觉反馈触控板的Dell XPS笔记本，还可以在<em
+    >Trigger &gt; Hardware &gt; Touchpad Haptics</em
+  >下把按压力度设为低、中或高。
+</p>
+
+<h3 id="typing-in-chinese-japanese-and-other-languages">
+  输入中文、日文及其他语言<a
+    class="manual__heading-link"
+    href="#typing-in-chinese-japanese-and-other-languages"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy在每个会话中都运行<a href="https://fcitx-im.org/">fcitx5</a
+  >输入法框架——CapsLock组合序列正是由它驱动的。这意味着非拉丁文字输入的底层设施已经就位：用<code
+    >omarchy pkg add</code
+  >安装一个输入引擎，如<code>fcitx5-mozc</code>（日文）或<code>fcitx5-chinese-addons</code>（中文），再装上<code>fcitx5-configtool</code>，把引擎加入输入法列表并设置切换键即可。
+</p>
+
+<h3 id="use-alt-as-super">
+  用ALT充当SUPER<a
+    class="manual__heading-link"
+    href="#use-alt-as-super"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在某些键盘上，用主meta键（Windows/cmd键）充当SUPER并不顺手。可以通过下面的修改改用ALT：
+</p>
+
+<pre><code class="language-lua">hl.config({
+  input = {
+    kb_options = "compose:caps,shift:both_capslock_cancel,altwin:swap_alt_win",
+  },
+})
+</code></pre>

--- a/src/i18n/zh-CN/manual/mac-support.html
+++ b/src/i18n/zh-CN/manual/mac-support.html
@@ -1,0 +1,164 @@
+<p>
+  Omarchy内置了对<strong>Intel Mac</strong
+  >的支持。目前有几个已知限制，只要你了解并能接受，就可以装上Omarchy，给老Mac注入新生命。
+</p>
+
+<p>
+  请注意，目前不直接支持在M系列Mac上安装。相关进展可以在我们<a
+    href="https://discord.gg/tXFUdasqhY"
+    >Discord</a
+  >的 #omarchy-on-other频道了解。
+</p>
+
+<p>
+  在一次简单测试中，仅仅安装Omarchy就让一台2019款MacBook Pro获得了36%
+  的性能提升。
+</p>
+
+<p><img src="/manual/images/macbook-omarchy.webp" alt="macbook-omarchy" /></p>
+
+<h3 id="installing-omarchy-on-mac">
+  在Mac上安装Omarchy<a
+    class="manual__heading-link"
+    href="#installing-omarchy-on-mac"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy目前只支持作为<strong>唯一</strong>的操作系统安装。安装过程中驱动器会被抹掉，MacOS将无法再启动。
+</p>
+
+<p>之后如果想要，仍可通过互联网恢复模式把它装回来。</p>
+
+<p>
+  本节假定你已经看过<a href="/manual/getting-started/">入门指南</a
+  >并准备好了U盘。如果还没有，请先去准备。
+</p>
+
+<h4 id="disable-secure-boot">
+  关闭安全启动<a
+    class="manual__heading-link"
+    href="#disable-secure-boot"
+    aria-label="本节链接"
+    >#</a
+  >
+</h4>
+
+<p>要从可启动U盘启动并运行系统，必须先关闭Apple的安全启动。步骤如下：</p>
+
+<ol>
+  <li>关闭Mac</li>
+  <li>开机并<em>立即</em>按住Command-R，直到出现加载画面</li>
+  <li>选择用户，按提示输入密码</li>
+  <li>
+    进入恢复界面后，在菜单栏选择<strong
+      >Utilities &gt; Startup Security Utility</strong
+    >
+  </li>
+  <li>按提示输入密码完成认证</li>
+  <li>在Secure Boot选项中选择“No Security”</li>
+  <li>
+    在External Boot选项中选择“Allow booting from external or removable media”
+  </li>
+</ol>
+
+<h4 id="start-the-installation">
+  开始安装<a
+    class="manual__heading-link"
+    href="#start-the-installation"
+    aria-label="本节链接"
+    >#</a
+  >
+</h4>
+
+<ol>
+  <li>插入U盘</li>
+  <li>重启Mac并<em>立即</em>按住Option，直到出现启动设备选择界面</li>
+  <li>选择橙色的EFI Boot设备</li>
+  <li><a href="/manual/getting-started/">照常完成安装</a></li>
+</ol>
+
+<p>
+  安装程序会检测Mac硬件并自动应用所需修复：Broadcom
+  Wi-Fi驱动和固件、需要它的MacBook机型上的SPI键盘驱动，以及这些机型的NVMe挂起修复。
+</p>
+
+<h3 id="known-limitations">
+  已知限制<a
+    class="manual__heading-link"
+    href="#known-limitations"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  社区成员一直在为这些问题寻找解决方案。如果它们对你造成困扰，请加入我们<a
+    href="https://discord.gg/tXFUdasqhY"
+    >Discord</a
+  >的 #omarchy-on-other频道，看看是否有最新的解决办法。
+</p>
+
+<h4 id="devices-with-t1-chip">
+  配备T1芯片的设备<a
+    class="manual__heading-link"
+    href="#devices-with-t1-chip"
+    aria-label="本节链接"
+    >#</a
+  >
+</h4>
+
+<p>Apple T1芯片于2016年底推出，仅用于第一代带Touch Bar的MacBook Pro机型。</p>
+<ul>
+  <li>MacBook Pro 13英寸（2016，两个Thunderbolt 3端口）– 型号：A1706</li>
+  <li>MacBook Pro 13英寸（2016，四个Thunderbolt 3端口）– 型号：A1708</li>
+  <li>MacBook Pro 15英寸（2016）– 型号：A1707</li>
+</ul>
+
+<h4 id="known-issues">
+  已知问题<a
+    class="manual__heading-link"
+    href="#known-issues"
+    aria-label="本节链接"
+    >#</a
+  >
+</h4>
+
+<ul>
+  <li>Touch Bar无法使用</li>
+  <li>声音无法工作</li>
+</ul>
+
+<h4 id="devices-with-t2-chip">
+  配备T2芯片的设备<a
+    class="manual__heading-link"
+    href="#devices-with-t2-chip"
+    aria-label="本节链接"
+    >#</a
+  >
+</h4>
+
+<p>
+  Apple T2安全芯片于2017年推出，随着2020年起向Apple芯片（M系列）的过渡而停产。
+</p>
+
+<ul>
+  <li>iMac Pro（2017）– 型号：A1862</li>
+  <li>MacBook Pro 13英寸（2018，四个Thunderbolt 3端口）– 型号：A1989</li>
+  <li>MacBook Pro 15英寸（2018）– 型号：A1990</li>
+  <li>MacBook Air（视网膜，13英寸，2018）– 型号：A1932</li>
+  <li>Mac mini（2018）– 型号：A1998</li>
+  <li>MacBook Pro 13英寸（2019，两个Thunderbolt 3端口）– 型号：A2159</li>
+  <li>MacBook Pro 13英寸（2019，四个Thunderbolt 3端口）– 型号：A2178</li>
+  <li>MacBook Pro 15英寸（2019）– 型号：A1990</li>
+  <li>MacBook Pro 13英寸（2020，两个Thunderbolt 3端口）– 型号：A2265</li>
+  <li>MacBook Pro 15英寸（2020）– 型号：A1990</li>
+</ul>
+
+<p>
+  在这些机型上，安装程序会自动设置打过补丁的<code>linux-t2</code>内核、T2音频配置、Apple的Broadcom
+  Wi-Fi/蓝牙固件，以及通过<code>t2fanrd</code>实现的风扇控制。Touch
+  Bar依靠内核内置的Boot Camp式支持运行。
+</p>

--- a/src/i18n/zh-CN/manual/making-your-own-theme.html
+++ b/src/i18n/zh-CN/manual/making-your-own-theme.html
@@ -1,0 +1,139 @@
+<p>
+  你可以把自己的主题放到<code>~/.config/omarchy/themes</code>。复制一个现有主题作为基础（在<code>/usr/share/omarchy/themes</code>里找），然后随心调整。只要主题在这个文件夹内，就会出现在主题选择菜单中。
+</p>
+
+<p>
+  主要需要调整的文件是<code>colors.toml</code>。它定义的色板会用来生成终端（Foot/Alacritty/Ghostty/Kitty）、btop、Chromium、Hyprland、Neovim、Helix、VSCode、Obsidian以及整个Omarchy
+  shell（状态栏、菜单、通知、OSD和锁屏）的配置。
+</p>
+
+<p>
+  也可以用内置的Aether应用创建新主题，它提供漂亮的图形界面来调配颜色和搜索背景图片。通过<code
+    >Super + Alt + Space</code
+  >的应用菜单启动即可。
+</p>
+
+<h3 id="what-an-installed-theme-can-contain">
+  安装的主题可以包含什么<a
+    class="manual__heading-link"
+    href="#what-an-installed-theme-can-contain"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  你自己写在<code>~/.config/omarchy/themes</code>里的主题可以包含任何内容——机器是你的，文件也是你的，Omarchy会全部应用。
+</p>
+
+<p>
+  用<code>omarchy theme install</code
+  >从别人仓库安装的主题则只保留颜色相关的部分，去掉那几个会在你机器上运行代码的文件：任何<code>.lua</code>文件、终端配置（<code>alacritty.toml</code>、<code>foot.ini</code>、<code>ghostty.conf</code>、<code>kitty.conf</code>）和<code>vscode.json</code>。主题的<code>hyprland.lua</code>是合成器在登录时运行的Lua，终端配置指定终端启动的程序，<code>vscode.json</code>指定要安装的VSCode扩展。安装别人的主题应该只改变桌面的外观，而不该改变它运行什么。
+</p>
+
+<p>
+  其他一切仍按主题作者所写原样生效——<code>btop.theme</code>、<code>chromium.theme</code>、<code>helix.toml</code>、<code>icons.theme</code>、<code>shell.toml</code>、背景图片和预览图都会保留。只有被去掉的部分会在你的机器上根据<code>colors.toml</code>重新生成。
+</p>
+
+<p>
+  Omarchy通过主题内是否带有自己的git仓库来区分两者，这正是<code
+    >omarchy theme install</code
+  >克隆后留下的痕迹。所以你写的主题始终完整属于你，从网上拉来的主题始终只有颜色。
+</p>
+
+<h3 id="light-mode">
+  浅色模式<a
+    class="manual__heading-link"
+    href="#light-mode"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  制作浅色主题时，在<code>colors.toml</code>顶部设置<code>mode = "light"</code
+  >，所有应用就会自动配对浅色模式。（旧方法——在主题根目录放一个名为<code>light.mode</code>的空文件——同样有效。）
+</p>
+
+<h3 id="icon-colors">
+  图标颜色<a
+    class="manual__heading-link"
+    href="#icon-colors"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  想让文件管理器的图标与主题配色一致，添加一个名为<code>icons.theme</code>的文件，写入想用的图标集名称。默认可选：<code
+    >Yaru Yaru-blue Yaru-dark Yaru-magenta Yaru-olive Yaru-prussiangreen
+    Yaru-purple Yaru-red Yaru-sage Yaru-wartybrown Yaru-yellow</code
+  >。
+</p>
+
+<h3 id="unlock-image">
+  解锁图片<a
+    class="manual__heading-link"
+    href="#unlock-image"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  附带<code>unlock.png</code>和<code>preview-unlock.png</code>的主题会列在<em
+    >Style &gt; Unlock</em
+  >下。<code>unlock.png</code>最好是透明png，预览图可以用<code
+    >omarchy plymouth preview</code
+  >生成。
+</p>
+
+<h3 id="theming-apps-omarchy-doesnt-cover">
+  为Omarchy未覆盖的应用设置主题<a
+    class="manual__heading-link"
+    href="#theming-apps-omarchy-doesnt-cover"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  如果你用的应用不在上述列表中，可以用模板教会Omarchy为它设置主题。在<code>~/.config/omarchy/themed/</code>中放一个文件，以它生成的配置文件命名并加上<code>.tpl</code>扩展名，然后用<code
+    >{{ background }}</code
+  >、<code>{{ foreground }}</code>、<code>{{ accent }}</code>、<code
+    >{{ red }}</code
+  >、<code>{{ color0 }}</code>到<code>{{ color15 }}</code
+  >以及色板的其余部分作为占位符编写配置。每次切换主题时，该文件都会用新主题的颜色重新生成。
+</p>
+
+<p>
+  该文件夹里有一份注释完整的<code>alacritty.toml.tpl.sample</code>可供参考——它列出了所有可用变量，以及<code>_strip</code>和<code>_rgb</code>修饰符，供需要不带<code>#</code>或十进制RGB颜色的应用使用。你的模板优先于Omarchy自带的模板，所以也可以借此覆盖内置应用的主题生成方式。
+</p>
+
+<h3 id="distributing-your-theme">
+  分发主题<a
+    class="manual__heading-link"
+    href="#distributing-your-theme"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  想分发主题供他人使用，需要把它放到GitHub这样的公开git服务器上。然后别人就可以在Omarchy菜单的<em
+    >Install &gt; Style &gt; Theme</em
+  >中用该URL安装。建议遵循<code>omarchy-[themename]-theme</code>的命名约定，安装后主题会在选择菜单中正确显示为<code>[themename]</code>。
+</p>
+
+<p>
+  剩下的<code>[themename]</code>会成为主题的目录名，所以必须是Omarchy能安全处理的名称：以字母、数字或下划线开头，其余部分可包含字母、数字、<code>.</code>、<code>_</code>、<code>+</code>和<code>-</code>。大写会自动转为小写，但其他任何字符——空格、引号、非英文字符——都会在安装时被拒绝，而不是变成目录名。所以<code>omarchy-tokyo-night-theme</code>、<code>omarchy-flexoki_light-theme</code>和<code>omarchy-c++-theme</code>都能正常安装。
+</p>
+
+<p>
+  记住，从仓库安装后，主题附带的任何<code>.lua</code>、终端配置或<code>vscode.json</code>都会被去掉，所以不要围绕这些文件来构建主题。
+</p>
+
+<p>
+  向<a href="https://github.com/omacom-io/omarchy-site">omarchy-site仓库</a
+  >提交拉取请求，可以把你的主题加入<a href="/themes/">额外主题页面</a>。
+</p>

--- a/src/i18n/zh-CN/manual/monitors.html
+++ b/src/i18n/zh-CN/manual/monitors.html
@@ -1,0 +1,156 @@
+<p>
+  Omarchy默认假定你使用的是支持2倍缩放的视网膜级显示器。这是获得清晰锐利的编程字体的前提，几乎所有配备高分辨率屏幕的新款高端笔记本都是为此优化的，也是你在27英寸5K的<a
+    href="https://www.apple.com/studio-display/"
+    >Apple Studio Display</a
+  >/<a
+    href="https://www.asus.com/us/displays-desktops/monitors/proart/proart-display-5k-pa27jcv/"
+    >ProArt PA27JCV</a
+  >/<a
+    href="https://www.samsung.com/us/computing/monitors/5k/27-viewfinity-s9-5k-monitor-with-thunderbolt-4-matte-display-and-smart-features-ls27c900panxza/"
+    >Samsung S9</a
+  >/<a href="https://kuycon.us/monitors/G27P/">Kuycon G27P</a>，或32英寸6K的<a
+    href="https://www.apple.com/pro-display-xdr/"
+    >Apple XDR</a
+  >/<a
+    href="https://www.asus.com/displays-desktops/monitors/proart/proart-display-6k-pa32qcv/"
+    >ProArt PA32QCV</a
+  >/<a href="https://kuycon.us/monitors/G32P/">Kuycon G32P</a>上想要的效果。
+</p>
+
+<p>
+  但如果显示器的PPI达不到218，就需要修改显示器设置。比如27或32英寸的4K屏，可以打开<code>~/.config/hypr/monitors.lua</code>（通过Omarchy菜单的<em
+    >Setup &gt; Monitors</em
+  >），切换为该组合的推荐分数缩放：
+</p>
+
+<pre><code class="language-lua">local omarchy_gdk_scale = 2
+local omarchy_monitor_scale = 1.6
+</code></pre>
+
+<p>1080p或1440p显示器通常只需1倍缩放：</p>
+
+<pre><code class="language-lua">local omarchy_gdk_scale = 1
+local omarchy_monitor_scale = 1
+</code></pre>
+
+<p>
+  <code>GDK_SCALE</code
+  >的修改只对之后启动的应用生效（GTK只接受整数，所以取最接近显示器缩放的整数即可）。修改后请退出那些尺寸过大的窗口（或用<code
+    >Ctrl + Alt + Del</code
+  >关闭所有窗口！）。
+</p>
+
+<p>
+  也可以用<code>Super + /</code>和<code>Super + Alt + /</code
+  >在主要缩放比例（1x、1.25x、1.6x、2x、3x、4x）之间上下切换。使用默认配置时，这些修改在重启后依然保留。
+</p>
+
+<h3 id="making-text-bigger-or-smaller">
+  放大或缩小文字<a
+    class="manual__heading-link"
+    href="#making-text-bigger-or-smaller"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  显示器缩放会改变一切的大小。如果只想让<em>文字</em>变大或变小，有一个专门的旋钮：
+</p>
+
+<pre><code>omarchy display text size 14
+</code></pre>
+
+<p>
+  它接受9到20之间的像素值，同时调整Omarchy
+  shell、GTK应用和终端，让整个桌面保持比例。不带参数运行可查看当前值，<code
+    >omarchy display text size reset</code
+  >恢复默认。Foot是唯一的例外：它无法重新加载配置，所以已打开的终端会保持旧尺寸，直到你开一个新的。
+</p>
+
+<h3 id="extending-and-mirroring-laptop-displays">
+  扩展与镜像笔记本显示器<a
+    class="manual__heading-link"
+    href="#extending-and-mirroring-laptop-displays"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  给笔记本接上外接屏幕时，显示会自动扩展。通过Omarchy菜单的<em
+    >Trigger &gt; Hardware</em
+  >或<code>Super + Ctrl + Alt + Delete</code
+  >可以改为镜像。外接屏幕是投影仪、你想边工作边展示时，这尤其方便。
+</p>
+
+<p>
+  处于扩展模式时，合上笔记本盖子会自动关闭内置屏幕，打开盖子则重新开启。也可以通过Omarchy菜单的<em
+    >Trigger &gt; Hardware</em
+  >或<code>Super + Ctrl + Delete</code>手动控制。
+</p>
+
+<h3 id="arranging-multiple-screens">
+  排列多块屏幕<a
+    class="manual__heading-link"
+    href="#arranging-multiple-screens"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Hyprland对多屏支持很好。布局方法参见<a
+    href="https://wiki.hypr.land/Configuring/Basics/Monitors/"
+    >Hyprland显示器文档</a
+  >，你还可以<a
+    href="https://wiki.hypr.land/Configuring/Basics/Workspace-Rules/"
+    >把特定工作区绑定到特定显示器</a
+  >。在Omarchy中，这些规则以<code>hl.monitor</code>条目的形式写在<code>~/.config/hypr/monitors.lua</code>中——文件自带注释示例，展示如何为某块显示器固定分辨率、位置和旋转。
+</p>
+
+<p>
+  想用TUI辅助多屏定位的话，也可以看看<a href="https://github.com/erans/hyprmon/"
+    >Hyprmon</a
+  >。
+</p>
+
+<h3 id="controlling-brightness">
+  控制亮度<a
+    class="manual__heading-link"
+    href="#controlling-brightness"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  显示器亮度由专用的亮度增减功能键控制。按住Shift再按这些键，会直接跳到最大或最小亮度。按键作用于当前聚焦的显示器，所以支持DDC/CI的外接显示器与笔记本屏幕的调节方式相同。
+</p>
+
+<h3 id="apple-displays">
+  Apple显示器<a
+    class="manual__heading-link"
+    href="#apple-displays"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  使用Apple显示器时，只要焦点在它上面，常规的键盘亮度键同样自动可用。这是通过<code>asdcontrol</code>命令实现的。
+</p>
+
+<p>
+  注意，使用Apple 6K XDR显示器时，<code>hyprctl monitors</code
+  >列表中可能出现一块幻影屏幕。可以通过<em>Setup &gt; Monitors</em>用类似<code
+    >hl.monitor({ output = "DP-2", disabled = true })</code
+  >的设置把它关掉。
+</p>
+
+<p>
+  Intel机器应使用普通的Thunderbolt线连接Apple显示器。没有Thunderbolt接口的其他机器，通常需要一根<a
+    href="https://www.amazon.com/dp/B0BNX7MS6N"
+    >DP + USB-A转USB-C线</a
+  >才能正常工作。
+</p>

--- a/src/i18n/zh-CN/manual/navigation.html
+++ b/src/i18n/zh-CN/manual/navigation.html
@@ -1,0 +1,202 @@
+<p>
+  Omarchy中的一切都通过键盘完成——<em>一切！</em>系统首次启动时，光靠鼠标什么也做不了。但按下<code
+    >Super + Space</code
+  >就能调出Omarchy菜单，从这里几乎可以完成所有操作。
+</p>
+
+<p>
+  不过大多数时候，Omarchy菜单并不是操作系统的主要方式。我们可以更快！所有最重要的应用都直接绑定了快捷键：<code
+    >Super + Return</code
+  >启动终端，<code>Super + Shift + Return</code
+  >启动浏览器。先后按下试试，你就能看到Hyprland平铺的魔力：
+</p>
+
+<p>
+  <img
+    src="/manual/images/navigation-browser-terminal.webp"
+    alt="navigation-browser-terminal"
+  />
+</p>
+
+<p>接着按<code>Super + J</code>，两个窗口会由左右并排改为上下堆叠：</p>
+
+<p>
+  <img src="/manual/images/navigation-stacked.webp" alt="navigation-stacked" />
+</p>
+
+<p>
+  再按一次<code>Super + J</code>，它们回到并排位置。然后在浏览器上试试<code
+    >Super + Shift + Arrow Right</code
+  >，交换两个窗口。
+</p>
+
+<p>
+  现在按<code>Super + Ctrl + T</code>启动活动监视器，它以浮动窗口出现。用<code
+    >Super + T</code
+  >可以把它平铺（再按一次恢复浮动）。再按<code>Super + Shift + F</code
+  >打开文件管理器，你就有了一个整齐的四分布局：
+</p>
+
+<p>
+  <img
+    src="/manual/images/navigation-fourway-tiling.webp"
+    alt="navigation-fourway-tiling"
+  />
+</p>
+
+<p>
+  用<code>Super + Arrow</code
+  >切换要激活的窗口。这会转移焦点，并把光标移到新应用的中央。
+</p>
+
+<p>
+  按<code>Super + Shift + 2</code>，当前聚焦的应用会移到第二个工作区，<code
+    >Super + Shift + 1</code
+  >把它移回来。（<code>Super + Shift + Alt + 2</code
+  >则把当前应用移到第二个工作区，但自己不跟过去。）
+</p>
+
+<p>
+  按住<code>Super</code>用鼠标点击窗口，可以重新安排它的位置；按住<code>Super</code>并使用鼠标右键，可以自由调整窗口大小。
+</p>
+
+<p>
+  用<code>Super + W</code>或<code>Super + Q</code>关闭窗口（<code
+    >Ctrl + Alt + Delete</code
+  >关闭所有窗口）。
+</p>
+
+<p>
+  你还可以用<code>Super + F</code>全屏，用<code>Super + Alt + F</code
+  >仅占满宽度（保留状态栏），或用<code>Super + Ctrl + F</code
+  >在窗口内全屏（看YouTube很合适！）。
+</p>
+
+<h3 id="dwindle-vs-scrolling-layout">
+  Dwindle布局与滚动布局<a
+    class="manual__heading-link"
+    href="#dwindle-vs-scrolling-layout"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy的默认布局叫dwindle。它让同一工作区内打开的所有窗口始终可见，哪怕不得不把它们缩小。
+</p>
+
+<p>
+  <img
+    src="/manual/images/navigation-dwindle-layout.webp"
+    alt="navigation-dwindle-layout"
+  />
+</p>
+
+<p>
+  你也可以把工作区切换成滚动布局：窗口并排排成一行，延伸到屏幕可见范围之外。用<code
+    >Super + L</code
+  >即可将当前工作区切换为这种布局。
+</p>
+
+<p>
+  <img
+    src="/manual/images/navigation-scrolling-layout.webp"
+    alt="navigation-scrolling-layout"
+  />
+</p>
+
+<p>
+  这个选择按工作区保存，并且会保留。所以你可以让工作区1用dwindle浏览网页，工作区2用滚动布局写代码，重启后依然如此。（同样的开关也在Omarchy菜单的<em
+    >Trigger &gt; Toggle &gt; Workspace Layout</em
+  >下。）
+</p>
+
+<p>
+  如果想把滚动布局设为默认，可以在<code>~/.config/hypr/looknfeel.lua</code>中设置：
+</p>
+
+<pre><code class="language-lua">hl.config({
+  general = {
+    layout = "scrolling",
+  },
+})
+</code></pre>
+
+<h3 id="grouping-windows">
+  窗口分组<a
+    class="manual__heading-link"
+    href="#grouping-windows"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  用<code>Super + G</code
+  >可以将窗口分组。进入分组后，在此期间启动的每个窗口都会归入该组。用<code
+    >Super + Ctrl + Arrow Left/Right</code
+  >在组内窗口之间移动，或用<code>Super + Alt + 1/2/3/4</code
+  >按顺序直接跳到组内某个窗口。
+</p>
+
+<p>
+  用<code>Super + Alt + G</code>把窗口移出分组，或再按一次<code>Super + G</code
+  >解散整个组。最后，<code>Super + Alt + Arrows</code>可以把组外的窗口移进组内。
+</p>
+
+<h3 id="popping-windows">
+  弹出窗口<a
+    class="manual__heading-link"
+    href="#popping-windows"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>Super + O</code
+  >可以把窗口从所在工作区中弹出，固定为浮动窗口，跟随你去往任何工作区。非常适合视频播放器之类的应用。
+</p>
+
+<p>
+  <img
+    src="/manual/images/navigation-popped-window.webp"
+    alt="navigation-popped-window"
+  />
+</p>
+
+<h3 id="scratchpad-workspace">
+  便签工作区<a
+    class="manual__heading-link"
+    href="#scratchpad-workspace"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  最后，还有一个特殊的便签工作区，会覆盖在当前工作区之上，很像Quake的控制台。用<code
+    >Super + Grave</code
+  >或<code>Super + S</code>切换显示，用<code>Super + Shift + Grave</code>或<code
+    >Super + Alt + S</code
+  >把窗口放进去。
+</p>
+
+<p>
+  它特别适合运行智能体的终端，或是那些你想随手操作又不想离开当前工作区的控制窗口。要把窗口移出便签工作区，直接用<code
+    >Super + Shift + 1</code
+  >之类的快捷键把它发送到其他工作区即可。
+</p>
+
+<h3 id="it-takes-some-getting-used-to">
+  需要一点时间适应！<a
+    class="manual__heading-link"
+    href="#it-takes-some-getting-used-to"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  用这种方式操作桌面需要一点时间适应，但一旦习惯，就很难再回到传统的鼠标驱动桌面了！
+</p>

--- a/src/i18n/zh-CN/manual/neovim.html
+++ b/src/i18n/zh-CN/manual/neovim.html
@@ -1,0 +1,113 @@
+<p>
+  <a href="https://neovim.io/">Neovim</a>是<a
+    href="https://en.wikipedia.org/wiki/Vi_(text_editor)"
+    >vi编辑器</a
+  >的现代实现，vi由Bill
+  Joy早在1976年创造。它是模式化编辑器，插入模式与命令模式分离；哪怕只学会它深不见底的按键命令集中的一小部分，也堪称一种超能力。当然，学习曲线也相当陡峭！
+</p>
+
+<p>
+  如果你对vim式编辑完全陌生，推荐观看YouTube上<a
+    href="https://www.youtube.com/watch?v=X6AR2RMB5tE&amp;list=PLm323Lc7iSW_wuxqmKx_xxNtJC_hJbQ7R"
+    >ThePrimeagen的Vim As Your Editor系列</a
+  >，它会教你基础。要知道，与主流编辑器不同，vim需要更长时间才能达到基本熟练；但一旦做到，回报也更大。
+</p>
+
+<p>
+  Neovim几乎可以无限配置。如果真想放开手脚，可以从零打造自己的Neovim配置。<a
+    href="https://www.youtube.com/watch?v=zHTeCSVAFNY"
+    >Typecraft有一门从零配置Neovim的好课程</a
+  >，<a href="https://www.youtube.com/watch?v=w7i4amO_zaE"
+    >ThePrimeagen也有一门</a
+  >。
+</p>
+
+<p>
+  不过Omarchy自带一套完整的Neovim配置——<code>omarchy-nvim</code>软件包——经过精心调校，用来展示开箱即用的最佳效果，你不必写一行配置。它基于<a
+    href="https://www.lazyvim.org/"
+    >LazyVim</a
+  >，一个Neovim插件与配置的发行版。非常出色。
+</p>
+
+<h2 id="lazyvim-basics">
+  LazyVim基础<a
+    class="manual__heading-link"
+    href="#lazyvim-basics"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  如前所述，我不会在这篇简短介绍中教你vim，但可以展示LazyVim的几个基础操作，以及怎样在其中移动。
+</p>
+
+<p>
+  首先，Neovim有leader键的概念，它基本上是所有命令的入口。LazyVim将其设为<code>Space</code>。按下它，稍等一秒，就会看到一组选项像这样内联显示：
+</p>
+
+<p>这是我一直在用的几个基本命令：</p>
+
+<ul>
+  <li><code>Space Space</code>：在当前目录中模糊查找任意文件。</li>
+  <li><code>Space S G</code>：用grep搜索所有文件，带预览。</li>
+  <li><code>Space E</code>：开关文件树。</li>
+  <li><code>Ctrl + W W</code>：在文件树与编辑器之间来回跳转。</li>
+  <li>
+    <code>Shift + H</code>：在打开的标签页（vim称之为buffer）之间向左移动。
+  </li>
+  <li><code>Shift + L</code>：在打开的标签页之间向右移动。</li>
+  <li><code>Space B D</code>：关闭标签页。</li>
+  <li><code>Space B O</code>：关闭当前之外的所有标签页。</li>
+  <li><code>Space G G</code>：在当前目录以浮动窗格启动LazyGit。</li>
+  <li><code>Space U W</code>：开关软换行。</li>
+</ul>
+
+<p>
+  在文件树中（<code>Space E</code>显示，<code>Ctrl + W W</code
+  >跳转过去），用<code>a</code>新建文件，用<code>A</code>新建目录。在树中按<code>?</code>可查看所有命令。
+</p>
+
+<p>
+  如果想掌握vim的基本语言，我写过一篇关于<a
+    href="https://world.hey.com/dhh/wonderful-vi-a1d034d3"
+    >三段式语法</a
+  >的文章，教你打出那些漂亮的连招！
+</p>
+
+<p>
+  所有可用命令参见<a href="https://www.lazyvim.org/keymaps"
+    >LazyVim Keymaps页面</a
+  >。
+</p>
+
+<h2 id="starting-neovim">
+  启动Neovim<a
+    class="manual__heading-link"
+    href="#starting-neovim"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  可以用<code>Super + Shift + N</code
+  >启动Neovim（这个绑定启动的是默认编辑器，开箱即为Neovim），但通常从终端启动更方便：进入要工作的目录，输入<code>n</code>。<code>n</code>是<code>nvim</code>的别名，默认打开当前目录。<code
+    >n myfile.txt</code
+  >则打开单个文件。
+</p>
+
+<h2 id="using-neovim-for-sudo-edits">
+  用Neovim编辑需要sudo的文件<a
+    class="manual__heading-link"
+    href="#using-neovim-for-sudo-edits"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  如果要编辑只有超级用户才能修改的文件，运行<code
+    >sudoedit /etc/sudoers.d/00-sudo-only-file</code
+  >，即可使用带全部插件配置的neovim进行编辑。
+</p>

--- a/src/i18n/zh-CN/manual/networking.html
+++ b/src/i18n/zh-CN/manual/networking.html
@@ -1,0 +1,145 @@
+<p>
+  Omarchy的网络由NetworkManager管理，通过<a href="/manual/the-top-bar/"
+    >状态栏</a
+  >中的网络图标或<code>Super + Ctrl + W</code>操作。
+</p>
+
+<p>
+  该面板会扫描Wi-Fi网络、显示信号强度并连接。有线网络什么都不用做——插上就能用。想留在终端里的话，<code>nmtui</code>提供同样的控制，另外还有一组<code
+    >omarchy network</code
+  >命令。
+</p>
+
+<h2 id="sharing-your-wi-fi">
+  分享Wi-Fi<a
+    class="manual__heading-link"
+    href="#sharing-your-wi-fi"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  与其把一长串密码念出来，不如在连着Wi-Fi时运行<em
+    >Setup &gt; Network &gt; QR Code</em
+  >。屏幕上会显示一个二维码，任何手机相机扫一下就能加入。这类功能一旦知道有，用得会比想象中频繁。
+</p>
+
+<p>
+  确实需要密码本身时，<code>omarchy network password &lt;interface&gt;</code
+  >会把它打印出来。
+</p>
+
+<h2 id="dns">
+  DNS<a class="manual__heading-link" href="#dns" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  Omarchy使用网络通过DHCP下发的DNS。可以在<em>Setup &gt; Network &gt; DNS</em
+  >下为整台机器覆盖它，Cloudflare和Google一键可选，选择<em>Custom</em>则可输入自己的服务器。
+</p>
+
+<p>
+  终端中，<code>omarchy dns</code>显示当前提供商，<code
+    >omarchy dns Cloudflare</code
+  >设置一个。
+</p>
+
+<h2 id="pinning-the-wi-fi-band">
+  固定Wi-Fi频段<a
+    class="manual__heading-link"
+    href="#pinning-the-wi-fi-band"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  如果路由器把2.4GHz、5GHz和6GHz放在同一个网络名下，笔记本有时会死守着慢的那个。<code
+    >omarchy network band</code
+  >显示当前所在频段，<code>omarchy network band 5</code
+  >固定频段，<code>auto</code>则交回自动选择。
+</p>
+
+<p>这固定的是频段而非具体接入点，所以在各个AP之间照常漫游。</p>
+
+<h2 id="how-fast-is-it">
+  网速有多快？<a
+    class="manual__heading-link"
+    href="#how-fast-is-it"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <em>Trigger &gt; Speed Test &gt; Network Speed Test</em
+  >用一对仪表盘测量实际的上下行速度。终端中是<code
+    >omarchy network speedtest down</code
+  >或<code>up</code>。（同一菜单里还有磁盘速度测试，用于衡量另一个瓶颈。）
+</p>
+
+<h2 id="the-firewall">
+  防火墙<a
+    class="manual__heading-link"
+    href="#the-firewall"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  防火墙默认开启，拦截所有入站流量，只有一个例外：53317端口，以便<a
+    href="/manual/guis/"
+    >LocalSend</a
+  >开箱即用。
+</p>
+
+<p>
+  SSH默认关闭，直到你通过<em>Setup &gt; Security &gt; SSHD</em
+  >开启，它会启动守护进程、开放带暴力破解限速的22端口，并授权一个密钥。Docker也被锁住，容器不会意外暴露到外网。完整说明参见<a
+    href="/manual/security/"
+    >安全</a
+  >。
+</p>
+
+<h2 id="tailscale">
+  Tailscale<a
+    class="manual__heading-link"
+    href="#tailscale"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://tailscale.com/">Tailscale</a
+  >是一款网状VPN，让你通过互联网安全访问所有电脑和服务器变得极为简单。通过<em
+    >Install &gt; Service &gt; Tailscale</em
+  >安装。
+</p>
+
+<p>
+  安装后状态栏中会出现Tailscale面板，可以连接和断开tailnet、切换账户、选择出口节点——你自己的机器和Mullvad地区都在列表中。它还能浏览你的机器，Taildrop就在这里：选中一台机器，按<code>s</code>向它发送文件，按<code>c</code>、<code>n</code>、<code>d</code>复制其IP、名称或完整DNS名。终端中的对应命令是<code
+    >omarchy tailscale send &lt;machine&gt; [file...]</code
+  >，发给你的文件会自动存入<code>~/Downloads</code>。到达通知会一直等到你点击打开或关闭，所以你不在机器旁时收到的文件，回来后仍在等你处理。
+</p>
+
+<p>安装后还会添加一个Tailscale管理控制台的Web应用。</p>
+
+<h2 id="when-it-stops-working">
+  网络失灵时<a
+    class="manual__heading-link"
+    href="#when-it-stops-working"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  重启之前，先试着单独重启出问题的那一部分。<em>Update &gt; Hardware</em
+  >下有Wi-Fi、蓝牙、音频和触控板，重新加载其中一项就能解决大多数“五分钟前还好好的”情况。参见<a
+    href="/manual/troubleshooting/"
+    >故障排除</a
+  >。
+</p>

--- a/src/i18n/zh-CN/manual/notices.html
+++ b/src/i18n/zh-CN/manual/notices.html
@@ -1,0 +1,43 @@
+<p>通过快捷通知，可以随时查看日期时间、电池状态和当前天气。</p>
+
+<h3 id="date--time">
+  日期与时间<a
+    class="manual__heading-link"
+    href="#date--time"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p><code>Super + Ctrl + Alt + T</code></p>
+
+<p><img src="/manual/images/notice-datetime.webp" alt="notice-datetime" /></p>
+
+<h3 id="weather">
+  天气<a class="manual__heading-link" href="#weather" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p><code>Super + Ctrl + Alt + W</code></p>
+
+<p><img src="/manual/images/notice-weather.webp" alt="notice-weather" /></p>
+
+<p>
+  位置根据IP地址推断，通常足够准确，但并非总是如此。可以用<code
+    >omarchy weather location --set Malibu</code
+  >固定位置，或附上坐标以求精确：<code
+    >omarchy weather location --set Malibu 34.0259,-118.7798</code
+  >。单独运行<code>omarchy weather location</code
+  >可查看它认为你在哪里，<code>--clear</code>则恢复自动检测。
+</p>
+
+<h3 id="battery">
+  电池<a class="manual__heading-link" href="#battery" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p><code>Super + Ctrl + Alt + B</code></p>
+
+<p><img src="/manual/images/notice-battery.webp" alt="notice-battery" /></p>

--- a/src/i18n/zh-CN/manual/omarchy-cli.html
+++ b/src/i18n/zh-CN/manual/omarchy-cli.html
@@ -1,0 +1,80 @@
+<p>
+  Omarchy通常通过快捷键和Omarchy菜单（<code>Super + Space</code
+  >）操作，但也可以通过<code>omarchy</code>命令行工具控制。让AI智能体协助你做定制或配置时，这尤其方便。
+</p>
+
+<p>
+  命令行工具可以访问所有内部工具，无论它们平时是通过菜单还是其他方式使用。在终端运行<code>omarchy</code>即可看到全部可用内容。
+</p>
+
+<p>大致是这样：</p>
+
+<pre><code>~ ❯ omarchy
+Omarchy command center
+
+Usage:
+  omarchy &lt;command&gt; [args...]
+  omarchy commands [--all] [--json] [--check]
+  omarchy &lt;group&gt; --help
+  omarchy &lt;group&gt; &lt;command&gt; --help
+
+Common commands:
+  omarchy update              Update Omarchy and system packages
+  omarchy theme list          List available themes
+  omarchy theme set &lt;name&gt;    Apply a theme
+  omarchy font list           List available fonts
+  omarchy screenshot          Take a screenshot
+  omarchy debug               Print debugging information
+
+Groups:
+  agent          AI coding agent usage data
+  audio          Audio input and output controls
+  bar            Omarchy shell bar layout and settings
+  battery        Battery status helpers
+  bluetooth      Bluetooth device controls
+  branch         Omarchy git branch management
+  branding       About and screensaver branding
+  brightness     Display and keyboard brightness
+  capture        Screenshots and screen recording
+  channel        Omarchy release channel management
+  clipboard      Clipboard helpers
+  cmd            Command and shortcut helpers
+  config         System configuration helpers
+  debug          Diagnostics and support logs
+  ...
+</code></pre>
+
+<p>每个分组都可以继续深入：</p>
+
+<pre><code>~ ❯ omarchy capture
+Capture commands - Screenshots and screen recording:
+  omarchy capture qr                                                                                                                                                                                                       Decode a QR code from a screenshot region
+  omarchy capture screenrecording [--fullscreen] [--with-desktop-audio] [--with-microphone-audio] [--with-webcam] [--webcam-device=&lt;device&gt;] [--webcam-size=&lt;small|medium|large&gt;] [--resolution=&lt;size&gt;] [--stop-recording]  Start or stop screen recording
+  omarchy capture screenrecording with webcam                                                                                                                                                                              Pick a webcam and start a screen recording with it
+  omarchy capture screenshot [smart|region|windows|fullscreen] [slurp|copy|save] [--editor=&lt;name&gt;]                                                                                                                         Take a screenshot
+  omarchy capture text                                                                                                                                                                                                     Extract text from a screenshot region with OCR
+  omarchy capture webcam resize &lt;smaller|larger|reset|small|medium|large&gt;                                                                                                                                                  Resize the active webcam recording overlay
+</code></pre>
+
+<p>
+  每条命令也都接受<code>--help</code>，无论针对整个分组（<code
+    >omarchy capture --help</code
+  >）还是单条命令（<code>omarchy capture screenshot --help</code>）。
+</p>
+
+<h3 id="opening-the-menu-from-the-terminal">
+  从终端打开菜单<a
+    class="manual__heading-link"
+    href="#opening-the-menu-from-the-terminal"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy菜单同样可以用脚本控制，适合自定义键绑定。<code>omarchy menu</code
+  >从根节点打开菜单；按名称可以直接跳到树中的任意位置：<code
+    >omarchy menu summon style.theme</code
+  >直达主题选择器，<code>omarchy menu toggle system</code
+  >打开系统菜单（已打开则关闭），<code>omarchy menu close</code>将其收起。
+</p>

--- a/src/i18n/zh-CN/manual/omarchy-on.html
+++ b/src/i18n/zh-CN/manual/omarchy-on.html
@@ -1,0 +1,108 @@
+<h3 id="apple-m1m2-chips">
+  Apple M1/M2芯片<a
+    class="manual__heading-link"
+    href="#apple-m1m2-chips"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <a href="https://asahi-alarm.org/">Asahi Alarm</a>是基于<a
+    href="https://asahilinux.org/"
+    >Asahi Linux</a
+  >为Apple M1/M2电脑构建的Arch版本。花些功夫可以在它之上运行Omarchy，参见<a
+    href="https://github.com/omarchy-mac/omarchy-mac"
+    >用户编写的指南</a
+  >。
+</p>
+
+<h3 id="apple-virtual-machine">
+  Apple虚拟机<a
+    class="manual__heading-link"
+    href="#apple-virtual-machine"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  也可以在Parallels虚拟机中安装Omarchy。过程相当繁琐，但同样有<a
+    href="https://github.com/basecamp/omarchy/discussions/452"
+    >用户编写的指南</a
+  >。
+</p>
+
+<h3 id="virtualbox">
+  VirtualBox<a
+    class="manual__heading-link"
+    href="#virtualbox"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  VirtualBox是流行的虚拟机软件，<a
+    href="https://github.com/basecamp/omarchy/discussions/176"
+    >Omarchy也能在其中运行</a
+  >，只是性能大概不会太好。
+</p>
+
+<h3 id="vmware-workstation-on-windows-11">
+  Windows 11上的VMware Workstation<a
+    class="manual__heading-link"
+    href="#vmware-workstation-on-windows-11"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  另一款流行的Windows虚拟机软件，<a
+    href="https://github.com/basecamp/omarchy/discussions/572"
+    >Omarchy也已在其中成功配置</a
+  >。
+</p>
+
+<h3 id="steam-deck">
+  Steam Deck<a
+    class="manual__heading-link"
+    href="#steam-deck"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Steam Deck运行的是Arch，这意味着你可以在Steam Deck上运行Omarchy。Altynbek
+  Orumbayev提供了<a href="https://github.com/aorumbayev/deckarchy"
+    >完整的安装脚本和说明</a
+  >。太酷了！
+</p>
+
+<h3 id="nixos">
+  NixOS<a class="manual__heading-link" href="#nixos" aria-label="本节链接">#</a>
+</h3>
+
+<p>
+  Omarchy本质上是Arch + Hyprland，但Henry Sipp把<a
+    href="https://github.com/henrysipp/omarchy-nix"
+    >这套配置的精髓移植到了NixOS</a
+  >。如果你已经入了nix的坑，这是个不错的起点。它未必能一直跟上Omarchy的最新变化，但依然很酷！
+</p>
+
+<h3 id="something-else">
+  其他平台！<a
+    class="manual__heading-link"
+    href="#something-else"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  想在非默认的配置上运行Omarchy，请加入<a href="https://discord.gg/tXFUdasqhY"
+    >社区Discord</a
+  >的 #omarchy-on-other频道。
+</p>

--- a/src/i18n/zh-CN/manual/other-packages.html
+++ b/src/i18n/zh-CN/manual/other-packages.html
@@ -1,0 +1,24 @@
+<p>
+  Arch在官方仓库和Arch用户仓库（AUR）中拥有极为丰富的软件包，几乎涵盖各类软件。
+</p>
+
+<p>
+  两者用起来都再简单不过。要安装Arch软件包，进入Omarchy菜单（<code
+    >Super + Space</code
+  >）的<em>Install &gt; Package</em
+  >，输入软件包名称，它会自动模糊筛选全部软件包列表。（也可以在终端手动运行<code
+    >omarchy pkg add [package]</code
+  >。）
+</p>
+
+<p>
+  AUR同理，使用<em>Install &gt; AUR</em
+  >即可。只需记住，AUR未经Arch团队审核，就像RubyGems或npm——任何人都可以上传。
+</p>
+
+<p>
+  要移除软件包，使用Omarchy菜单的<em>Remove &gt; Package</em
+  >，它会一并移除软件包、配置文件和依赖。（也可以手动运行<code
+    >omarchy pkg drop [package]</code
+  >。）
+</p>

--- a/src/i18n/zh-CN/manual/prompt.html
+++ b/src/i18n/zh-CN/manual/prompt.html
@@ -1,0 +1,13 @@
+<p>
+  Omarchy默认内置一个极简的<a href="https://starship.rs/">Starship</a
+  >提示符。我喜欢把提示符保持成这样：不需要显示用户，因为永远是我；不需要显示时间，因为它一直在屏幕顶部。
+</p>
+
+<p><img src="/manual/images/prompt.webp" alt="prompt" /></p>
+
+<p>
+  想要更多信息或样式，可以修改<code>~/.config/starship.toml</code>中的<a
+    href="https://starship.rs/"
+    >Starship.rs</a
+  >配置。能做的事很多，只是别太过火（或者过火也行，随你，这是你的电脑！）
+</p>

--- a/src/i18n/zh-CN/manual/reminders.html
+++ b/src/i18n/zh-CN/manual/reminders.html
@@ -1,0 +1,10 @@
+<p>
+  Omarchy内置了简单的提醒功能：设定倒计时，附上一条消息。按<code
+    >Super + Ctrl + R</code
+  >设置提醒，<code>Super + Ctrl + Alt + R</code>查看全部提醒，<code
+    >Super + Ctrl + Shift + R</code
+  >清除全部。这些也都可以在<em>Trigger &gt; Reminder</em
+  >中操作，或者使用命令行：<code>omarchy reminder 7 'Tea ready'</code>。
+</p>
+
+<p><img src="/manual/images/reminders.webp" alt="reminders" /></p>

--- a/src/i18n/zh-CN/manual/screenshots-recording.html
+++ b/src/i18n/zh-CN/manual/screenshots-recording.html
@@ -1,0 +1,263 @@
+<p>
+  所有能从屏幕上抓取的东西都挂在Print
+  Screen键上：单独按下是截图，配合修饰键则是录屏、取色或提取区域内的文字。如果键盘没有Print
+  Screen键，<code>Super + Ctrl + C</code>会以菜单形式打开同一组功能。
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Print Screen</code></td>
+      <td>截图</td>
+    </tr>
+    <tr>
+      <td><code>Alt + Print Screen</code></td>
+      <td>录屏（或停止正在进行的录屏）</td>
+    </tr>
+    <tr>
+      <td><code>Super + Print Screen</code></td>
+      <td>取色器</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Print Screen</code></td>
+      <td>从区域提取文字</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + C</code></td>
+      <td>捕获菜单</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + .</code></td>
+      <td>转码图片或视频</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="screenshots">
+  截图<a class="manual__heading-link" href="#screenshots" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  按下<code>Print Screen</code
+  >，屏幕随即冻结，瞄准时不会有任何东西移动。拖出方框可自由框选；只点一下，则截图会吸附到你点中的矩形——点中窗口就是窗口，点中状态栏或空隙就是整个显示器。改主意了？再按一次<code
+    >Print Screen</code
+  >即可取消。
+</p>
+
+<p>
+  结果同时去往两处：图片目录中的一个PNG，以及剪贴板，所以可以用<code
+    >Super + V</code
+  >直接粘贴到聊天窗口。随后会弹出带缩略图的通知，点击它（或按<code
+    >Super + Alt + ,</code
+  >调出最近一条通知），截图会在标注编辑器Tensaku中打开，发送前可以画上箭头和方框。
+</p>
+
+<p>
+  文件默认保存在<code>~/Pictures</code>，命名类似<code>screenshot-2026-08-13_14-22-05.png</code>。如果希望单独放在一个文件夹，设置<code>OMARCHY_SCREENSHOT_DIR</code>——会话环境变量放在哪里参见<a
+    href="/manual/faq/"
+    >常见问题</a
+  >。目录不存在时Omarchy会自动创建。编辑器也可以用<code>OMARCHY_SCREENSHOT_EDITOR</code>更换。
+</p>
+
+<p>
+  在终端中，<code>omarchy screenshot</code
+  >拍摄同样的截图，还可以更明确地指定：<code
+    >omarchy capture screenshot region</code
+  >仅自由框选，<code>windows</code>吸附到窗口和显示器矩形，<code>fullscreen</code>跳过选择器直接抓取当前聚焦的显示器。第二个参数<code>copy</code>只把截图放到剪贴板，<code>save</code>只保存到磁盘。
+</p>
+
+<h3 id="driving-the-picker-from-the-keyboard">
+  用键盘操作选择器<a
+    class="manual__heading-link"
+    href="#driving-the-picker-from-the-keyboard"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>选择界面显示期间，完全可以不用鼠标：</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>按键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Return</code></td>
+      <td>捕获高亮的窗口</td>
+    </tr>
+    <tr>
+      <td><code>Ctrl + Return</code></td>
+      <td>捕获整个屏幕</td>
+    </tr>
+    <tr>
+      <td><code>Tab</code> / <code>Ctrl + Tab</code></td>
+      <td>高亮下一个/上一个窗口</td>
+    </tr>
+    <tr>
+      <td>方向键</td>
+      <td>高亮该方向的窗口</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  方向键和Tab会把光标移到所选窗口上，高亮随之跟进，你能看清即将捕获的内容。这些绑定仅在选择界面显示时存在，不会与你自己的配置冲突。
+</p>
+
+<h2 id="screen-recording">
+  录屏<a
+    class="manual__heading-link"
+    href="#screen-recording"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <code>Alt + Print Screen</code>打开<em
+    >Trigger &gt; Capture &gt; Screenrecord</em
+  >，它会询问音轨内容：无音频、桌面音频、桌面加麦克风，或桌面加麦克风加摄像头。最后一项仅在确实接入了摄像头时才出现。选定后会得到与截图相同的选择器：拖出区域，或点击窗口或显示器。
+</p>
+
+<p>
+  录制由gpu-screen-recorder完成，它在GPU上以60fps编码，必要时回退到CPU。结果是<code>~/Videos</code>中的一个MP4，命名类似<code>screenrecording-2026-08-13_14-22-05.mp4</code>。设置<code>OMARCHY_SCREENRECORD_DIR</code>可以更改——但与截图目录不同，这个目录必须已经存在，否则录制会拒绝开始。
+</p>
+
+<p>
+  录制期间，状态栏上会出现一个小指示器，点击即可停止。也可以再按一次<code
+    >Alt + Print Screen</code
+  >，或使用<em>Trigger &gt; Capture &gt; Screenrecord</em>下的<em
+    >Stop Screenrecording</em
+  >，该条目仅在确实有录制进行时才出现。
+</p>
+
+<p>
+  停止后会先做一点整理再把文件交给你：裁掉第一帧，如果有音频则归一化到 -14
+  LUFS，并将开头PipeWire采集的爆音消除。随后会出现一条带录像缩略图的通知，点击即可用mpv播放。
+</p>
+
+<h3 id="the-webcam-overlay">
+  摄像头画面<a
+    class="manual__heading-link"
+    href="#the-webcam-overlay"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  带摄像头录制时，摄像头画面会以固定的竖版裁剪窗口出现在录制区域右下角。如果它挡住了需要的内容，可以随时调整大小：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>功能</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Alt + [</code></td>
+      <td>缩小摄像头画面</td>
+    </tr>
+    <tr>
+      <td><code>Super + Alt + ]</code></td>
+      <td>放大摄像头画面</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  共有小、中、大三种尺寸，快捷键在其间切换，默认为中。尺寸与录制画面成比例，无论录制的是1080p还是6K显示器，摄像头在画面中的占比都相同。如果录制的是一个区域而非整个显示器，画面会固定在该区域而非显示器的角落，始终保持在录制范围内。
+</p>
+
+<p>
+  也可以直接调用<code>omarchy-capture-webcam-resize small</code
+  >，或用<code>reset</code>恢复为中等尺寸。
+</p>
+
+<h2 id="text-qr-codes-and-colours">
+  文字、二维码与颜色<a
+    class="manual__heading-link"
+    href="#text-qr-codes-and-colours"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <code>Super + Ctrl + Print Screen</code>框选区域并将其OCR到剪贴板，详见<a
+    href="/manual/text-extraction-dictation/"
+    >文字提取与语音听写</a
+  >。
+</p>
+
+<p>
+  <em>Trigger &gt; Capture &gt; QR Code</em
+  >对二维码做同样的事：框选包含二维码的区域，解码结果进入剪贴板。它只识别二维码——否则密集的屏幕内容很容易被误判为条形码。值得一提的是，解码结果只进入剪贴板，不去任何其他地方：不会打印，不出现在通知中，而且标记为敏感内容，不会留在<a
+    href="/manual/unified-clipboard-history/"
+    >剪贴板历史</a
+  >里。二维码常常携带机密，比如2FA设置码背后的<code>otpauth://</code>
+  URI，你不会希望它出现在日志中。粘贴则照常可用。
+</p>
+
+<p>
+  <code>Super + Print Screen</code>（或<em>Trigger &gt; Capture &gt; Color</em
+  >）把光标变成吸管，点击屏幕上的任意位置，颜色值即进入剪贴板。再按一次快捷键可不取色直接退出。
+</p>
+
+<h2 id="transcoding-before-you-share">
+  分享前转码<a
+    class="manual__heading-link"
+    href="#transcoding-before-you-share"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  4K录屏或手机里的原始HEIC往往太大，无法直接发送。<code>Super + Ctrl + .</code
+  >（或<em>Trigger &gt; Transcode</em
+  >）解决这个问题：它提供一个覆盖<code>~/Pictures</code>和<code>~/Videos</code>的模糊文件选择器，然后询问格式和尺寸。
+</p>
+
+<p>
+  图片可转为jpg或png，分高、中、低三档，宽度分别限制在3160、2160和1080像素。视频可转为mp4或动态gif，分4k、1080p和720p三档。转换后的文件写在原文件旁边，文件名带有分辨率——如<code>demo-1080p.mp4</code>——路径以文件URI形式复制到剪贴板，可以直接粘贴到接受文件拖放的应用中。
+</p>
+
+<p>
+  如果已经知道想要什么，终端中同样可用：<code
+    >omarchy transcode ~/Videos/demo.mov mp4 1080p</code
+  >。此外还有<code>omarchy transcode ascii</code
+  >，可把图片转成ASCII艺术，主要用于<a href="/manual/branding/">品牌定制</a>。
+</p>
+
+<h2 id="sending-it-somewhere">
+  发送出去<a
+    class="manual__heading-link"
+    href="#sending-it-somewhere"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  拿到文件后，<code>Super + Ctrl + S</code
+  >打开分享菜单，通过LocalSend发送到网络中的另一台设备。参见<a
+    href="/manual/guis/"
+    >图形应用</a
+  >。
+</p>

--- a/src/i18n/zh-CN/manual/security.html
+++ b/src/i18n/zh-CN/manual/security.html
@@ -1,0 +1,112 @@
+<p>
+  Omarchy极其重视安全。它是一个能让你在<em>真实世界</em>中做<em>真实工作</em>的操作系统，丢失一台笔记本不该演变成安全事故。我们为此做了以下几件事：
+</p>
+
+<ol>
+  <li>
+    <em>全盘加密是强制的</em
+    >：这是保护数据物理安全最重要的一步。电脑丢失或被盗时，数据已用标准的LUKS（Linux
+    Unified Key Setup）完整加密。
+  </li>
+  <li>
+    <em>防火墙默认开启</em>：所有入站流量默认拦截，只有<a
+      href="https://localsend.org/"
+      >LocalSend</a
+    >的53317端口例外。连ssh也是关闭的，直到你通过<em
+      >Setup &gt; Security &gt; SSHD</em
+    >开启，设置过程会开放22端口（带暴力破解限速）。我们甚至用<a
+      href="https://github.com/chaifeng/ufw-docker"
+      >ufw-docker</a
+    >锁住Docker访问，防止容器意外暴露到外网。
+  </li>
+  <li>
+    <em>Arch始终拥有最新更新</em
+    >：Omarchy所基于的Arch是滚动发行版，任何软件包中发现并修复的安全漏洞，都能很快通过<code>omarchy-update</code>安装。你运行的永远是一切软件的最新、最安全版本。
+  </li>
+  <li>
+    <em>Omarchy维护自己的软件包和镜像</em
+    >：Omarchy默认只依赖Arch自己的core/extra/multilib仓库和Omarchy软件包仓库。你可以直接从AUR安装软件，但基础安装不会——只有少数可选安装项（如第三方浏览器）来自AUR。
+  </li>
+  <li>
+    <em>Cloudflare保护我们免受DDoS</em
+    >：Omarchy的全部分发基础设施——ISO、Omarchy软件包、Arch镜像——都在Cloudflare强大的DDoS防护之后，并托管在其CDN上。这提供了极佳的可用性。
+  </li>
+</ol>
+
+<h2 id="changing-your-passwords">
+  修改密码<a
+    class="manual__heading-link"
+    href="#changing-your-passwords"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  加密安装有两个密码：开机解锁驱动器的密码，以及登录和<code>sudo</code>用的密码。两者都可以在Omarchy菜单的<em
+    >Update &gt; Password</em
+  >下修改——<em>Drive Encryption</em
+  >对应前者，<em>User</em>对应后者。修改驱动器密码会先要求输入当前密码，请准备好。
+</p>
+
+<h2 id="passing-on-a-machine-youve-already-used">
+  转让用过的机器<a
+    class="manual__heading-link"
+    href="#passing-on-a-machine-youve-already-used"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  把机器交给别人时，不必重装。在Omarchy菜单中运行<em
+    >Setup &gt; Reset Computer</em
+  >，输入<code>reset</code>确认，然后重启。这会抹掉所有用户账户和<code>/home</code>中的一切，丢弃安装以来所做的全部软件包和系统改动，并清除机器身份——网络连接、主机密钥等等。重启后出现的是首次开机的设置向导，等待新主人输入自己的名字、密码和加密密码。
+</p>
+
+<p>
+  它通过恢复安装程序创建的基线快照来实现，所以只在从Omarchy
+  ISO安装的机器上可用。另外，在未加密的驱动器上，重置只是删除而非安全擦除，如果数据敏感，请改为全新安装。
+</p>
+
+<h2 id="passwordless-sudo">
+  免密码sudo<a
+    class="manual__heading-link"
+    href="#passwordless-sudo"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  有时你希望<code>sudo</code>别再问密码，最常见的是AI智能体在替你做一长串系统操作时。<em
+    >Setup &gt; Security &gt; Passwordless Sudo</em
+  >会关闭密码询问15分钟，然后自动恢复。计时结束前再次运行可提前结束；15分钟不够的话，用<code
+    >omarchy-sudo-passwordless 30</code
+  >指定自己的分钟数。
+</p>
+
+<p>
+  对这一点要保持清醒：开启期间，以你的用户身份运行的任何程序都能不经询问以root身份做任何事。这正是它的意义所在，也是它的全部风险。
+</p>
+
+<h2 id="signing-keys">
+  签名密钥<a
+    class="manual__heading-link"
+    href="#signing-keys"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  所有ISO签名和Omarchy仓库软件包的公钥是<code>40DFB630FF42BCFFB047046CF0134EE680CAC571</code>（<a
+    href="https://keys.openpgp.org/search?q=pkgs%40omarchy.org"
+    >在openpgp.org验证</a
+  >）。<code>omarchy/omarchy-keyring</code>软件包也包含该密钥，并将用于平滑推送可能的更新。
+</p>
+
+<p>
+  在任意ISO版本的URL后加上
+  .sig即可找到其签名，例如https://iso.omarchy.org/omarchy-x.x.x.iso.sig。
+</p>

--- a/src/i18n/zh-CN/manual/shell-functions.html
+++ b/src/i18n/zh-CN/manual/shell-functions.html
@@ -1,0 +1,140 @@
+<p>Omarchy内置了一组shell函数，用于简化常见任务、封装参数繁琐的调用。</p>
+
+<h2 id="compression">
+  压缩<a class="manual__heading-link" href="#compression" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<ul>
+  <li><code>compress [file/dir]</code>：将文件或目录打包为tar.gz。</li>
+  <li><code>decompress [file.tar.gz]</code>：解压tar.gz文件。</li>
+</ul>
+
+<h2 id="drives">
+  驱动器<a class="manual__heading-link" href="#drives" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<ul>
+  <li>
+    <code>iso2sd [image.iso]</code
+    >：用指定的iso文件在SD卡上创建可启动驱动器，交互式选择目标。
+  </li>
+  <li>
+    <code>format-drive [device] [name]</code
+    >：将整块磁盘格式化为单个exFAT分区（Windows和macOS也能读写）。不带参数运行可查看可用驱动器。请务必小心！
+  </li>
+</ul>
+
+<h2 id="dev-layouts">
+  开发布局<a
+    class="manual__heading-link"
+    href="#dev-layouts"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>tmux的即时多窗格开发布局：</p>
+
+<ul>
+  <li>
+    <code>tdl [ai]</code>：创建Tmux Dev
+    Layout，包含编辑器、AI智能体和终端。使用智能体别名，如<code>tdl c</code
+    >对应opencode，<code>tdl cx</code>对应Claude
+    Code；传入第二个智能体可同时运行两个，如<code>tdl c cx</code>。
+  </li>
+  <li>
+    <code>tds</code>：创建Tmux Dev Square，包含编辑器、diff监视（通过<code
+      >hunk diff --watch</code
+    >）、终端和opencode。
+  </li>
+  <li>
+    <code>tdlm [ai]</code
+    >：为当前目录下的每个子目录创建一个<code>tdl</code>窗口。
+  </li>
+  <li>
+    <code>tsl [count] [command]</code
+    >：创建一组网格平铺的窗格，全部运行同一条命令（非常适合AI智能体）。
+  </li>
+</ul>
+
+<p>
+  同样的布局在Herdr中对应<code>hdl</code>、<code>hds</code>、<code>hdlm</code>和<code>hsl</code>。
+</p>
+
+<h2 id="git-worktrees">
+  Git工作树<a
+    class="manual__heading-link"
+    href="#git-worktrees"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<ul>
+  <li>
+    <code>ga [branch]</code>：在当前仓库旁创建新的工作树和分支，并进入其中。
+  </li>
+  <li><code>gd</code>：删除当前工作树及其分支（会先要求确认）。</li>
+</ul>
+
+<h2 id="rsync-watchers">
+  Rsync监视器<a
+    class="manual__heading-link"
+    href="#rsync-watchers"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<ul>
+  <li>
+    <code>rsw [source] [destination]</code>：启动后台监视器，一有变动就把source
+    rsync到destination。目标可以是远程主机，如<code
+      >rsw ~/Work/app nyc-dev:Work/app</code
+    >。
+  </li>
+  <li><code>lsw</code>：列出所有活动的监视器。</li>
+  <li><code>dsw</code>：停止所有活动的监视器。</li>
+</ul>
+
+<h2 id="ssh-portforwarding">
+  SSH端口转发<a
+    class="manual__heading-link"
+    href="#ssh-portforwarding"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>适合面向远程机器做Web开发，同时享有localhost的安全上下文权限。</p>
+
+<ul>
+  <li><code>fip</code>：通过SSH将远程主机的一个或多个端口转发到localhost。</li>
+  <li><code>dip</code>：断开一个或多个已转发的端口。</li>
+  <li><code>lip</code>：列出所有活动的SSH端口转发。</li>
+</ul>
+
+<p>
+  假设你在一台可通过<code>nyc-dev</code>访问的机器上以<code>3000</code>端口启动了开发服务器，运行<code
+    >fip nyc-dev 3000</code
+  >转发该端口，<code>localhost:3000</code>实际访问的就是<code>nyc-dev:3000</code>，而且无需SSL证书就能获得测试web
+  socket等功能所需的安全上下文。
+</p>
+
+<h2 id="ssh-reconnection">
+  SSH自动重连<a
+    class="manual__heading-link"
+    href="#ssh-reconnection"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <code>ssh</code
+  >本身被包装在一个函数中：若远程的tmux、Herdr或编辑器占用终端时连接中断，它会清理终端；交互式会话掉线时会自动重连（Ctrl-C可停止重试）。
+</p>

--- a/src/i18n/zh-CN/manual/shell-plugins.html
+++ b/src/i18n/zh-CN/manual/shell-plugins.html
@@ -1,0 +1,221 @@
+<p>
+  Omarchy桌面运行在一个名为<code>omarchy-shell</code>的长期存活的Quickshell进程中，屏幕上看到的几乎一切都是它内部的插件。状态栏是插件，从状态栏下拉的面板、表情选择器和剪贴板管理器这类全屏叠层、Omarchy菜单本身、锁屏、polkit对话框，以及监控电池、在夜间调暖屏幕色温的无界面服务，也都是插件。
+</p>
+
+<p>
+  这不只是实现细节。它意味着你可以关闭桌面的某些部分、替换它们，或者自己写一个，而无需改动Omarchy的一行源码。
+</p>
+
+<p>
+  第一方插件随Omarchy一起发布，位于<code>$OMARCHY_PATH/shell/plugins/</code>。你自己添加的东西——自己的实验，或在GitHub上找到的插件——位于<code>~/.config/omarchy/plugins/</code>。两者在启动时以同样的方式被发现，唯一的区别是在磁盘上的位置。
+</p>
+
+<h2 id="seeing-what-you-have">
+  查看已有插件<a
+    class="manual__heading-link"
+    href="#seeing-what-you-have"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<pre><code>omarchy plugin list
+</code></pre>
+
+<p>
+  这会列出发现的每个插件及其id、是否启用、属于第一方还是第三方、类型和显示名称。要把结果交给其他程序处理，加上<code>--json</code>。
+</p>
+
+<p>
+  插件id带有命名空间。内置插件都以<code>omarchy.</code>开头——<code>omarchy.clock</code>、<code>omarchy.network</code>、<code>omarchy.notifications</code>——这个命名空间是保留的，第三方插件永远无法占用。
+</p>
+
+<h2 id="turning-them-on-and-off">
+  启用与禁用<a
+    class="manual__heading-link"
+    href="#turning-them-on-and-off"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<pre><code>omarchy plugin enable omarchy.tailscale
+omarchy plugin disable omarchy.weather
+</code></pre>
+
+<p>
+  也可以使用菜单：<em>Setup &gt; Plugins</em
+  >下有Enable、Disable、Add、Clone和Remove，每一项都带一个选择器，只列出对该操作有意义的插件。
+</p>
+
+<p>
+  启用状态保存在<code>~/.config/omarchy/shell.json</code>中，两类插件的规则略有不同。第三方插件只要其id出现在该文件的任何位置——状态栏布局条目、<code>plugins[]</code>中的条目，或<code>bar.id</code>——就处于启用状态。非状态栏部件的第一方插件则相反：它们默认开启，只有列入<code>disabledPlugins[]</code>才会关闭。
+</p>
+
+<p>
+  完整的状态栏插件根本没有关闭状态。状态栏永远有且只有一个，所以替换它的方式是启用另一个。状态栏部件的摆放参见<a
+    href="/manual/the-top-bar/"
+    >状态栏</a
+  >。
+</p>
+
+<h2 id="adding-a-plugin-from-git">
+  从git添加插件<a
+    class="manual__heading-link"
+    href="#adding-a-plugin-from-git"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>第三方插件就是一个根目录带有<code>manifest.json</code>的git仓库。</p>
+
+<pre><code>omarchy plugin add https://github.com/acme/omarchy-weather.git --enable
+</code></pre>
+
+<p>
+  在做任何事情之前，它会明确告诉你：插件是在你长期存活的shell进程内运行的任意代码，没有沙箱；然后显示URL并请你确认。请认真对待这一点。插件不是配置文件——它是与会话同寿的代码，能触及你的用户账户所能触及的一切。只添加你愿意运行的仓库，启用之前先读一读代码。
+</p>
+
+<p>
+  随后它把仓库克隆到暂存目录，验证清单，若已有其他插件占用该id则拒绝安装，最后移入<code>~/.config/omarchy/plugins/&lt;id&gt;/</code>。不带<code>--enable</code>时，它会问你是否现在就启用，你可以拒绝，先去读代码。整个过程它不会运行插件中的任何东西，不执行安装钩子，也不要求sudo——只是克隆文件、检查清单，并通过IPC切换一个开关。
+</p>
+
+<p>更新就是对同一份检出做一次快进拉取：</p>
+
+<pre><code>omarchy plugin update acme.weather
+omarchy plugin update
+</code></pre>
+
+<p>
+  不带id时会更新你所有由git管理的插件。应用前会显示diff；若本地修改无法快进则拒绝更新；新版本验证失败时会回滚。
+</p>
+
+<pre><code>omarchy plugin remove acme.weather
+</code></pre>
+
+<p>
+  移除会先禁用插件，然后：git检出则直接删除（仓库仍在上游），符号链接则取消链接。没有git仓库的手工插件目录不会被直接删除，而是移到插件目录内一个带时间戳的备份中。
+</p>
+
+<h2 id="cloning-a-built-in-to-modify-it">
+  克隆内置插件来修改<a
+    class="manual__heading-link"
+    href="#cloning-a-built-in-to-modify-it"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  这是我最喜欢的部分。想改变某个内置部件的行为，不要编辑<code>$OMARCHY_PATH</code>下的文件——它们属于软件包，下次更新就会被覆盖。改为克隆它：
+</p>
+
+<pre><code>omarchy plugin clone omarchy.clock
+</code></pre>
+
+<p>
+  这会把整个插件复制到<code>~/.config/omarchy/plugins/dhh.clock</code>（前缀是你的用户名，不是我的），重命名为“My
+  Clock”，启用它，并让shell从内置版本切换到你的副本——同时保留已有状态栏部件的位置和设置。加上<code>--edit</code>会立即在<code>$EDITOR</code>中打开新目录，菜单中的<em
+    >Setup &gt; Plugins &gt; Clone Plugin</em
+  >做的就是这件事。
+</p>
+
+<p>
+  用户名前缀让克隆的id归你所有，分享出去也不会与他人冲突。对原始内置id的调用会被路由到你的克隆，所以引用<code>omarchy.clock</code>的地方都无需更新。要是改乱了，<code
+    >omarchy plugin remove dhh.clock</code
+  >就能恢复内置版本。
+</p>
+
+<p>
+  在<code>~/.config/omarchy/plugins/</code>下任何位置保存文件都会自动重新加载插件代码，所以可以让编辑器一直开着，看着修改即时生效。
+</p>
+
+<h2 id="writing-your-own">
+  编写自己的插件<a
+    class="manual__heading-link"
+    href="#writing-your-own"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  插件是一个包含<code>manifest.json</code>和若干QML的目录。清单声明<code
+    >schemaVersion: 1</code
+  >、<code>id</code>、<code>name</code>、<code>version</code>、一个或多个<code>kinds</code>，以及一个<code>entryPoints</code>对象，为每种类型指向对应的QML文件：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>类型</th>
+      <th>说明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>bar-widget</code></td>
+      <td>当前状态栏可以放入某个区域的组件</td>
+    </tr>
+    <tr>
+      <td><code>panel</code></td>
+      <td>常驻或按需召唤的浮动窗口</td>
+    </tr>
+    <tr>
+      <td><code>overlay</code></td>
+      <td>全屏叠层</td>
+    </tr>
+    <tr>
+      <td><code>menu</code></td>
+      <td>按需召唤的菜单界面</td>
+    </tr>
+    <tr>
+      <td><code>service</code></td>
+      <td>没有界面的无头单例</td>
+    </tr>
+    <tr>
+      <td><code>bar</code></td>
+      <td>替换内置状态栏的完整状态栏</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  一个插件可以同时声明多种类型——媒体插件既是<code>service</code>也是<code>bar-widget</code>。状态栏部件还有一个额外的<code>barWidget</code>块，包含显示名称、分类、可选的<code>defaultSection</code>，以及<code>allowMultiple</code>，用于说明状态栏上放多个是否合理。大多数部件设为<code>false</code>，间隔符和指示器设为<code>true</code>。
+</p>
+
+<p>发布之前，先检查一下：</p>
+
+<pre><code>omarchy plugin validate ./my-plugin
+</code></pre>
+
+<p>
+  这会运行与shell加载时相同的检查：schema版本、必填字段、id未被保留、入口点是安全的相对路径且确实存在、每种声明的类型都有入口点，以及目录内不含任何符号链接。
+</p>
+
+<p>
+  要了解全貌，源码就是文档：Omarchy仓库中的<code>shell/README.md</code>讲解清单schema、shell的IPC契约和<code>shell.json</code>的确切结构；<code>shell/plugins/README.md</code>列出每个第一方插件的id、类型和入口点。
+</p>
+
+<h2 id="sharing-yours-with-the-world">
+  与世界分享<a
+    class="manual__heading-link"
+    href="#sharing-yours-with-the-world"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  做出满意的作品后，放进一个公开的git仓库。这就是全部的分发机制——任何人都能用你的URL运行<code
+    >omarchy plugin add</code
+  >，几秒钟内就能跑起来。
+</p>
+
+<p>
+  为了让大家真正找到它，请在<a href="https://plugins.omarchy.org"
+    >omarchyplugins.com</a
+  >登记。那是Omarchy
+  shell插件的社区目录，也是你在动手之前，查看是否有人已经做了同样部件的第一站。开始之前先去逛逛！
+</p>

--- a/src/i18n/zh-CN/manual/shell-tools.html
+++ b/src/i18n/zh-CN/manual/shell-tools.html
@@ -1,0 +1,122 @@
+<p>
+  除了标准的Linux工具，Omarchy还内置了一批增强版shell工具。以下是其中的重点。
+</p>
+
+<h2 id="fzf">
+  fzf<a class="manual__heading-link" href="#fzf" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://junegunn.github.io/fzf/">fzf</a
+  >通过<code>ff</code>别名提供文件模糊查找。进入任意目录，输入<code>ff</code>，就能模糊查找该目录树下的任何文件，右侧同时显示候选文件的预览。
+</p>
+
+<p><code>Ctrl + R</code>则用fzf模糊查找命令历史。</p>
+
+<p>在Neovim中输入<code>Space Space</code>时，用的也是这个工具。</p>
+
+<p>完整手册见<code>man fzf</code>。</p>
+
+<h2 id="zoxide">
+  Zoxide<a class="manual__heading-link" href="#zoxide" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/ajeetdsouza/zoxide">Zoxide</a
+  >是cd的替代品。它记住你去过的目录，下次跳转更省事。比如<code
+    >cd ~/.config/omarchy</code
+  >一次之后，下次只需<code>cd omarchy</code>（甚至<code>cd oma</code
+  >），Zoxide就会直接带你过去。
+</p>
+
+<p>完整手册见<code>man zoxide</code>。</p>
+
+<h2 id="ripgrep">
+  ripgrep<a class="manual__heading-link" href="#ripgrep" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/BurntSushi/ripgrep">ripgrep</a>通过<code
+    >rg &lt;pattern&gt; &lt;path&gt;</code
+  >搜索文件内容，例如<code>rg Controller app/</code
+  >会找出app目录中所有提到<code>Controller</code>的地方。
+</p>
+
+<p>在Neovim中输入<code>Space S G</code>时，用的也是这个工具。</p>
+
+<p>完整手册见<code>man rg</code>。</p>
+
+<h2 id="eza">
+  eza<a class="manual__heading-link" href="#eza" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://eza.rocks/">eza</a
+  >是ls的替代品，提供信息更丰富、带颜色和图标的目录列表。默认已将eza设为ls的别名。<code>lt</code>显示两层嵌套的列表，<code>lsa</code>显示包含隐藏文件的列表，<code>lta</code>则是包含隐藏文件的嵌套列表。
+</p>
+
+<p>完整手册见<code>man eza</code>。</p>
+
+<h2 id="fd">
+  fd<a class="manual__heading-link" href="#fd" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://github.com/sharkdp/fd">fd</a
+  >是更易用的<code>find</code>替代品。<code>fd person.rb</code
+  >在当前目录树中查找名为<code>person.rb</code>的文件；<code
+    >fd person.rb /</code
+  >搜索整个文件系统；<code>fd person.rb / -H</code
+  >搜索整个文件系统并包含隐藏目录。
+</p>
+
+<p>完整手册见<code>man fd</code>。</p>
+
+<h2 id="bat">
+  bat<a class="manual__heading-link" href="#bat" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://github.com/sharkdp/bat">bat</a
+  >是带语法高亮、行号和分页的<code>cat</code>。运行<code>bat somefile.rb</code
+  >，你就明白为什么再也回不去了。它还在别处默默工作：man页面的上色和<code>ff</code>中的预览，都出自它手。
+</p>
+
+<p>完整手册见<code>man bat</code>。</p>
+
+<h2 id="tldr">
+  tldr<a class="manual__heading-link" href="#tldr" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://tldr.sh/">tldr</a
+  >是那些先讲三屏历史才给一个示例的man页面的解药。<code>tldr tar</code
+  >直接给出你真正需要的几种用法。
+</p>
+
+<h2 id="yt-dlp">
+  yt-dlp<a class="manual__heading-link" href="#yt-dlp" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/yt-dlp/yt-dlp">yt-dlp</a
+  >可从YouTube及数百个其他网站下载视频。<code>yt-dlp &lt;url&gt;</code
+  >会把可用的最高画质下载到当前目录。
+</p>
+
+<p>完整手册见<code>man yt-dlp</code>。</p>
+
+<h2 id="try">
+  try<a class="manual__heading-link" href="#try" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://github.com/tobi/try">try</a
+  >用带日期戳的目录轻松管理编程实验。所有实验都存放在<code>~/Work/tries</code>，通过<code>try</code>访问。
+</p>

--- a/src/i18n/zh-CN/manual/system-sleep.html
+++ b/src/i18n/zh-CN/manual/system-sleep.html
@@ -1,0 +1,60 @@
+<p>
+  Omarchy默认启用挂起和休眠，但如果其中任何一项在你的机器上有问题，可以把它关掉。
+</p>
+
+<h3 id="power-profiles">
+  电源配置<a
+    class="manual__heading-link"
+    href="#power-profiles"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在笔记本上，Omarchy会分别记住接通电源和使用电池时的电源配置，并随插拔自动切换。开箱即用的默认值是：接电源时性能模式，用电池时平衡模式。
+</p>
+
+<p>
+  用<code>omarchy powerprofiles list</code>查看机器支持的配置，用<code
+    >omarchy powerprofiles set autodetect power-saver</code
+  >为当前所处状态设置想要的配置。要在不插拔电源的情况下设置另一种状态，直接点名：<code
+    >omarchy powerprofiles set battery power-saver</code
+  >。无论选了什么，下次进入该状态时都会恢复。
+</p>
+
+<h3 id="toggle-suspend">
+  开关挂起<a
+    class="manual__heading-link"
+    href="#toggle-suspend"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在终端运行<code>omarchy toggle suspend</code
+  >开关挂起。它只是显示或隐藏<em>System</em>（或<code>Super + Esc</code
+  >）下的对应选项，你可以借此观察挂起在你的系统上是否稳定可用。如果不行，用同一条命令再把它隐藏起来。
+</p>
+
+<h3 id="toggle-hibernation">
+  开关休眠<a
+    class="manual__heading-link"
+    href="#toggle-hibernation"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在终端运行<code>omarchy hibernation setup</code
+  >设置休眠。休眠会在启动盘上创建一个与物理内存等大的/swap子卷，所以请确保有充足的剩余空间。32GB内存的机器需要始终为这个卷保留32GB以上的空闲空间。休眠还要求使用默认的Limine启动加载器。
+</p>
+
+<p>
+  设置完成后，<em>System</em>（或<code>Super + Esc</code
+  >）下会出现休眠选项，你可以观察它在你的系统上是否稳定可用。如果不行，运行<code
+    >omarchy hibernation remove</code
+  >移除。
+</p>

--- a/src/i18n/zh-CN/manual/system-snapshots.html
+++ b/src/i18n/zh-CN/manual/system-snapshots.html
@@ -1,0 +1,67 @@
+<p>
+  每次Omarchy更新都会自动创建快照，想自己创建的话，用<code
+    >omarchy-snapshot create</code
+  >。
+</p>
+
+<p>
+  要启动并恢复快照，在Limine启动加载器中选择它。（如果当前是直接进入Omarchy解密界面，需要先在BIOS中把Limine选为启动项。）
+</p>
+
+<p>
+  在该界面中根据日期和版本选择要启动的快照。快照创建时的Omarchy版本显示在左下角。
+</p>
+
+<p>
+  <img
+    src="/manual/images/snapshots-bootloader.webp"
+    alt="snapshots-bootloader"
+  />
+</p>
+
+<p>
+  进入系统后会弹出通知，提示你正处于可启动的快照中，点击即开始恢复。也可以使用<code
+    >omarchy-snapshot restore</code
+  >。
+</p>
+
+<p>
+  <img src="/manual/images/snapshots-restore.webp" alt="snapshots-restore" />
+</p>
+
+<p>
+  这会恢复根文件系统，但不包括<code>/home</code>。所以它适合撤销出问题的系统更新，不适合找回丢失的个人文件。
+</p>
+
+<p>
+  这也意味着<code>~/.config</code>目录保持原样。如果回滚到的库或应用的旧版本使用了新格式的配置文件，就需要手动处理。
+</p>
+
+<p>
+  <em
+    >注意：此功能仅在使用Limine启动加载器的安装上可用，Omarchy
+    2.0起它已是默认选择。GRUB或systemd-boot上不可用。</em
+  >
+</p>
+
+<h3 id="skipping-the-boot-menu">
+  跳过启动菜单<a
+    class="manual__heading-link"
+    href="#skipping-the-boot-menu"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  如果从不碰启动菜单，只想让机器直接进入解密界面，在Omarchy菜单中运行<em
+    >Setup &gt; Direct Boot</em
+  >。它会添加一个直接指向Omarchy的EFI条目，固件不经Limine直接启动。
+</p>
+
+<p>
+  代价就是开头提到的那一点：开启直接启动后，要进入快照得先在BIOS启动菜单中选择Limine。再次运行<em
+    >Setup &gt; Direct Boot</em
+  >可移除该条目，恢复经由Limine启动。有些固件对自定义EFI条目不太友好，所以该设置在American
+  Megatrends和Apple固件上会拒绝运行。
+</p>

--- a/src/i18n/zh-CN/manual/terminal.html
+++ b/src/i18n/zh-CN/manual/terminal.html
@@ -1,0 +1,89 @@
+<p>
+  <a href="https://codeberg.org/dnkl/foot">Foot</a
+  >是Omarchy的默认终端。它快速、轻巧，连老电脑也能胜任，但不支持原生标签页和分屏。
+</p>
+
+<p>
+  如果你用Tmux，可能并不在意；如果不用，我们也完整支持<em>Alacritty</em>、<em>Ghostty</em>和<em>Kitty</em>作为备选。在Omarchy菜单的<em
+    >Install &gt; Terminal</em
+  >下选择你偏好的终端即可。
+</p>
+
+<p>
+  用<code>Super + Return</code>启动新终端。（这个绑定会自动指向你通过<em
+    >Install &gt; Terminal</em
+  >安装的终端，也可以在<em>Setup &gt; Defaults &gt; Terminal</em
+  >下在已安装的终端之间切换。）
+</p>
+
+<h2 id="tmux">
+  Tmux<a class="manual__heading-link" href="#tmux" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  Tmux为窗格、窗口（即标签页）和可恢复的会话提供了一致、可编程的界面，与所用终端无关。它在远程主机上同样可用，SSH到服务器时也能沿用同一套方式。
+</p>
+
+<p>
+  用<code>Super + Alt + Return</code
+  >在新终端中启动Tmux会话。由于Tmux是常驻进程，即使关闭了终端也能恢复会话：按<code
+    >Ctrl + Space</code
+  >（即前缀键）再按<code>s</code>，即可查看所有活动会话。
+</p>
+
+<p>
+  Omarchy自带一套经过人体工学优化的Tmux配置，键绑定不少，建议把<a
+    href="/manual/hotkeys/#tmux"
+    >速查表</a
+  >放在手边。
+</p>
+
+<h2 id="tmux-layout-functions">
+  Tmux布局函数<a
+    class="manual__heading-link"
+    href="#tmux-layout-functions"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  因为Tmux可编程，我们可以用函数创建布局。Omarchy内置四个函数，对应常见的开发者布局。
+</p>
+
+<p>
+  <code>tdl [agent]</code
+  >启动一个三分的IDE式界面：左侧是<code>$EDITOR</code>，右侧是你选定的AI智能体（如<code>c</code>代表opencode，<code>cx</code>代表Claude，<code>codex</code>代表OpenAI），底部是终端。
+</p>
+
+<p>所以<code>tdl c</code>会启动这样的布局（或者直接用<code>ic</code>）：</p>
+
+<p><img src="/manual/images/tmux-tdl.webp" alt="tmux-tdl" /></p>
+
+<p>
+  还可以用<code>tdl c cx</code>同时启动第二个智能体（opencode +
+  claude）（或直接用<code>icx</code>）：
+</p>
+
+<p><img src="/manual/images/tmux-tdl2.webp" alt="tmux-tdl2" /></p>
+
+<p>
+  另有<code>tds</code>，启动一个四格布局：左上编辑器，右上实时diff监视，左下终端，右下opencode。
+</p>
+
+<p>
+  用<code>tdlm [agent]</code
+  >可以为当前目录下的每个子目录启动这套布局，然后用<code
+    >alt + 1/2/3/4/5/...</code
+  >切换：
+</p>
+
+<p><img src="/manual/images/tmux-tdlm.webp" alt="tmux-tdlm" /></p>
+
+<p>
+  最后，<code>tsl [panes] [command]</code>可以启动一群智能体。<code
+    >tsl 4 c</code
+  >会给你一个四格的opencode智能体网格：
+</p>
+
+<p><img src="/manual/images/tmux-tsl.webp" alt="tmux-tsl" /></p>

--- a/src/i18n/zh-CN/manual/text-extraction-dictation.html
+++ b/src/i18n/zh-CN/manual/text-extraction-dictation.html
@@ -1,0 +1,41 @@
+<h3 id="text-extraction">
+  文字提取<a
+    class="manual__heading-link"
+    href="#text-extraction"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  按<code>Super + Ctrl + PrtScr</code
+  >框选屏幕区域进行文字提取。开源OCR模型tesseract会迅速把选区转换成文字并放到剪贴板，然后按<code
+    >Super + V</code
+  >粘贴即可。
+</p>
+
+<p>从图片页脚抓取地址，或从网页标题图中抓取电话号码时，这非常方便。</p>
+
+<p><img src="/manual/images/text-extraction.webp" alt="text-extraction" /></p>
+
+<h3 id="dictation">
+  语音听写<a
+    class="manual__heading-link"
+    href="#dictation"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy通过<a href="https://voxtype.io/">Voxtype</a
+  >提供AI语音听写，可在Omarchy菜单的<em>Install &gt; AI &gt; Dictation</em
+  >中安装。默认加载一个150MB的英文基础模型；在终端运行<code
+    >voxtype setup model</code
+  >可以更换模型，所有设置都在<code>~/.config/voxtype/config.toml</code>中调整。
+</p>
+
+<p>
+  安装后，按住<code>F9</code>或用<code>Super + Ctrl + X</code
+  >切换即可开始听写，识别出的文字会出现在当前聚焦的输入区域。
+</p>

--- a/src/i18n/zh-CN/manual/the-top-bar.html
+++ b/src/i18n/zh-CN/manual/the-top-bar.html
@@ -1,0 +1,379 @@
+<p>
+  屏幕顶部的那一条是Omarchy状态栏。它不是外挂的状态栏，而是Omarchy
+  shell的一部分——同一个常驻的Quickshell进程还负责绘制菜单、通知、OSD弹窗和锁屏。因此它与其他一切主题完全一致，面板也能即时打开，而无需启动新的应用。
+</p>
+
+<p>它也是桌面上唯一始终显示的部分，所以值得弄清楚那些小图标各是什么。</p>
+
+<h2 id="whats-on-it-by-default">
+  默认内容<a
+    class="manual__heading-link"
+    href="#whats-on-it-by-default"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  状态栏分三个区域。左侧是Omarchy标志（菜单启动器）和工作区指示器；中间是状态指示器、时钟、键盘布局、天气和Omarchy更新标记；右侧是系统托盘、智能体、蓝牙、网络、音频、显示和电源。
+</p>
+
+<p>
+  其中一些只在有内容时才出现：键盘布局仅在配置了多个布局时显示，更新标记仅在有Omarchy更新等待时显示，智能体图标则在Omarchy首次在这台机器上发现AI编程用量时出现（参见<a
+    href="/manual/ai/"
+    >AI</a
+  >）。
+</p>
+
+<h2 id="clicking-around">
+  点击操作<a
+    class="manual__heading-link"
+    href="#clicking-around"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  几乎每个部件在左键、右键和中键点击时都有动作，不少还响应滚轮。这是大家容易错过的部分——许多好东西都藏在右键和中键里。
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>部件</th>
+      <th>左键</th>
+      <th>右键</th>
+      <th>中键/滚轮</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>菜单</td>
+      <td>Omarchy菜单</td>
+      <td>新终端</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>工作区</td>
+      <td>聚焦该工作区</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>时钟</td>
+      <td>日历弹窗</td>
+      <td>循环切换显示格式</td>
+      <td>中键：时区选择</td>
+    </tr>
+    <tr>
+      <td>天气</td>
+      <td>预报弹窗</td>
+      <td>以通知显示完整天气</td>
+      <td>中键：刷新</td>
+    </tr>
+    <tr>
+      <td>音频</td>
+      <td>音频面板</td>
+      <td>静音</td>
+      <td>中键：面板 · 滚轮：音量</td>
+    </tr>
+    <tr>
+      <td>麦克风</td>
+      <td>麦克风静音</td>
+      <td>-</td>
+      <td>中键：音频面板 · 滚轮：输入音量</td>
+    </tr>
+    <tr>
+      <td>网络</td>
+      <td>网络面板</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>蓝牙</td>
+      <td>蓝牙面板</td>
+      <td>开关蓝牙</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>显示</td>
+      <td>显示面板</td>
+      <td>-</td>
+      <td>滚轮：亮度</td>
+    </tr>
+    <tr>
+      <td>电源</td>
+      <td>电源面板</td>
+      <td>开关电量百分比</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>媒体</td>
+      <td>播放/暂停</td>
+      <td>封面弹窗</td>
+      <td>中键：下一首 · 滚轮：上一首/下一首</td>
+    </tr>
+    <tr>
+      <td>智能体</td>
+      <td>智能体面板</td>
+      <td>启动你的智能体</td>
+      <td>中键：下一个订阅</td>
+    </tr>
+    <tr>
+      <td>托盘</td>
+      <td>悬停展开抽屉</td>
+      <td>右键箭头进行管理</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>Omarchy更新</td>
+      <td>运行更新</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  表中的部件并非全都默认出现。媒体部件（MPRIS正在播放，带滚动的曲目与艺人）和麦克风部件都是内置的，但默认关闭——需要的话按下文方法添加。
+</p>
+
+<h2 id="the-panels">
+  面板<a class="manual__heading-link" href="#the-panels" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  点击状态栏图标会打开一个面板。它是带滑块、列表和键盘导航的正式弹窗，而不是工具提示。每个面板都有快捷键，所以你永远不必去瞄准一个16像素的图标：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>面板</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>Super + Ctrl + A</code></td>
+      <td>音频</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + W</code></td>
+      <td>网络</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + B</code></td>
+      <td>蓝牙</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + D</code></td>
+      <td>显示</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + P</code></td>
+      <td>电源</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + Alt + D</code></td>
+      <td>日历</td>
+    </tr>
+    <tr>
+      <td><code>Super + Ctrl + 1-9</code></td>
+      <td>切换右侧区域的第n个面板</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>面板不只是信息展示，而是真正操作的地方：</p>
+
+<ul>
+  <li>
+    <strong>音频</strong
+    >提供主音量滑块、输出设备选择和按应用的混音器，可以只调低某个浏览器标签页而不影响其他。
+  </li>
+  <li>
+    <strong>网络</strong>扫描Wi-Fi，显示信号强度，连接网络，并可选择DNS提供商。
+  </li>
+  <li><strong>蓝牙</strong>列出设备，支持连接/断开并显示电量。</li>
+  <li>
+    <strong>电源</strong
+    >显示电池状态，切换电源模式（会分别记住电池与外接电源下的选择），并显示一些系统信息。
+  </li>
+  <li>
+    <strong>显示</strong
+    >提供亮度滑块、文字大小、显示器缩放预设，以及多屏时的逐显示器控制。更多内容参见<a
+      href="/manual/monitors/"
+      >显示器</a
+    >。
+  </li>
+  <li><strong>时钟</strong>打开带ISO周数的月历，可按月切换。</li>
+</ul>
+
+<p>
+  每个面板都支持键盘和鼠标：方向键移动，Return确认，Tab切换到相邻面板，Escape关闭。
+</p>
+
+<p>
+  <code>Super + Ctrl + 1-9</code
+  >按右侧区域从左到右计数，跳过没有面板的托盘，因此数字与你要指向的图标一一对应。
+</p>
+
+<h3 id="tailscale-and-dropbox">
+  Tailscale与Dropbox<a
+    class="manual__heading-link"
+    href="#tailscale-and-dropbox"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  还有两个部件只在通过<strong>Install → Service</strong
+  >安装对应服务后才会出现，两者都值得了解，因为它们不只是显示状态。
+</p>
+
+<p>
+  <strong>Tailscale</strong
+  >面板可以连接和断开tailnet、切换账户、选择出口节点（你自己的机器和Mullvad地区都会出现在列表中）。它还能浏览你的机器：选中一台后，按<code>s</code>即可通过Taildrop向它发送文件，这是把文件传到手机或另一台笔记本最快的方式；<code>c</code>复制该机器的IP，<code>n</code>复制名称，<code>d</code>复制完整DNS名称。每一行也有发送按钮，如果你更愿意点击。终端中对应的命令是<code
+    >omarchy tailscale send &lt;machine&gt; [file...]</code
+  >。
+</p>
+
+<p>
+  <strong>Dropbox</strong>面板负责登录，显示已用存储空间，并列出最近同步的文件。
+</p>
+
+<p>移除任一服务，对应部件也会从状态栏消失。</p>
+
+<h2 id="indicators">
+  指示器<a class="manual__heading-link" href="#indicators" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  中间那一小簇是指示器部件，显示已开启模式的状态图标：勿扰、夜间模式、待触发的<a
+    href="/manual/reminders/"
+    >提醒</a
+  >、进行中的录屏、保持唤醒，以及<a href="/manual/text-extraction-dictation/"
+    >语音听写</a
+  >。模式激活时它们亮起，平时则不碍事——把鼠标悬停在状态栏中间即可看到未激活的那些。点击指示器可切换对应模式。
+</p>
+
+<p>
+  如果希望它们始终可见，将该部件的<code>alwaysShow</code>设为<code>true</code>。如果只关心其中几个，在<code>items</code>中列出想要的：<code
+    >["Dnd", "Reminder", "NightLight"]</code
+  >。指示器部件可以有多个，不同区域可以显示不同的子集。
+</p>
+
+<h2 id="rearranging-the-bar">
+  重新排列状态栏<a
+    class="manual__heading-link"
+    href="#rearranging-the-bar"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>状态栏自己配置自己，移动东西不必打开配置文件。</p>
+
+<p>
+  抓住状态栏中部的一块空白，拖向另一条屏幕边缘，状态栏就会移过去——左、右、上、下都可以，每个部件都会自适应（垂直状态栏会退化为紧凑的纯图标形式）。按住不放同样可以开始拖动。双击同一块空白可切换透明度。拖动任意部件可以重新排序，或把它扔到另一个区域。
+</p>
+
+<p>
+  如果更愿意从菜单中选择，<strong>Style → Menu Bar</strong
+  >同时提供位置和透明度设置。
+</p>
+
+<p>
+  同样的操作也有对应命令，正是<a href="/manual/dotfiles/">配置文件</a
+  >方案需要的：
+</p>
+
+<pre><code class="language-bash">omarchy bar position bottom
+omarchy bar transparent toggle
+omarchy bar move omarchy.clock --section center --index 0
+omarchy bar set omarchy.clock format "HH:mm"
+omarchy bar defaults          # back to the shipped layout
+</code></pre>
+
+<p>
+  要彻底添加或移除某个部件，使用插件命令。<code>omarchy plugin list</code
+  >列出shell识别的每个部件及其id，然后：
+</p>
+
+<pre><code class="language-bash">omarchy plugin enable omarchy.media --section center
+omarchy plugin disable omarchy.weather
+</code></pre>
+
+<h2 id="hiding-the-bar">
+  隐藏状态栏<a
+    class="manual__heading-link"
+    href="#hiding-the-bar"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <code>Super + Shift + Space</code
+  >可以关闭再显示状态栏，而不终止shell——面板和快捷键照常工作，你只是拿回了那些像素。菜单中的<strong
+    >Trigger → Toggle → Menu Bar</strong
+  >也提供同样的开关。
+</p>
+
+<h2 id="the-config-file">
+  配置文件<a
+    class="manual__heading-link"
+    href="#the-config-file"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  以上一切都存放在<code>~/.config/omarchy/shell.json</code>的<code>bar</code>键下。这是一个精简版本：
+</p>
+
+<pre><code class="language-json">{
+  "version": 1,
+  "bar": {
+    "position": "top",
+    "transparent": false,
+    "centerAnchor": "omarchy.clock",
+    "layout": {
+      "left": [{ "id": "omarchy.menu" }, { "id": "omarchy.workspaces" }],
+      "center": [{ "id": "omarchy.clock", "format": "HH:mm" }],
+      "right": [{ "id": "omarchy.audio" }, { "id": "omarchy.power" }]
+    }
+  }
+}
+</code></pre>
+
+<p>
+  每个部件都是三个布局数组之一中的一个条目，它的设置直接写在该条目上——没有单独的设置文件，也没有<code>config</code>子对象。时钟的<code>format</code>、<code>formatAlt</code>（右键切换到的格式）和<code>verticalFormat</code>都直接放在<code
+    >{ "id": "omarchy.clock" }</code
+  >上。
+</p>
+
+<p>
+  <code>centerAnchor</code
+  >指定中间区域中固定在屏幕正中的那一个部件，其余部件分列两侧。这就是为什么天气和更新标记来来去去，时钟依然稳居正中。将它设为空字符串，中间列表就会作为整体居中。
+</p>
+
+<p>
+  有一条规则值得记住：<strong>一旦有了自己的<code>shell.json</code>，它就是唯一依据</strong>。在你做任何自定义之前，shell读取Omarchy的默认文件；一旦你拖动了部件、运行了<code
+    >omarchy bar</code
+  >或亲自编辑了文件，它就归你所有——不会进行深度合并，所以未来Omarchy版本新增的默认部件不会自动出现在你的状态栏上。想要重新开始时，<code
+    >omarchy bar defaults</code
+  >会恢复默认布局。
+</p>
+
+<p>
+  同一文件还在顶层（<code>bar</code>键之外）保存空闲计时：<code>idle.screensaver</code>和<code>idle.lock</code>，都是从进入空闲开始计算的秒数。因此默认屏保在150秒时启动，锁屏在300秒时启动。
+</p>

--- a/src/i18n/zh-CN/manual/themes.html
+++ b/src/i18n/zh-CN/manual/themes.html
@@ -1,0 +1,225 @@
+<p>
+  Omarchy内置二十二款精美主题。可以通过Omarchy菜单（<code>Super + Space</code
+  >）中的<em>Style &gt; Theme</em>选择，或用<code
+    >Super + Ctrl + Shift + Space</code
+  >直接跳到主题选择器。
+</p>
+
+<p>
+  每款主题都会统一设置桌面、终端、neovim、活动监视器（btop）、Chromium，以及整个Omarchy
+  shell：状态栏、菜单、通知、OSD和锁屏。（Obsidian需要在应用内的<em
+    >Appearance &gt; Themes</em
+  >中手动选择Omarchy主题。）
+</p>
+
+<p>每款主题附带一组背景图片，可用<code>Super + Ctrl + Space</code>切换。</p>
+
+<p>
+  你可以在<a href="/themes/">额外主题页面</a>找到更多主题，也可以<a
+    href="/manual/making-your-own-theme/"
+    >制作自己的主题</a
+  >。
+</p>
+
+<p>
+  <img src="/manual/images/tokyo-night-preview.webp" alt="tokyo-night" />
+  <em>Tokyo Night</em>
+</p>
+
+<p>
+  <img src="/manual/images/catppuccin-preview.webp" alt="catppuccin" />
+  <em>Catppuccin</em>
+</p>
+
+<p>
+  <img src="/manual/images/lumon-preview.webp" alt="lumon" /> <em>Lumon</em>
+</p>
+
+<p>
+  <img src="/manual/images/ethereal-preview.webp" alt="ethereal" />
+  <em>Ethereal</em>
+</p>
+
+<p>
+  <img src="/manual/images/everforest-preview.webp" alt="everforest" />
+  <em>Everforest</em>
+</p>
+
+<p>
+  <img src="/manual/images/gruvbox-preview.webp" alt="gruvbox" />
+  <em>Gruvbox</em>
+</p>
+
+<p>
+  <img src="/manual/images/miasma-preview.webp" alt="miasma" /> <em>Miasma</em>
+</p>
+
+<p>
+  <img src="/manual/images/hackerman-preview.webp" alt="hackerman" />
+  <em>Hackerman</em>
+</p>
+
+<p>
+  <img src="/manual/images/osaka-jade-preview.webp" alt="osaka-jade" />
+  <em>Osaka Jade</em>
+</p>
+
+<p>
+  <img src="/manual/images/kanagawa-preview.webp" alt="kanagawa" />
+  <em>Kanagawa</em>
+</p>
+
+<p><img src="/manual/images/nord-preview.webp" alt="nord" /> <em>Nord</em></p>
+
+<p>
+  <img src="/manual/images/matte-black-preview.webp" alt="matte-black" />
+  <em>Matte Black</em>
+</p>
+
+<p>
+  <img src="/manual/images/vantablack-preview.webp" alt="vantablack" />
+  <em>Vantablack</em>
+</p>
+
+<p>
+  <img src="/manual/images/ristretto-preview.webp" alt="ristretto" />
+  <em>Ristretto</em>
+</p>
+
+<p>
+  <img src="/manual/images/retro-82-preview.webp" alt="retro-82" />
+  <em>Retro 82</em>
+</p>
+
+<p>
+  <img src="/manual/images/flexoki-light-preview.webp" alt="flexoki-light" />
+  <em>Flexoki Light</em>
+</p>
+
+<p>
+  <img src="/manual/images/rose-pine-preview.webp" alt="rose-pine" />
+  <em>Rose Pine</em>
+</p>
+
+<p>
+  <img
+    src="/manual/images/catppuccin-latte-preview.webp"
+    alt="catppuccin-latte"
+  />
+  <em>Catppuccin Latte</em>
+</p>
+
+<p>
+  <img src="/manual/images/white-preview.webp" alt="white" /> <em>White</em>
+</p>
+
+<h3 id="unlocks">
+  解锁界面<a class="manual__heading-link" href="#unlocks" aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  主题还可以自带解锁界面设计，用于开机解密过程。可在<em>Style &gt; Unlock</em
+  >下选择。效果如下：
+</p>
+
+<p>
+  <img src="/manual/images/catppuccin-preview-unlock.webp" alt="catppuccin" />
+  <em>Catppuccin</em>
+</p>
+
+<p>
+  <img
+    src="/manual/images/catppuccin-latte-preview-unlock.webp"
+    alt="catppuccin-latte"
+  />
+  <em>Catppuccin Latte</em>
+</p>
+
+<p>
+  <img src="/manual/images/ethereal-preview-unlock.webp" alt="ethereal" />
+  <em>Ethereal</em>
+</p>
+
+<p>
+  <img src="/manual/images/everforest-preview-unlock.webp" alt="everforest" />
+  <em>Everforest</em>
+</p>
+
+<p>
+  <img
+    src="/manual/images/flexoki-light-preview-unlock.webp"
+    alt="flexoki-light"
+  />
+  <em>Flexoki Light</em>
+</p>
+
+<p>
+  <img src="/manual/images/gruvbox-preview-unlock.webp" alt="gruvbox" />
+  <em>Gruvbox</em>
+</p>
+
+<p>
+  <img src="/manual/images/hackerman-preview-unlock.webp" alt="hackerman" />
+  <em>Hackerman</em>
+</p>
+
+<p>
+  <img src="/manual/images/kanagawa-preview-unlock.webp" alt="kanagawa" />
+  <em>Kanagawa</em>
+</p>
+
+<p>
+  <img src="/manual/images/lumon-preview-unlock.webp" alt="lumon" />
+  <em>Lumon</em>
+</p>
+
+<p>
+  <img src="/manual/images/matte-black-preview-unlock.webp" alt="matte-black" />
+  <em>Matte Black</em>
+</p>
+
+<p>
+  <img src="/manual/images/miasma-preview-unlock.webp" alt="miasma" />
+  <em>Miasma</em>
+</p>
+
+<p>
+  <img src="/manual/images/nord-preview-unlock.webp" alt="nord" /> <em>Nord</em>
+</p>
+
+<p>
+  <img src="/manual/images/osaka-jade-preview-unlock.webp" alt="osaka-jade" />
+  <em>Osaka Jade</em>
+</p>
+
+<p>
+  <img src="/manual/images/retro-82-preview-unlock.webp" alt="retro-82" />
+  <em>Retro 82</em>
+</p>
+
+<p>
+  <img src="/manual/images/ristretto-preview-unlock.webp" alt="ristretto" />
+  <em>Ristretto</em>
+</p>
+
+<p>
+  <img src="/manual/images/rose-pine-preview-unlock.webp" alt="rose-pine" />
+  <em>Rose Pine</em>
+</p>
+
+<p>
+  <img src="/manual/images/tokyo-night-preview-unlock.webp" alt="tokyo-night" />
+  <em>Tokyo Night</em>
+</p>
+
+<p>
+  <img src="/manual/images/vantablack-preview-unlock.webp" alt="vantablack" />
+  <em>Vantablack</em>
+</p>
+
+<p>
+  <img src="/manual/images/white-preview-unlock.webp" alt="white" />
+  <em>White</em>
+</p>

--- a/src/i18n/zh-CN/manual/toggles-idle-screensaver.html
+++ b/src/i18n/zh-CN/manual/toggles-idle-screensaver.html
@@ -1,0 +1,277 @@
+<p>
+  日常改动的许多东西其实不是设置，而是模式：开一小时再关掉。熬夜工作时开夜间模式，演示时开勿扰，看视频时开保持唤醒。Omarchy称之为开关，它们的工作方式完全一致——一个快捷键、一个菜单项、一条命令，作用于同一个开关。
+</p>
+
+<h3 id="the-toggle-menu">
+  开关菜单<a
+    class="manual__heading-link"
+    href="#the-toggle-menu"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>Super + Ctrl + O</code>直接打开<em>Trigger &gt; Toggle</em
+  >，也可以从Omarchy菜单（<code>Super + Space</code
+  >）一路点进去。列表中的每一项都是可以随手拨动的开关，不必关心状态存放在哪里。
+</p>
+
+<p>
+  在终端中，同样的开关是<code>omarchy toggle &lt;thing&gt;</code>。单独运行<code
+    >omarchy toggle</code
+  >可查看整组。
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>开关</th>
+      <th>快捷键</th>
+      <th>命令</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>夜间模式</td>
+      <td><code>Super + Ctrl + N</code></td>
+      <td><code>omarchy toggle nightlight</code></td>
+    </tr>
+    <tr>
+      <td>通知静音</td>
+      <td><code>Super + Ctrl + ,</code></td>
+      <td><code>omarchy toggle notification silencing</code></td>
+    </tr>
+    <tr>
+      <td>保持唤醒（不在空闲时锁定）</td>
+      <td><code>Super + Ctrl + I</code></td>
+      <td><code>omarchy toggle idle</code></td>
+    </tr>
+    <tr>
+      <td>崩溃捕获</td>
+      <td>-</td>
+      <td><code>omarchy toggle crash-capture</code></td>
+    </tr>
+    <tr>
+      <td>屏保</td>
+      <td>-</td>
+      <td><code>omarchy toggle screensaver</code></td>
+    </tr>
+    <tr>
+      <td>菜单栏</td>
+      <td><code>Super + Shift + Space</code></td>
+      <td><code>omarchy toggle bar</code></td>
+    </tr>
+    <tr>
+      <td>触控板</td>
+      <td><code>XF86TouchpadToggle</code></td>
+      <td><code>omarchy toggle touchpad</code></td>
+    </tr>
+    <tr>
+      <td>触摸屏</td>
+      <td>-</td>
+      <td><code>omarchy toggle touchscreen</code></td>
+    </tr>
+    <tr>
+      <td>挂起</td>
+      <td>-</td>
+      <td><code>omarchy toggle suspend</code></td>
+    </tr>
+    <tr>
+      <td>混合GPU</td>
+      <td>-</td>
+      <td><code>omarchy toggle hybrid gpu</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  触控板、触摸屏和混合GPU的开关位于<em>Trigger &gt; Hardware</em>（<code
+    >Super + Ctrl + H</code
+  >）而非Toggle下，因为它们只在确实存在对应硬件时才出现。触控板和触摸屏的开关在Hyprland重新加载后依然有效：被禁用设备的名称会保存到一个小状态文件中，Hyprland启动时读取并再次禁用。
+</p>
+
+<p>
+  Toggle菜单中还有几项虽然不是<code>omarchy toggle</code
+  >命令，但行为相同：状态栏中的电量百分比、工作区布局（<code>Super + L</code
+  >）、窗口间隙（<code>Super + Shift + Backspace</code
+  >），以及单窗口方形比例（<code>Super + Ctrl + Backspace</code>）。
+</p>
+
+<p>
+  这些开关大多只是<code>~/.local/state/omarchy/toggles/</code>下的一个标记文件。想在脚本中根据某个开关分支，<code>omarchy-toggle-enabled</code>会直接给出退出码，无需自己去找：
+</p>
+
+<pre><code class="language-bash">omarchy-toggle-enabled screensaver-off &amp;&amp; echo "screensaver is off"
+</code></pre>
+
+<p>
+  标记按关闭状态命名——<code>screensaver-off</code>、<code>suspend-off</code>、<code>bar-off</code>——存在即表示该功能已禁用。
+</p>
+
+<h3 id="indicators-in-the-bar">
+  状态栏中的指示器<a
+    class="manual__heading-link"
+    href="#indicators-in-the-bar"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  某个模式开启时，状态栏中间时钟旁会出现一个小图标。那是指示器部件，涵盖语音听写、录屏、待触发的提醒、夜间模式、勿扰和保持唤醒。
+</p>
+
+<p>
+  未激活的指示器默认隐藏。把鼠标悬停到它们周围，它们会以暗色淡入，这样不知道快捷键也能点击开启；点击已激活的指示器则将其关闭。如果希望始终显示全部，在<code>~/.config/omarchy/shell.json</code>的<code>omarchy.indicators</code>条目上将<code>alwaysShow</code>设为<code>true</code>——状态栏部件的配置方式参见<a
+    href="/manual/the-top-bar/"
+    >状态栏</a
+  >。
+</p>
+
+<h3 id="night-light">
+  夜间模式<a
+    class="manual__heading-link"
+    href="#night-light"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>Super + Ctrl + N</code
+  >将屏幕色温调暖至4000K，再按一次恢复6500K。它由hyprsunset驱动，如果hyprsunset尚未运行，开关会替你启动。
+</p>
+
+<p>
+  默认情况下，hyprsunset完全不改动屏幕：<code>~/.config/hypr/hyprsunset.conf</code>自带一个恒等配置，正是为了在你要求暖色之前保持显示原样。如果希望按时间自动切换，把它换成时间配置：
+</p>
+
+<pre><code>profile {
+    time = 20:00
+    temperature = 4000
+}
+</code></pre>
+
+<p>
+  然后在<code>~/.config/hypr/autostart.lua</code>中添加<code>o.launch_on_start("hyprsunset")</code>，让hyprsunset随登录启动。开关使用的4000K/6500K这一对是固定的，想要其他色温就去改配置文件。
+</p>
+
+<h3 id="do-not-disturb">
+  勿扰<a
+    class="manual__heading-link"
+    href="#do-not-disturb"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>Super + Ctrl + ,</code
+  >让通知静音。开启期间不会弹出提示，状态栏中会出现一个划掉的铃铛，提醒你桌面为何安静了。
+</p>
+
+<p>
+  不过什么都不会丢失。被静音的通知会直接写入通知历史，正是你回来后想知道错过了什么时需要的记录。用<code
+    >Super + Shift + Alt + ,</code
+  >打开它。通知的其余内容参见<a href="/manual/notices/">快捷通知</a>。
+</p>
+
+<p>
+  两类消息仍会通过：Omarchy对你刚做的操作的确认提示（“Theme
+  changed”、“Screenshot
+  saved”），以及从命令行发送的紧急警报。那些把所有消息都标记为紧急、强行挤到你面前的聊天应用，不在此列。
+</p>
+
+<h3 id="idle">
+  空闲<a class="manual__heading-link" href="#idle" aria-label="本节链接">#</a>
+</h3>
+
+<p>
+  空闲行为由Omarchy
+  shell负责，计时位于<code>~/.config/omarchy/shell.json</code>顶层的<code>idle</code>块：
+</p>
+
+<pre><code class="language-json">{
+  "version": 1,
+  "idle": {
+    "screensaver": 150,
+    "lock": 300
+  }
+}
+</code></pre>
+
+<p>
+  两个数字都是从进入空闲那一刻算起的秒数，而不是彼此的间隔。按默认值，屏保在两分半后出现，锁屏在五分钟时接管，无论屏保是否运行过。保存文件，shell会立即采用新计时。
+</p>
+
+<p>
+  如果在锁定期限之前退出屏保，这算作活动，待执行的锁定会被取消。你不会因为看了一眼机器就被锁在外面。
+</p>
+
+<p>
+  要彻底停止空闲锁定，按<code>Super + Ctrl + I</code>——或运行<code
+    >omarchy toggle idle</code
+  >——开启保持唤醒，状态栏中会出现咖啡杯指示器。长时间演示或想盯着的构建开始前，就按它；再按一次恢复正常。脚本中需要时，<code
+    >omarchy toggle idle status</code
+  >会以JSON输出当前状态。
+</p>
+
+<p>
+  这里说的是锁定和屏保，不涉及电源。挂起和休眠有各自的设置，参见<a
+    href="/manual/system-sleep/"
+    >系统睡眠</a
+  >。
+</p>
+
+<h3 id="the-screensaver">
+  屏保<a
+    class="manual__heading-link"
+    href="#the-screensaver"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy的屏保是随机文字特效中的ASCII艺术，每个显示器一个实例。任何按键或鼠标移动都会退出。
+</p>
+
+<p>
+  可以从<em>System &gt; Screensaver</em>（<code>Super + Esc</code
+  >）按需启动，即使关闭了空闲屏保也会强制显示。默认没有绑定快捷键。
+</p>
+
+<p>
+  如果想从工作直接进入锁定，<code>omarchy toggle screensaver</code
+  >可关闭空闲屏保。它需要一个能够配置的终端——Alacritty、Foot、Ghostty或Kitty——如果默认终端是其他程序，它会提示你。
+</p>
+
+<p>
+  屏保绘制的标志可以在<em>Style &gt; Screensaver</em
+  >下更换：上传png或svg，Omarchy会将其转换为ASCII。参见<a
+    href="/manual/branding/"
+    >品牌定制</a
+  >。
+</p>
+
+<h3 id="the-lock-screen">
+  锁屏<a
+    class="manual__heading-link"
+    href="#the-lock-screen"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  <code>Super + Ctrl + L</code>锁定机器。这会运行Omarchy
+  shell的锁屏，熄灭显示，把键盘布局重置为第一个（免得用错误的字母表输入密码），并且——如果1Password正在运行——顺便将其锁定。
+</p>
+
+<p>
+  锁屏接受密码，设置指纹后也接受指纹。这一点和其他认证方式参见<a
+    href="/manual/hardware-authentication/"
+    >硬件认证</a
+  >。
+</p>

--- a/src/i18n/zh-CN/manual/troubleshooting.html
+++ b/src/i18n/zh-CN/manual/troubleshooting.html
@@ -1,0 +1,147 @@
+<h3 id="i-broke-my-system-with-an-update">
+  更新把系统搞坏了！<a
+    class="manual__heading-link"
+    href="#i-broke-my-system-with-an-update"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  先尝试把<a href="/manual/system-snapshots/">系统回滚</a
+  >到最近一次更新之前的版本。如果不行，用<code>omarchy-debug</code>把问题分享到Discord的
+  #omarchy-help。要是这些都不奏效，可以用<code>omarchy-reinstall</code>重装默认配置和软件包。
+</p>
+
+<h3 id="why-are-some-apps-so-large-on-my-display">
+  为什么有些应用在我的显示器上特别大？<a
+    class="manual__heading-link"
+    href="#why-are-some-apps-so-large-on-my-display"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy假定使用2倍高分辨率显示器，这需要在<code>~/.config/hypr/monitors.lua</code>中把<code>GDK_SCALE</code>设为2。如果你用的是1倍显示器，把<code
+    >local omarchy_gdk_scale = 2</code
+  >改为1（然后重启所有尺寸过大的应用）。参见<a href="/manual/monitors/"
+    >显示器</a
+  >一章。
+</p>
+
+<p>
+  Spotify可以用<code>Ctrl + Minus</code>缩小界面（<code>Ctrl + Plus</code
+  >放大）。
+</p>
+
+<h3 id="why-isnt-caps-lock-working">
+  为什么Caps Lock不起作用？<a
+    class="manual__heading-link"
+    href="#why-isnt-caps-lock-working"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在Omarchy中，Caps Lock被指定为xcompose键，<a
+    href="/manual/hotkeys/#quick-emojis"
+    >快速表情</a
+  >和<a href="/manual/hotkeys/#quick-completions">其他自动补全</a
+  >都靠它。如果确实怀念大写锁定，可以编辑<code>~/.config/hypr/input.lua</code>把xcompose键映射到别处，比如右Alt：
+</p>
+
+<pre><code>hl.config({
+  input = {
+    kb_options = "compose:ralt",
+  },
+})
+</code></pre>
+
+<h3 id="my-wi-fi-bluetooth-audio-or-trackpad-just-stopped-working">
+  Wi-Fi、蓝牙、音频或触控板突然不工作了<a
+    class="manual__heading-link"
+    href="#my-wi-fi-bluetooth-audio-or-trackpad-just-stopped-working"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  重启之前，先试着单独重启出问题的子系统。Omarchy菜单的<em
+    >Update &gt; Hardware</em
+  >下有Wi-Fi、蓝牙、音频和触控板，重新加载其中一项就能解决大多数“五分钟前还好好的”情况——蓝牙耳机连不上、挂起后触控板失灵、拔掉显示器后声音消失。
+</p>
+
+<h3 id="why-are-my-external-speakers-not-playing">
+  为什么外接音箱不出声？<a
+    class="manual__heading-link"
+    href="#why-are-my-external-speakers-not-playing"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  多半是因为它没被设为主输出。点击状态栏右侧的扬声器图标，会弹出音量面板，在那里选择输出设备（也可以按应用调节音量）。
+</p>
+
+<h3 id="my-laptop-speakers-sound-off">
+  笔记本扬声器听起来不对劲<a
+    class="manual__heading-link"
+    href="#my-laptop-speakers-sound-off"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  在某些笔记本上，Omarchy会自动应用一套扬声器调音，校正内置扬声器的频率响应。<code
+    >omarchy audio tuning status</code
+  >显示你的机器上是否启用了调音，<code>omarchy audio tuning off</code
+  >关闭它，让扬声器回到原声。
+</p>
+
+<h3 id="why-cant-i-login-or-sudo-with-my-password">
+  为什么密码正确却无法登录或sudo？<a
+    class="manual__heading-link"
+    href="#why-cant-i-login-or-sudo-with-my-password"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  多半是输错太多次被锁定了。如果发生在锁屏上，按<code>CTRL + ALT + F2</code
+  >打开一个新的TTY，以root登录，然后运行<code
+    >faillock --reset --user [your-username]</code
+  >。锁定即被重置，可以继续使用。
+</p>
+
+<h3
+  id="why-isnt-my-1password-authorization-prompts-for-1password-ssh-agent--cli-appearing"
+>
+  为什么1Password SSH Agent / CLI的授权提示没有出现？<a
+    class="manual__heading-link"
+    href="#why-isnt-my-1password-authorization-prompts-for-1password-ssh-agent--cli-appearing"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>这可能有两个原因：</p>
+
+<p>
+  要显示完整的审批提示，必须开启Settings &gt; Advanced &gt; Use Hardware
+  Acceleration。<em>注意：需要重启后才生效。</em>
+</p>
+
+<p>
+  <img
+    src="/manual/images/troubleshooting-1password.webp"
+    alt="troubleshooting-1password"
+  />
+</p>
+
+<p>另外，开机后如果还没启动过1Password，提示也不会出现。</p>

--- a/src/i18n/zh-CN/manual/tuis.html
+++ b/src/i18n/zh-CN/manual/tuis.html
@@ -1,0 +1,152 @@
+<h2 id="lazygit">
+  Lazygit<a class="manual__heading-link" href="#lazygit" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/jesseduffield/lazygit">Lazygit</a>是GitHub
+  Desktop这类应用的绝佳替代品，而且运行在终端里。
+</p>
+
+<p>
+  可以直接运行：进入任意由git管理的目录，执行<code>lazygit</code>；也可以在Neovim中用<code
+    >Space G G</code
+  >启动。
+</p>
+
+<p>
+  用<code>Tab</code>在各窗格间切换。在Files窗格中用<code>Space</code>选择要暂存的文件，再用<code>c</code>创建提交。<code>?</code>可查看全部命令。
+</p>
+
+<h2 id="lazydocker">
+  Lazydocker<a
+    class="manual__heading-link"
+    href="#lazydocker"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/jesseduffield/lazydocker">Lazydocker</a
+  >与Lazygit一脉相承，同样以终端界面管理容器和镜像。
+</p>
+
+<p>用<code>Super + Shift + D</code>启动。</p>
+
+<p>
+  用<code>s</code>停止容器，<code>r</code>启动或重启。<code>?</code>可查看全部命令。
+</p>
+
+<h2 id="btop">
+  Btop<a class="manual__heading-link" href="#btop" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://github.com/aristocratos/btop">Btop</a
+  >是一款漂亮的资源监视器，显示内存、CPU、磁盘和网络用量，并列出所有活动进程供你管理。
+</p>
+
+<p>
+  Omarchy称之为活动监视器，按<code>Super + Ctrl + T</code
+  >启动。它以浮动窗口打开，可用<code>Super + T</code>平铺。
+</p>
+
+<h2 id="herdr">
+  Herdr<a class="manual__heading-link" href="#herdr" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://github.com/omacom-io/herdr">Herdr</a
+  >是一款终端工作区管理器，提供工作区、标签页和窗格，并将它们保持在一个可脱离、可随时回来的持久会话中。
+</p>
+
+<p>
+  用<code>Super + Ctrl + Return</code
+  >启动（或重新接入已有会话）。Omarchy内置的Herdr配置与其Tmux配置一致，所以前缀键同样是<code
+    >Ctrl + Space</code
+  >。<code>Super + Ctrl + K</code>可浏览全部键绑定。
+</p>
+
+<h2 id="fastfetch">
+  Fastfetch<a
+    class="manual__heading-link"
+    href="#fastfetch"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://github.com/fastfetch-cli/fastfetch">Fastfetch</a
+  >显示内核版本、运行时间、主题、CPU、内存等系统信息，是流行的neofetch的继任者。
+</p>
+
+<p>
+  Omarchy将它作为Omarchy菜单（<code>Super + Space</code
+  >）中的<em>About</em>提供。
+</p>
+
+<h2 id="disk-usage">
+  磁盘用量<a
+    class="manual__heading-link"
+    href="#disk-usage"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  硬盘满了却不知道是什么占的空间？从应用启动器（<code>Super + Space</code
+  >）启动<em>Disk Usage</em>。它是指向整个文件系统的交互模式<a
+    href="https://github.com/Byron/dua-cli"
+    >dua</a
+  >，可以一路深入到罪魁祸首所在的目录（按大小降序排列），并直接在其中删除。
+</p>
+
+<h2 id="cliamp">
+  Cliamp<a class="manual__heading-link" href="#cliamp" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://www.cliamp.stream/">Cliamp</a>是受Winamp
+  2.x启发的复古终端音乐播放器，内置lo-fi节拍电台。用<code
+    >Super + Shift + Alt + M</code
+  >启动，或从Omarchy菜单的<em>Apps</em>下启动。按<code>?</code>查看完整键绑定列表。
+</p>
+
+<h2 id="what-about-wi-fi-and-bluetooth">
+  Wi-Fi和蓝牙呢？<a
+    class="manual__heading-link"
+    href="#what-about-wi-fi-and-bluetooth"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  你不会找到Wi-Fi和蓝牙的TUI——这些工作属于Omarchy
+  shell。点击状态栏中的Wi-Fi图标（或按<code>Super + Ctrl + W</code
+  >）查看并连接网络，点击蓝牙图标（或按<code>Super + Ctrl + B</code
+  >）配对并连接设备。详情参见<a href="/manual/networking/">网络</a>。
+</p>
+
+<h2 id="adding-your-own">
+  添加自己的应用<a
+    class="manual__heading-link"
+    href="#adding-your-own"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  任何终端程序都能获得完整的应用待遇。进入Omarchy菜单（<code>Super + Space</code
+  >）的<em>Install &gt; TUI</em
+  >，填写名称、启动命令、窗口样式和图标，它就会像其他应用一样出现在应用启动器中。在<em
+    >Remove &gt; TUI</em
+  >下可以移除。
+</p>

--- a/src/i18n/zh-CN/manual/unattended-installs.html
+++ b/src/i18n/zh-CN/manual/unattended-installs.html
@@ -1,0 +1,145 @@
+<p>
+  Omarchy
+  ISO可以在无人操作的情况下自行完成安装。如果安装程序发现另一块标签为<code>cidata</code>且带有配置文件的驱动器，它会把文件复制过来，完全跳过设置向导，并自行重启进入装好的系统。不需要特殊的ISO构建，也没有额外的启动菜单项——没有这样的驱动器时，一切照旧，你看到的还是普通向导。
+</p>
+
+<p>
+  这让Omarchy很适合作为一次性开发环境的基础镜像：在Proxmox或用Packer创建虚拟机，启动，走开，然后SSH进去。<code>cidata</code>是cloud-init的<code>NoCloud</code>标签，所有常见的虚拟化工具都已经知道如何挂载这样的驱动器。
+</p>
+
+<h2 id="the-configuration-files">
+  配置文件<a
+    class="manual__heading-link"
+    href="#the-configuration-files"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  这些文件正是安装程序自己的向导所写入的，所以获得初始文件最简单的办法是做一次交互式安装（比如在虚拟机里），然后复制它写入<code>/root</code>的内容：
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>文件</th>
+      <th>必需</th>
+      <th>用途</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>user_configuration.json</code></td>
+      <td>是</td>
+      <td>磁盘、主机名、时区、键盘</td>
+    </tr>
+    <tr>
+      <td><code>user_credentials.json</code></td>
+      <td>是</td>
+      <td>用户名和密码哈希</td>
+    </tr>
+    <tr>
+      <td><code>user_full_name.txt</code></td>
+      <td>否</td>
+      <td>Git全名</td>
+    </tr>
+    <tr>
+      <td><code>user_email_address.txt</code></td>
+      <td>否</td>
+      <td>Git邮箱</td>
+    </tr>
+    <tr>
+      <td><code>user_encrypt_installation.txt</code></td>
+      <td>否</td>
+      <td>配置中含有<code>disk_encryption</code>块时为<code>true</code></td>
+    </tr>
+    <tr>
+      <td><code>authorized_keys</code></td>
+      <td>否</td>
+      <td>SSH公钥，每行一个</td>
+    </tr>
+    <tr>
+      <td><code>tailscale_authkey</code></td>
+      <td>否</td>
+      <td>首次启动时加入tailnet所用的Tailscale认证密钥</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  用<code>openssl passwd -6 "yourpassword"</code
+  >生成<code>user_credentials.json</code>所需的密码哈希。
+</p>
+
+<p>
+  也可以用一个名为<code>defer-provisioning</code>的空文件代替<code>user_credentials.json</code>。这会执行与交互式安装中相同的<a
+    href="/manual/getting-started/"
+    >为他人准备的安装</a
+  >：机器不带任何个人信息安装，第一个启动它的人选择键盘并创建自己的用户。这是批量装机的模式，驱动器上不应携带任何人的凭据。
+</p>
+
+<h2 id="ssh-access">
+  SSH访问<a
+    class="manual__heading-link"
+    href="#ssh-access"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  存在<code>authorized_keys</code>时，安装会把这些密钥设为用户的<code>~/.ssh/authorized_keys</code>，启用<code>sshd</code>，并在防火墙上开放端口。（标准的Omarchy安装自带openssh，但服务禁用、端口关闭，否则无人值守的机器将无法访问。）安装只添加你的密钥——不会放松SSH守护进程的其他任何认证设置。
+</p>
+
+<p>
+  存在<code>tailscale_authkey</code>时，机器改为在首次启动时加入你的tailnet：Tailscale从ISO附带的软件包安装，防火墙放行tailnet接口，后台任务在机器真正联网后立即执行加入，失败则重试直到成功。请使用可重复使用的预授权密钥，这样一份驱动器镜像就能服务多台机器。
+</p>
+
+<h2 id="building-the-cidata-drive">
+  制作cidata驱动器<a
+    class="manual__heading-link"
+    href="#building-the-cidata-drive"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>任何带有正确标签的文件系统都可以。最简单的是做一个小ISO：</p>
+
+<pre><code class="language-bash">mkdir cidata
+cp user_configuration.json user_credentials.json authorized_keys cidata/
+genisoimage -output cidata.iso -volid cidata -joliet -rock cidata/
+</code></pre>
+
+<p>然后把它和Omarchy ISO一起挂载到虚拟机。下面是完整的Proxmox示例：</p>
+
+<pre><code class="language-bash">qm create 101 --name my-omarchy \
+  --bios ovmf --machine q35 --cpu host --cores 4 --memory 8192 \
+  --ostype l26 --scsihw virtio-scsi-single \
+  --efidisk0 local-lvm:0,efitype=4m,pre-enrolled-keys=0 \
+  --scsi0 local-lvm:40,discard=on,iothread=1 \
+  --net0 virtio,bridge=vmbr0 --vga virtio --serial0 socket \
+  --ide2 local:iso/omarchy.iso,media=cdrom \
+  --ide3 local:iso/cidata.iso,media=cdrom \
+  --boot order='scsi0;ide2'
+
+qm start 101
+</code></pre>
+
+<p>
+  启动顺序有意把磁盘放在最前：首次启动时空磁盘会落到ISO，之后装好的系统就一直从磁盘启动。
+</p>
+
+<h2 id="two-caveats">
+  两点注意<a
+    class="manual__heading-link"
+    href="#two-caveats"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  加密的无人值守安装并非完全无人值守——首次启动时仍需有人输入LUKS口令。而且<code>user_configuration.json</code>中的<code>disk_encryption</code>块以明文携带该口令，所以从加密安装生成的cidata驱动器要当作机密对待。
+</p>

--- a/src/i18n/zh-CN/manual/unified-clipboard-history.html
+++ b/src/i18n/zh-CN/manual/unified-clipboard-history.html
@@ -1,0 +1,70 @@
+<p>
+  在Linux上，通常终端内要用<code>Ctrl + Shift + C/V</code
+  >复制粘贴，其他地方则用<code>Ctrl + C/V</code
+  >。对不是从小用Linux的人来说，这很难习惯！从Mac迁移过来的话，从super换成ctrl同样别扭。
+</p>
+
+<p>Omarchy用一套（几乎）处处通用的统一剪贴板快捷键解决了这两个问题：</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>快捷键</th>
+      <th>命令</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Super + C</td>
+      <td>复制</td>
+    </tr>
+    <tr>
+      <td>Super + X</td>
+      <td>剪切</td>
+    </tr>
+    <tr>
+      <td>Super + V</td>
+      <td>粘贴</td>
+    </tr>
+    <tr>
+      <td>Super + Ctrl + V</td>
+      <td>剪贴板历史</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>
+  <em
+    >注意：大多数智能体运行环境粘贴图片用<code>Ctrl + V</code
+    >，粘贴文本则用<code>Super + V</code>。</em
+  >
+</p>
+
+<h3 id="clipboard-history">
+  剪贴板历史<a
+    class="manual__heading-link"
+    href="#clipboard-history"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  剪贴板历史由Omarchy shell提供，文本和图片均支持。按<code
+    >Super + Ctrl + V</code
+  >调出，用回车选中条目，它就会放到剪贴板上，随时可以用<code>Super + V</code
+  >粘贴。
+</p>
+
+<p>
+  <img src="/manual/images/clipboard-history.webp" alt="clipboard-history" />
+</p>
+
+<p>直接输入即可搜索历史记录：</p>
+
+<p>
+  <img
+    src="/manual/images/clipboard-history-search.webp"
+    alt="clipboard-history-search"
+  />
+</p>

--- a/src/i18n/zh-CN/manual/updates.html
+++ b/src/i18n/zh-CN/manual/updates.html
@@ -1,0 +1,111 @@
+<p>
+  Omarchy和所有软件包通过Omarchy菜单（<code>Super + Space</code>）的<em
+    >Update &gt; Omarchy</em
+  >保持最新。
+</p>
+
+<p>
+  Omarchy本身以普通pacman软件包的形式从<a
+    href="https://github.com/omacom-io/omarchy-pkgs"
+    >Omarchy软件包仓库</a
+  >安装。因此一次更新会安装<a
+    href="https://github.com/basecamp/omarchy/releases"
+    >最新的Omarchy版本</a
+  >，运行待执行的迁移让系统与最新版同步，并从<a
+    href="https://github.com/omacom-io/omarchy-mirror"
+    >Omarchy Arch镜像</a
+  >和<a href="https://aur.archlinux.org/">AUR</a
+  >（如果安装过AUR软件包）更新全部系统软件包。
+</p>
+
+<p>有新版本发布时，时钟右侧会出现一个圆形箭头图标，点击即开始更新。</p>
+
+<p><img src="/manual/images/update-available.webp" alt="update-available" /></p>
+
+<h3 id="four-channels">
+  四个通道<a
+    class="manual__heading-link"
+    href="#four-channels"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  Omarchy沿四个通道更新：stable、RC、edge和dev。新安装默认使用stable通道，它跟踪<a
+    href="https://github.com/basecamp/omarchy/releases/"
+    >正式版本</a
+  >，以及比最新版滞后一个月的<a
+    href="https://github.com/omacom-io/omarchy-mirror"
+    >stable Omarchy Arch镜像</a
+  >，这样需要修改配置的新不兼容问题会在影响大家之前被发现。
+</p>
+
+<p>
+  如果想帮忙提前发现这些问题，可以切换到edge通道。它让Omarchy软件包跟踪最新的开发构建，并在最新Arch软件包可用时立即更新。仅当你熟悉Linux并知道如何修复出问题的系统时，才建议这样做。
+</p>
+
+<p>
+  每次重大版本发布前，我们会通过RC通道做最终验证。有兴趣参与最后打磨的话，欢迎来Discord的
+  #omarchy-release-candidates。
+</p>
+
+<p>
+  最后是dev通道，它把Omarchy直接链接到<code>~/omarchy</code>中源代码的git检出，并搭配edge软件包。只有经验丰富、直接参与Omarchy开发并能容忍故障的Linux用户才应使用这个通道。
+</p>
+
+<p>
+  通过Omarchy菜单的<em>Update &gt; Channel</em
+  >（或终端中的<code>omarchy-channel-set</code>）在通道之间切换。
+</p>
+
+<h3 id="firmware-updates">
+  固件更新<a
+    class="manual__heading-link"
+    href="#firmware-updates"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  会过时的不只是软件包。许多笔记本和外设通过Linux Vendor Firmware
+  Service分发BIOS、SSD和扩展坞固件，Omarchy菜单的<em>Update &gt; Firmware</em
+  >会获取并安装你的硬件所有待更新的固件。首次运行时它会安装<code>fwupd</code>。许多固件只能在重启期间写入，所以被要求重启时不必惊讶。
+</p>
+
+<h3 id="warning-about-direct-pacmanyay-updates">
+  关于直接使用pacman/yay更新的提醒<a
+    class="manual__heading-link"
+    href="#warning-about-direct-pacmanyay-updates"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  熟悉Arch的人可能想自己运行<code>pacman -Syu</code>或<code>yay -Syu</code
+  >，但这样会错过Omarchy随新软件包一起执行的快照、迁移和配置更新。因此Omarchy会拦下直接的系统升级，并引导你使用<code
+    >omarchy update</code
+  >。（如果你确实清楚自己在做什么，拦截提示会告诉你如何为单次操作绕过它。）
+</p>
+
+<h3 id="rolling-back-bad-updates">
+  回滚有问题的更新<a
+    class="manual__heading-link"
+    href="#rolling-back-bad-updates"
+    aria-label="本节链接"
+    >#</a
+  >
+</h3>
+
+<p>
+  更新后遇到问题时，可以把系统回滚到更新前创建的快照：重启，在启动加载菜单中选择开始更新之前的那个快照即可。
+</p>
+
+<p><img src="/manual/images/bootloader.webp" alt="bootloader" /></p>
+
+<p>
+  如果配置文件不知怎么损坏了，也可以在终端运行<code>omarchy reinstall</code
+  >重装Omarchy。这会重装所有默认Omarchy软件包，切换到stable并降级过新的软件包，同时重置全部配置文件。注意，你对Omarchy默认配置所做的所有修改都会被覆盖！
+</p>

--- a/src/i18n/zh-CN/manual/web-apps.html
+++ b/src/i18n/zh-CN/manual/web-apps.html
@@ -1,0 +1,159 @@
+<p>
+  通过Omarchy菜单（<code>Super + Space</code>）的<em>Install &gt; Web App</em
+  >可以添加自己的Web应用。它会询问应用名称、应用URL，以及无法通过favicon获取时的图标URL。<a
+    href="https://dashboardicons.com"
+    >Dashboard Icons</a
+  >提供了许多流行Web应用的高质量PNG图标。
+</p>
+
+<p>
+  添加后即可通过应用启动器（<code>Super + Space</code
+  >）访问，并使用精美的无边框Web应用窗口。
+</p>
+
+<p>要移除Web应用，前往Omarchy菜单的<em>Remove &gt; Web App</em>。</p>
+
+<p>
+  建议先用普通浏览器登录所有账户，再使用Web应用快捷方式。轻量的包装框架与1password配合不佳，所以先直接登录更省事。
+</p>
+
+<p>
+  这些Web应用的键盘快捷键都可以在<code>~/.config/hypr/bindings.lua</code>中修改。
+</p>
+
+<p>在Web应用中，<code>Shift + Alt + L</code>可将当前URL复制到剪贴板。</p>
+
+<p>Omarchy默认已内置一批Web应用：</p>
+
+<h2 id="hey">
+  HEY<a class="manual__heading-link" href="#hey" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://www.hey.com/">HEY</a
+  >是一项邮件与日历服务，对厌倦了Gmail、Outlook或Apple
+  Mail的人来说是绝佳替代。它由Omarchy的诞生地<a href="https://37signals.com/"
+    >37signals</a
+  >出品。
+</p>
+
+<p>
+  用<code>Super + Shift + E</code>启动HEY Email，<code
+    >Super + Shift + Alt + E</code
+  >直接撰写新邮件，<code>Super + Shift + C</code>启动HEY Calendar。
+</p>
+
+<h2 id="basecamp">
+  Basecamp<a class="manual__heading-link" href="#basecamp" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://basecamp.com/">Basecamp</a
+  >是一项项目管理服务，帮助小团队更快推进、取得更多进展。与其把Trello、Slack、Asana、Notion之类拼凑在一起，不如用Basecamp把一切集中在一处。它由Omarchy的诞生地<a
+    href="https://37signals.com/"
+    >37signals</a
+  >出品。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Basecamp</p>
+
+<h2 id="chatgpt">
+  ChatGPT<a class="manual__heading-link" href="#chatgpt" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p><a href="https://chatgpt.com">ChatGPT</a>是全球最流行的AI聊天机器人。</p>
+
+<p>用<code>Super + Shift + A</code>启动ChatGPT。</p>
+
+<h2 id="grok">
+  Grok<a class="manual__heading-link" href="#grok" aria-label="本节链接">#</a>
+</h2>
+
+<p><a href="https://grok.com">Grok</a>是xAI的聊天机器人。</p>
+
+<p>用<code>Super + Shift + Alt + A</code>启动Grok。</p>
+
+<h2 id="whatsapp">
+  WhatsApp<a class="manual__heading-link" href="#whatsapp" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://www.whatsapp.com/">WhatsApp</a
+  >是全球最流行的即时通讯服务之一，其网页版是Linux上的好选择。
+</p>
+
+<p>用<code>Super + Shift + Alt + G</code>启动WhatsApp。</p>
+
+<h2 id="google-apps">
+  Google应用<a
+    class="manual__heading-link"
+    href="#google-apps"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  Google Messages、Google Photos、Google Maps和Google
+  Contacts也都以Web应用形式内置。
+</p>
+
+<p>
+  用<code>Super + Shift + Ctrl + G</code>启动Google Messages，<code
+    >Super + Shift + P</code
+  >启动Google Photos，<code>Super + Shift + S</code>启动Google Maps。Google
+  Contacts可通过应用启动器（<code>Super + Space</code>）打开。
+</p>
+
+<h2 id="x">
+  X<a class="manual__heading-link" href="#x" aria-label="本节链接">#</a>
+</h2>
+
+<p>X是新闻首发的地方。</p>
+
+<p>
+  用<code>Super + Shift + X</code>启动X，<code>Super + Shift + Alt + X</code
+  >直接撰写新帖子。
+</p>
+
+<h2 id="youtube">
+  YouTube<a class="manual__heading-link" href="#youtube" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p><a href="https://youtube.com/">YouTube</a>是全球最流行的视频平台。</p>
+
+<p>用<code>Super + Shift + Y</code>启动YouTube。</p>
+
+<h2 id="zoom">
+  Zoom<a class="manual__heading-link" href="#zoom" aria-label="本节链接">#</a>
+</h2>
+
+<p>
+  <a href="https://zoom.us/">Zoom</a
+  >是美国最流行的视频会议系统，全球连接质量都很出色，而且无需付费账户即可召开40分钟的会议。Omarchy封装了Zoom的网页客户端，zoom会议链接会直接在其中打开。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Zoom。</p>
+
+<h2 id="discord">
+  Discord<a class="manual__heading-link" href="#discord" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  <a href="https://discord.com/">Discord</a
+  >是大多数游戏和开源社区的聚集地，包括<a href="https://discord.gg/tXFUdasqhY"
+    >Omarchy自己的社区</a
+  >。
+</p>
+
+<p>通过应用启动器（<code>Super + Space</code>）启动Discord。</p>

--- a/src/i18n/zh-CN/manual/windows-vm.html
+++ b/src/i18n/zh-CN/manual/windows-vm.html
@@ -1,0 +1,111 @@
+<p>
+  Omarchy提供了一种通过Docker虚拟机运行Windows的便捷方式，可在Omarchy菜单（<code
+    >Super + Space</code
+  >）的<em>Install &gt; Windows</em>中安装。
+</p>
+
+<p>
+  这需要机器支持KVM虚拟化——大多数机器都支持，但有时在BIOS中被关闭了，安装程序会提示你。此外还需要磁盘空间：分配给Windows的容量，再加上镜像本身约10GB。
+</p>
+
+<p>
+  安装程序会询问要分配多少内存、多少CPU核心和多少磁盘（64GB或以上是合理的下限），然后询问Windows用户名和密码。留空则使用<code
+    >docker</code
+  >
+  /
+  <code>admin</code
+  >。下载需要一段时间——10到15分钟属正常——可以在浏览器中打开<code>http://127.0.0.1:8006</code>查看进度。浏览器在打开控制台前会要求输入同样的用户名和密码。
+</p>
+
+<p><img src="/manual/images/windows-vm.webp" alt="windows-vm" /></p>
+
+<h2 id="using-it">
+  使用<a class="manual__heading-link" href="#using-it" aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  安装完成后，从应用启动器启动<em>Windows</em>。若虚拟机未运行，它会先启动，然后通过RDP全屏连接。冷启动请给它15到30秒。
+</p>
+
+<p>
+  RDP会话包含声音、麦克风和共享剪贴板，在Linux与Windows之间复制文本开箱即用。分辨率跟随窗口大小，Omarchy还会传递显示缩放设置，所以在HiDPI屏幕上不会模糊。
+</p>
+
+<p>
+  关闭RDP窗口时，虚拟机会自动关机。如果希望它继续运行——比如里面有任务正在进行——改用<code
+    >omarchy windows vm launch --keep-alive</code
+  >启动。
+</p>
+
+<p>其余控制都在同一条命令上：</p>
+
+<pre><code class="language-bash">omarchy windows vm status    # is it running?
+omarchy windows vm stop      # shut it down
+omarchy windows vm launch    # start and connect
+</code></pre>
+
+<h2 id="sharing-files">
+  共享文件<a
+    class="manual__heading-link"
+    href="#sharing-files"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  家目录中的<code>~/Windows</code>会自动与虚拟机共享，想让Windows访问的文件放在这里即可。虚拟机无法访问文件系统的其他任何部分，所以Windows那边的任何恶意程序都伤不到你。它自己的虚拟磁盘位于<code>~/.windows</code>。
+</p>
+
+<p>
+  这两个家目录路径各自保持在自己的文件系统上。它们也可以是指向你所拥有目录的符号链接，虚拟磁盘放在更大的驱动器上时很有用。安装程序测量的是实际容纳<code>~/.windows</code>的文件系统的可用空间，而不一定是家目录所在的文件系统。
+</p>
+
+<p>
+  磁盘目录与共享目录应保持独立、互不重叠。移除时会有意清空磁盘目录，但保留共享目录。删除前，Omarchy会执行一次有界的包含关系检查，若检查超时或无法证明两棵目录树彼此独立，则拒绝删除任何内容。
+</p>
+
+<p>
+  虚拟机启动前，Omarchy会打开并固定这两个目录，然后将确切的目录inode绑定挂载到<code>/var/lib/omarchy/windows/mounts</code>下受root保护的每用户私有锚点上。Docker只能看到这些受保护的锚点。这既保留了自定义磁盘位置，又防止以你身份运行的其他进程在特权容器使用前调换已检查的路径。迁移期间，现有的磁盘目录和共享目录会被收紧为<code>0700</code>权限，其他本地账户无法浏览其内容。
+</p>
+
+<p>
+  虚拟机的端口只绑定到localhost，网络上的任何设备都无法触及这台Windows机器。Web控制台也需要配置的Windows用户名和密码，防止其他本地账户通过8006端口操控虚拟机。
+</p>
+
+<h2 id="limits-and-licensing">
+  限制与许可<a
+    class="manual__heading-link"
+    href="#limits-and-licensing"
+    aria-label="本节链接"
+    >#</a
+  >
+</h2>
+
+<p>
+  这套方案没有GPU直通，不适合游戏或视频编辑。但用来运行Microsoft
+  Office或其他非用不可的软件，非常合适。
+</p>
+
+<p>安装的是未激活的Windows 11 Pro，需要自备许可证密钥才能使用受限功能。</p>
+
+<p>
+  如果这台电脑出厂时预装了Windows，即便安装了Omarchy，OEM密钥仍保存在固件中，用<code
+    >omarchy windows key</code
+  >即可显示。该密钥绑定于这台机器——它可以激活在同一硬件上重装的Windows，但通常无法激活虚拟机。
+</p>
+
+<p>
+  之后可以重新运行<code>omarchy-windows-vm install</code
+  >调整资源分配，它会根据你的回答重写虚拟机配置。compose文件位于<code>/var/lib/omarchy/windows/docker-compose.yml</code>，由root拥有——这是有意为之，以防以你身份运行的进程改写它，让特权启动把整块磁盘挂载进容器。如需手动编辑（例如挂载USB设备），请使用<code>sudo</code>，全部选项参见<a
+    href="https://github.com/dockur/windows"
+    >Dockur Windows项目</a
+  >。
+</p>
+
+<p>
+  要彻底删除，使用Omarchy菜单的<em>Remove &gt; Windows</em
+  >。这会删除虚拟机磁盘及其全部数据，请先确保重要内容已移出<code>~/Windows</code>。
+</p>


### PR DESCRIPTION
The manual was English-only for every locale. This adds a way for a locale to ship a translated manual, and uses it for zh-CN.

## Mechanism

- `src/i18n/<locale>/manual.json` holds `{ slug: { title, sourceHash } }` and `src/i18n/<locale>/manual/<slug>.html` holds the chapter body. Hashes are computed from `src/data/manual.json` with the same helper news translations use, so an English edit automatically invalidates the translation.
- `translateManualChapter` in `src/i18n/content.ts` swaps in the translated title and body. A missing or stale chapter renders the English original behind a short "not translated yet" notice instead of failing the build.
- The manual index, chapter pages, search index and SEO titles/descriptions all read the translated chapters. The five manual UI strings are only required from locales that set `manual: true`.
- `foldHeadingLinks` now tolerates whitespace around heading anchors, since Prettier wraps longer translated headings.
- `check-translations.mjs` requires every chapter for locales with a manual, verifies the source hash, and checks that the set of `href`, `src` and `id` attributes is identical to the English chapter.
- `verify-locales.py` includes `/manual/` and every chapter page for locales with a manual, and skips alternate links and footer language links for locales without one.
- `docs/translations.md` documents the new files and flag.

## zh-CN

- `manual: true` in `locales.json` and all 51 chapters translated, following the wording and register of the existing zh-CN UI, blocks and news translations.
- Commands, menu paths, code blocks, links, ids and images are unchanged from the English chapters.

## Verification

- `npm run check:translations -- zh-CN`: 239 UI messages, 21 news articles, 51 manual chapters.
- `npx tsc --noEmit`, `npx eslint src scripts`, `npm test` pass.
- `npm run build:locale -- zh-CN` builds; `python3 scripts/verify-locales.py zh-CN` verifies 89 pages and 21 RSS articles.
- English and every other locale still redirect `/manual/*` to the English site as before.
