### PR TITLE
Fix duplicate hero navigation in translated editions

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -509,7 +509,11 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
         <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
           {glyph}
 
-          <nav aria-label={t('Main')} className="hidden items-center sm:flex">
+          <nav
+            data-nav-links
+            aria-label={t('Main')}
+            className="hidden items-center sm:flex"
+          >
             {navLinks.map((link) =>
               'href' in link ? (
                 <a

--- a/src/styles.css
+++ b/src/styles.css
@@ -1128,7 +1128,7 @@ h6 {
 }
 
 /* Hide real labels while the blended copy is visible to avoid double painting. */
-[data-nav-blend] nav[aria-label='Main'] a,
+[data-nav-blend] [data-nav-links] a,
 [data-nav-blend] [data-nav-glyph],
 [data-nav-blend] [data-nav-toggle] {
   color: transparent;
@@ -1139,7 +1139,7 @@ h6 {
    painted through one comes out near enough black. Hovering hands the labels
    back to the real layer anyway - this is only here so that the two can never
    be seen in the same frame. */
-[data-nav-blend] nav[aria-label='Main'] a,
+[data-nav-blend] [data-nav-links] a,
 [data-nav-blend] [data-nav-glyph]:hover,
 [data-nav-blend] [data-nav-toggle]:hover {
   background-color: transparent;


### PR DESCRIPTION
The shared header's hero blend rules depend on the English accessibility label `aria-label='Main'`. In any locale that translates that label, the selectors stop matching: the real navigation links remain visible alongside the blended ghost copy, producing duplicate header text over the hero. This affects translated editions globally; Chinese was where the issue was first observed.

Add a stable `data-nav-links` attribute to the shared navigation and use it in both blend selectors. Styling now works independently of the selected language, while preserving translated accessibility labels and the existing header design. The fix applies to every locale, including English, with no additional JavaScript.

Validation: formatting, ESLint, and `git diff --check` passed. The Chinese development page returned HTTP 200 and rendered the new attribute alongside its translated label. Automated browser interaction testing was not completed.
