### PR TITLE
Run news and site translations concurrently

### DIFF
--- a/.github/workflows/translate-news.yml
+++ b/.github/workflows/translate-news.yml
@@ -92,20 +92,31 @@ jobs:
           auth.write_text(json.dumps({'schema_version': 1, 'providers': {'meta': {'api_key': key}}}))
           auth.chmod(0o600)
           PY
-      - name: Translate pending site strings in parallel
-        if: steps.pending.outputs.site != '0'
-        id: generate_site
+      - name: Translate site and news concurrently
+        if: steps.pending.outputs.count != '0'
         continue-on-error: true
         env:
           MUSE_MODEL: ${{ vars.MUSE_MODEL || 'muse-spark-1.3-contributor' }}
-        run: python3 scripts/translate-site.py --concurrency 8
-      - name: Translate pending stories in parallel
-        if: steps.pending.outputs.news != '0'
-        id: generate_news
-        continue-on-error: true
-        env:
-          MUSE_MODEL: ${{ vars.MUSE_MODEL || 'muse-spark-1.3-contributor' }}
-        run: python3 scripts/translate-news.py --concurrency 8
+          PENDING_SITE: ${{ steps.pending.outputs.site }}
+          PENDING_NEWS: ${{ steps.pending.outputs.news }}
+        run: |
+          pids=()
+          if [ "$PENDING_SITE" != '0' ]; then
+            python3 scripts/translate-site.py --concurrency 8 &
+            pids+=("$!")
+          fi
+          if [ "$PENDING_NEWS" != '0' ]; then
+            python3 scripts/translate-news.py --concurrency 8 &
+            pids+=("$!")
+          fi
+          # Wait for both queues even if one fails, retaining all valid results.
+          result=0
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+              result=1
+            fi
+          done
+          exit "$result"
       - name: Validate completed translations
         run: npm run check:translations
       - name: Commit completed translations

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -88,7 +88,7 @@ Cloudflare custom domains handle routing and TLS directly. Registered national d
 | Polski           | [pl.omarchy.org](https://pl.omarchy.org) |
 | Lietuvių         | [lt.omarchy.org](https://lt.omarchy.org) |
 | Gaeilge          | [ga.omarchy.org](https://ga.omarchy.org) |
-| Nederlands | [nl.omarchy.org](https://nl.omarchy.org) |
+| Nederlands       | [nl.omarchy.org](https://nl.omarchy.org) |
 
 ## Pointing a new domain to a language site
 
@@ -117,7 +117,7 @@ Keep English chapters in the existing source repository. Store translations sepa
 
 ## Publish English first, translate afterward
 
-Push English component, prose, or Markdown news changes to master. The Pages workflow renders the Markdown and deploys English without waiting for any translations. After that deployment succeeds, the translation workflow regenerates the same English source, finds missing UI/prose keys and missing or stale news by source hash, and invokes Muse with up to eight concurrent batches or stories. UI/prose batches contain at most 20 strings or 8,000 source characters (an indivisible longer HTML block remains intact). Each result must preserve HTML structure and links before it is saved; UI/prose also validates placeholders, numeric values, and command literals. Shared layout, styling, images, and code changes reach every language through the same builds without requiring translation. Successful translations are committed by the Actions bot; failed items remain queued for the hourly retry. A newer English edit invalidates older translations automatically.
+Push English component, prose, or Markdown news changes to master. The Pages workflow renders the Markdown and deploys English without waiting for any translations. After that deployment succeeds, the translation workflow regenerates the same English source, finds missing UI/prose keys and missing or stale news by source hash, and runs the site and news queues concurrently, each with up to eight Muse batches or stories in flight (at most sixteen combined). News does not wait behind site-copy translations. UI/prose batches contain at most 20 strings or 8,000 source characters (an indivisible longer HTML block remains intact). Each result must preserve HTML structure and links before it is saved; UI/prose also validates placeholders, numeric values, and command literals. Shared layout, styling, images, and code changes reach every language through the same builds without requiring translation. Successful translations are committed by the Actions bot; failed items remain queued for the hourly retry. A newer English edit invalidates older translations automatically.
 
 The workflow builds and deploys language sites in a separate six-runner matrix. A model failure does not roll back English publication. If a language deployment fails, the hourly run retries deployment; you can also rerun failed jobs or manually dispatch the workflow. Concurrent runs are serialized; if a rebase conflicts with an editorial change, no forced push is attempted and the next run starts from current master.
 


### PR DESCRIPTION
News translations currently wait for the entire site-copy queue to finish. Start both queues together so a site-copy backlog no longer delays news translation.

Each queue retains eight concurrent Muse requests, for a maximum of sixteen combined. Empty queues are skipped. The workflow waits for both processes even when one fails, then validates and commits successful results through the existing retry/deployment flow. Translation selection is unchanged: only missing or outdated content goes to Muse.

Validated the exact Bash step with fixtures covering concurrent startup, either queue failing, waiting for both results, and skipping empty queues. Bash syntax, formatting, and diff checks pass.
