### PR TITLE
Translate the Voices toggle

### DIFF
--- a/src/components/Voices.tsx
+++ b/src/components/Voices.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { CardRail } from '@/components/CardRail'
 import voices from '@/data/voices.json'
+import { t } from '@/i18n/site'
 
 /** The wall's height before the fold, on a wide screen. */
 const FOLD_REM = 42
@@ -94,7 +95,7 @@ export function Voices() {
       </div>
       <div className="mt-6 hidden justify-center sm:flex">
         <Button variant="outline" aria-expanded={open} onClick={toggle}>
-          {open ? 'Show less' : 'View more'}
+          {open ? t('Show less') : t('View more')}
         </Button>
       </div>
     </>

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -342,5 +342,7 @@
   "Omarchy Server 4.0": "Omarchy Server 4.0",
   "Plugin": "Plugin",
   "Rangers": "Rangers",
-  "Server - Omarchy": "Server - Omarchy"
+  "Server - Omarchy": "Server - Omarchy",
+  "View more": "Meer bekijken",
+  "Show less": "Minder bekijken"
 }


### PR DESCRIPTION
The "View more" / "Show less" button under the Voices section on the home page is a hardcoded string in `src/components/Voices.tsx`, so it shows in English on every language site (checked on nl.omarchy.org, and the Dutch, Danish and French catalogues all lack the key). This routes both labels through `t()` and adds the Dutch values in `messages/nl.json`. Other languages fall back to English until the translation workflow picks the two new keys up.

`npm run lint`, `npm run typecheck`, `npm test`, `prettier --check` and `npm run check:translations -- --strict-site nl` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ht7n7vD54HXt4CZgP2Xb
