### PR TITLE
Native-speaker pass over the Dutch news articles

### DIFF
--- a/src/i18n/nl/news.json
+++ b/src/i18n/nl/news.json
@@ -4,7 +4,7 @@
     "sourceHash": "a76cd32b42674a074c278018eb2180207f7de4f171e5217e41e501fb360fc091"
   },
   "omacom-foundation-accelerates-spending-goals": {
-    "title": "Omacom Foundation schroeft het bestedingstempo op",
+    "title": "Omacom Foundation versnelt de bestedingen",
     "sourceHash": "40d10806f7a90648e312d9bdc550b3d6c2455062faa6646020bd835b5d594225"
   },
   "omacom-patronage-is-open-to-everyone": {

--- a/src/i18n/nl/news/100000-downloads-in-a-week.html
+++ b/src/i18n/nl/news/100000-downloads-in-a-week.html
@@ -1,7 +1,7 @@
 <p>
   Honderdduizend downloads van de Omarchy-ISO in één week! Honderdduizend mensen
   die besloten: dít is de week dat ik eindelijk Linux ga proberen (of er weer
-  naar terugga). Wat een bazen!
+  naar terugkeer). Wat een bazen!
 </p>
 
 <p>
@@ -19,9 +19,9 @@
 <p>
   Omdat <a href="https://www.cloudflare.com/">Cloudflare</a> vóór alles staat:
   de ISO’s, de Omarchy-pakketten en onze Arch-mirror. Alles op R2, alles achter
-  hun CDN. En geen van beide heeft er natuurlijk ook maar een druppel zweet om
-  gelaten. Daarom hadden honderdduizend mensen de afgelopen week een snelle,
-  saaie, totaal onopvallende download, waar ook ter wereld.
+  hun CDN. En geen van beide is er natuurlijk ook maar van gaan zweten. Daarom
+  hadden honderdduizend mensen de afgelopen week een snelle, saaie download
+  zonder enig gedoe, waar ook ter wereld.
 </p>
 
 <p>

--- a/src/i18n/nl/news/1password-and-37signals-become-distinguished-corporate-patrons.html
+++ b/src/i18n/nl/news/1password-and-37signals-become-distinguished-corporate-patrons.html
@@ -3,7 +3,7 @@
   Distinguished Corporate Patrons!
   <a href="https://1password.com">1Password</a> en
   <a href="https://37signals.com">37signals</a> leggen de komende drie jaar elk
-  100.000 dollar per jaar in, waarmee de financiering van de foundation op 12,6
+  100.000 dollar per jaar in, waarmee de financiering van de stichting op 12,6
   miljoen dollar komt.
 </p>
 
@@ -32,22 +32,22 @@
   <a href="https://world.hey.com/dhh/all-in-on-omarchy-at-37signals-68162450"
     >het hele technische team al overgezet naar Omarchy</a
   >, en we hebben op weg naar Quattro (en daarvoor) allerlei rekeningen betaald.
-  Nu is die steun officieel, via de foundation, op dezelfde voorwaarden als
+  Nu is die steun officieel, via de stichting, op dezelfde voorwaarden als
   iedereen.
 </p>
 
 <p>
-  Ook goed om te zeggen: bedrijfsgeld en privégeld kopen precies hetzelfde,
+  Ook goed om te weten: bedrijfsgeld en privégeld kopen precies hetzelfde,
   namelijk erkenning voor je aandeel in de missie. Er is hier geen
   voor-wat-hoort-wat.
 </p>
 
 <p>
-  Omarchy laat zijn beslissingen altijd afhangen van wat het allerbeste
-  kneedbare OS ter wereld oplevert. En dat wordt nog preciezer afgebakend door
-  de “by DHH” die je ziet als je het systeem installeert. Voordat dit een
-  geweldig systeem voor iedereen kan zijn, moet het eerst een geweldig systeem
-  voor mij persoonlijk zijn. Eerst je eigen zuurstofmasker op, en zo!
+  Omarchy baseert zijn beslissingen altijd op wat het allerbeste kneedbare OS
+  ter wereld oplevert. En dat wordt nog preciezer afgebakend door de “by DHH”
+  die je ziet als je het systeem installeert. Voordat dit een geweldig systeem
+  voor iedereen kan zijn, moet het eerst een geweldig systeem voor mij
+  persoonlijk zijn. Eerst je eigen zuurstofmasker op, je kent het wel!
 </p>
 
 <p>

--- a/src/i18n/nl/news/introducing-omarchy-air.html
+++ b/src/i18n/nl/news/introducing-omarchy-air.html
@@ -2,7 +2,7 @@
   Omarchy vindt dat een computer net zo mooi moet zijn als hij productief is.
   Dat uitgangspunt dragen de themamakers en andere Omarchy-kunstenaars al sinds
   dag één. Complete paletten bouwen, in hun eigen tijd, gratis, omdat ze wilden
-  dat hun machine ergens op leek.
+  dat hun machine er goed uitzag.
 </p>
 
 <p>
@@ -27,22 +27,22 @@
 <p>
   <a href="https://github.com/HANCORE-linux">HANCORE</a> heeft twee thema's die
   standaard met Omarchy meekomen – Solitude en Last Horizon – en nog eens
-  twintig op <a href="/themes/">de extra's-pagina</a>, meer dan wie dan ook
-  heeft bijgedragen: Batou, Oxo Carbon, Velvet Night, Rose of Dune, Shades of
-  Jade, en zo gaat het maar door. Hij is een werktuigbouwkundig ingenieur die
-  uitgroeide tot een van de bepalende esthetische krachten in deze community,
+  twintig op <a href="/themes/">de pagina met extra thema's</a>, meer dan wie
+  dan ook heeft bijgedragen: Batou, Oxo Carbon, Velvet Night, Rose of Dune,
+  Shades of Jade, en zo gaat het maar door. Werktuigbouwkundige van huis uit,
+  uitgegroeid tot een van de bepalende esthetische krachten in deze community,
   zit in <a href="/teams/">Omarchy Core</a> en helpt
   <a href="https://plugins.omarchy.org/">het plugin-ecosysteem</a> in goede
   banen te leiden.
 </p>
 
 <p>
-  <a href="https://github.com/OldJobobo">OldJobobo</a> tekende voor drie van de
+  <a href="https://github.com/OldJobobo">OldJobobo</a> maakte drie van de
   thema's die met Omarchy meekomen – Lumon, Miasma en Retro 82 – plus nog eens
-  tien op de extra's-pagina, van Batman tot City-783 tot Sakura Mochi. Hij werkt
-  in complete paletten in plaats van losse kleurenschema's, en daarom houden
-  zijn thema's stand in de terminal, Neovim, btop én de shell, in plaats van
-  alleen op een screenshot goed te ogen.
+  tien op de pagina met extra thema's, van Batman tot City-783 tot Sakura Mochi.
+  Hij werkt in complete paletten in plaats van losse kleurenschema's, en daarom
+  houden zijn thema's stand in de terminal, Neovim, btop én de shell, in plaats
+  van alleen op een screenshot goed te lijken.
 </p>
 
 <p>De laatste plek is op uitnodiging. Het programma begint in oktober.</p>

--- a/src/i18n/nl/news/introducing-the-omarchy-rangers.html
+++ b/src/i18n/nl/news/introducing-the-omarchy-rangers.html
@@ -25,16 +25,16 @@
 </ul>
 
 <p>
-  Drie mensen, drie continenten, en dat is zo’n beetje het punt. De
-  Omarchy-community houdt geen kantooruren in één tijdzone, en dat moeten de
-  mensen die haar helpen ook niet doen.
+  Drie mensen, drie continenten, en dat is precies de bedoeling. De
+  Omarchy-community houdt geen kantooruren in één tijdzone, en dat hoeven de
+  mensen die haar helpen ook niet.
   <a href="https://discord.com/invite/tXFUdasqhY">De Discord</a> gonst altijd.
 </p>
 
 <p>
   Want bijna niemand stapt in z’n eentje over op Linux. En mensen blijven vaak
-  omdat iemand die eerste week een welkom gevoel gaf. Sommigen doen daarna
-  hetzelfde voor de volgende. Zo groeit dit hele ding.
+  omdat iemand ervoor zorgde dat die eerste week welkom voelde. Sommigen doen
+  daarna hetzelfde voor de volgende. Zo groeit dit hele gebeuren.
 </p>
 
 <p>

--- a/src/i18n/nl/news/omacom-foundation-accelerates-spending-goals.html
+++ b/src/i18n/nl/news/omacom-foundation-accelerates-spending-goals.html
@@ -1,8 +1,9 @@
 <p>
-  Dit is dé kans voor Linux. De desktop ligt voor het grijpen zoals in decennia
-  niet is voorgekomen. De agents hebben het besturingssysteem kneedbaar gemaakt.
-  De hardware was nog nooit zo goed. En de concurrentie had nog nooit zo veel
-  zin om haar eigen gebruikers te pesten. Dit moment laten we niet voorbijgaan!
+  Dit is dé kans voor Linux. De desktop ligt voor het grijpen zoals al
+  tientallen jaren niet meer. De agents hebben het besturingssysteem kneedbaar
+  gemaakt. De hardware was nog nooit zo goed. En de concurrentie had nog nooit
+  zo veel zin om haar eigen gebruikers te pesten. Dit moment laten we niet
+  voorbijgaan!
 </p>
 
 <p>
@@ -34,7 +35,7 @@
     >ontwikkelaars</a
   >
   die het snel, compatibel en veilig maken. Naar wedstrijden, subsidies en
-  infrastructuur. Naar alles wat nodig is om de profetie van Linux op de desktop
+  infrastructuur. Naar alles wat nodig is om de Profetie van Linux op de desktop
   te vervullen.
 </p>
 
@@ -45,7 +46,7 @@
 
 <p>
   Wil je meedoen? <a href="https://donate.omarchy.org">Word donateur</a> via ons
-  nieuwe open steunprogramma. En ben je geïnteresseerd in de opties voor
-  Founding Patron of Distinguished Patron, als particulier of als bedrijf, mail
-  dan <a href="mailto:david@omarchy.org">david@omarchy.org</a>.
+  nieuwe open donateurschap. En wil je Founding of Distinguished Patron worden,
+  als particulier of als bedrijf? Mail dan
+  <a href="mailto:david@omarchy.org">david@omarchy.org</a>.
 </p>

--- a/src/i18n/nl/news/omacom-foundation-funding-hits-10m.html
+++ b/src/i18n/nl/news/omacom-foundation-funding-hits-10m.html
@@ -9,13 +9,13 @@
 
 <p>
   Net als de oorspronkelijke acht Founding Patrons leggen Drew en Peter ieder 1
-  miljoen dollar in. Daarmee heeft de foundation tien donateurs en een ronde
-  TIEN MILJOEN DOLLAR om onze gedurfde missie vooruit te stuwen: Linux op de
-  desktop laten slagen, maar dan op een veel grotere schaal.
+  miljoen dollar in. Daarmee heeft de stichting tien Founding Patrons en een
+  ronde TIEN MILJOEN DOLLAR om onze gedurfde missie vooruit te stuwen: Linux op
+  de desktop laten slagen, maar dan op een veel grotere schaal.
 </p>
 
 <p>
-  Het is extra zoet om Drew en Peter aan boord te hebben, omdat ik persoonlijk
+  Het is extra mooi om Drew en Peter aan boord te hebben, omdat ik persoonlijk
   zo’n grote fan ben van allebei en van wat ze hebben neergezet. Ik ben al bijna
   twintig jaar enthousiast klant van Dropbox, en het is de spil van hoe ik met
   <em
@@ -46,18 +46,18 @@
   rond Omarchy wil hebben. Drew maakte van een persoonlijke ergernis over
   bestanden tussen computers heen slepen Dropbox. Peter maakte van een
   weekendproject OpenClaw, en herinnerde iedereen er en passant aan hoeveel
-  honger er is naar computers die persoonlijk, programmeerbaar en leuk
+  behoefte er is aan computers die persoonlijk, programmeerbaar en leuk
   aanvoelen.
 </p>
 
 <p>
   Dat is ook de geest achter de Omacom Foundation. Wij zijn er om de
   infrastructuur, opensourceprojecten en ontwikkelaars te financieren die nodig
-  zijn om van de Linux-desktop een heerlijk thuis te maken voor de volgende
+  zijn om van de Linux-desktop een fijn thuis te maken voor de volgende
   generatie computergebruikers.
 </p>
 
 <p>
-  Welkom, Drew en Peter. Tien Founding Patrons. Tien miljoen dollar. De profetie
+  Welkom, Drew en Peter. Tien Founding Patrons. Tien miljoen dollar. De Profetie
   is weer 2 miljoen dollar dichterbij!
 </p>

--- a/src/i18n/nl/news/omacom-foundation-hires-krzysztof-wilczynski.html
+++ b/src/i18n/nl/news/omacom-foundation-hires-krzysztof-wilczynski.html
@@ -1,8 +1,8 @@
 <p>
   De <a href="/foundation/">Omacom Foundation</a> heeft haar eerste fulltime
-  kracht binnen!
+  medewerker aangenomen!
   <a href="https://x.com/kwilczynski">Krzysztof Wilczyński</a> komt ons werk aan
-  de Omarchy Kernel leiden. Dit is precies waarvoor de foundation is opgericht:
+  de Omarchy Kernel leiden. Dit is precies waarvoor de stichting is opgericht:
   goede mensen betalen om aan moeilijke problemen te werken, in het belang van
   iedereen.
 </p>
@@ -10,9 +10,9 @@
 <p>
   Krzysztof is al jaren Linux-kernelontwikkelaar. Hij is co-maintainer van het
   PCI Endpoint-subsysteem en van de native PCI host bridge- en endpoint-drivers.
-  Dat is het loodgieterswerk dat Linux verbindt met je GPU, je NVMe-schijf en je
-  wifikaart. Hij is ook reviewer van het nieuwe Rust PCI-werk in de kernel.
-  Voordat hij zich vol op de kernel stortte, werkte hij jarenlang in systems
+  Dat is de bedrading tussen Linux en je GPU, je NVMe-schijf en je wifikaart.
+  Hij is ook reviewer van het nieuwe Rust PCI-werk in de kernel. Voordat hij
+  zich helemaal op de kernel stortte, werkte hij jarenlang in systems
   engineering, aan Kubernetes en container-runtimes.
 </p>
 
@@ -20,7 +20,7 @@
   Al die ervaring neemt hij nu mee naar de Omarchy Kernel. De focus: prestaties,
   compatibiliteit en beveiliging. We willen dat Linux vliegt op gloednieuwe
   laptops én op stokoude ThinkPads. We willen dat het op meer machines out of
-  the box werkt. En we willen het potdicht.
+  the box werkt. En we willen het potdicht hebben.
 </p>
 
 <p>
@@ -28,4 +28,4 @@
   helpt de koers van de distro als geheel uit te zetten.
 </p>
 
-<p>Welkom aan boord, Krzysztof! Tijd om die kernel te laten gillen.</p>
+<p>Welkom aan boord, Krzysztof! Tijd om die kernel te laten opstijgen.</p>

--- a/src/i18n/nl/news/omacom-foundation-launches-with-8-million.html
+++ b/src/i18n/nl/news/omacom-foundation-launches-with-8-million.html
@@ -1,36 +1,100 @@
-<p>Het is tijd om groot te dromen. Omarchy Quattro heeft mensen de kans gegeven om te ervaren hoe de kneedbare computer van de toekomst eruitziet, en ze vinden het geweldig (echt heel erg!). Het voelt nu als een morele plicht om deze toekomst breder beschikbaar te maken en voor het eerst in wat een eeuwigheid lijkt fundamenteel te veranderen hoe mensen met hun computer omgaan.</p>
+<p>
+  Het is tijd om groot te dromen. Omarchy Quattro heeft mensen de kans gegeven
+  om te ervaren hoe de kneedbare computer van de toekomst eruitziet, en ze
+  vinden het geweldig (en niet zo'n beetje ook!). Het voelt nu als een morele
+  plicht om deze toekomst breder beschikbaar te maken en voor het eerst in wat
+  een eeuwigheid lijkt fundamenteel te veranderen hoe mensen met hun computer
+  omgaan.
+</p>
 
-<p>Om precies dat te doen, richt ik de Omacom Foundation op om ervoor te zorgen dat deze missie volledig gefinancierd, duurzaam en klaar om te versnellen is.</p>
+<p>
+  Daarom richt ik de Omacom Foundation op, zodat deze missie volledig
+  gefinancierd is, lang meegaat en klaar is om te versnellen.
+</p>
 
-<p>Deze stichting zonder winstoogmerk zal de handelsmerken beheren, de infrastructuur financieren, het werk promoten en de open-sourceprojecten en ontwikkelaars ondersteunen waarvan Omarchy afhankelijk is.</p>
+<p>
+  Deze non-profitstichting beheert de handelsmerken, financiert de
+  infrastructuur, promoot het werk en steunt de opensourceprojecten en
+  ontwikkelaars waarop Omarchy is gebouwd.
+</p>
 
-<p>Deze twaalf Founding Patrons dragen elk $1 miljoen bij aan deze missie:</p>
+<p>
+  Deze twaalf Founding Patrons dragen elk 1 miljoen dollar bij aan deze missie:
+</p>
 
 <ul>
-  <li><a href="https://x.com/tobi">Tobi Lütke</a>, CEO van <a href="https://www.shopify.com/">Shopify</a></li>
-  <li><a href="https://x.com/patrickc">Patrick Collison</a>, CEO van <a href="https://stripe.com">Stripe</a></li>
-  <li><a href="https://x.com/MichaelDell">Michael Dell</a>, voorzitter en CEO van <a href="https://www.dell.com">Dell Technologies</a></li>
-  <li><a href="https://x.com/jack">Jack Dorsey</a>, Block Head en voorzitter van <a href="https://block.xyz">Block</a></li>
-  <li><a href="https://x.com/eastdakota">Matthew Prince</a>, CEO van <a href="https://www.cloudflare.com">Cloudflare</a></li>
-  <li><a href="https://x.com/brendaniribe">Brendan Iribe</a>, medeoprichter van <a href="https://www.sesame.com">Sesame</a> en Oculus</li>
-  <li><a href="https://x.com/jasonfried">Jason Fried</a>, CEO van <a href="https://37signals.com">37signals</a></li>
-  <li><a href="https://x.com/drewhouston">Drew Houston</a>, medeoprichter en co-CEO van <a href="https://www.dropbox.com">Dropbox</a></li>
-  <li><a href="https://x.com/steipete">Peter Steinberger</a>, maker van <a href="https://openclaw.ai">OpenClaw</a></li>
-  <li><a href="https://x.com/brian_armstrong">Brian Armstrong</a>, CEO van <a href="https://www.coinbase.com">Coinbase</a></li>
-  <li><a href="https://x.com/xdanger">Yunjie Dai</a>, medeoprichter van <a href="https://www.taptap.io">TapTap</a></li>
+  <li>
+    <a href="https://x.com/tobi">Tobi Lütke</a>, CEO van
+    <a href="https://www.shopify.com/">Shopify</a>
+  </li>
+  <li>
+    <a href="https://x.com/patrickc">Patrick Collison</a>, CEO van
+    <a href="https://stripe.com">Stripe</a>
+  </li>
+  <li>
+    <a href="https://x.com/MichaelDell">Michael Dell</a>, voorzitter en CEO van
+    <a href="https://www.dell.com">Dell Technologies</a>
+  </li>
+  <li>
+    <a href="https://x.com/jack">Jack Dorsey</a>, Block Head en voorzitter van
+    <a href="https://block.xyz">Block</a>
+  </li>
+  <li>
+    <a href="https://x.com/eastdakota">Matthew Prince</a>, CEO van
+    <a href="https://www.cloudflare.com">Cloudflare</a>
+  </li>
+  <li>
+    <a href="https://x.com/brendaniribe">Brendan Iribe</a>, medeoprichter van
+    <a href="https://www.sesame.com">Sesame</a> en Oculus
+  </li>
+  <li>
+    <a href="https://x.com/jasonfried">Jason Fried</a>, CEO van
+    <a href="https://37signals.com">37signals</a>
+  </li>
+  <li>
+    <a href="https://x.com/drewhouston">Drew Houston</a>, medeoprichter en
+    co-CEO van <a href="https://www.dropbox.com">Dropbox</a>
+  </li>
+  <li>
+    <a href="https://x.com/steipete">Peter Steinberger</a>, maker van
+    <a href="https://openclaw.ai">OpenClaw</a>
+  </li>
+  <li>
+    <a href="https://x.com/brian_armstrong">Brian Armstrong</a>, CEO van
+    <a href="https://www.coinbase.com">Coinbase</a>
+  </li>
+  <li>
+    <a href="https://x.com/xdanger">Yunjie Dai</a>, medeoprichter van
+    <a href="https://www.taptap.io">TapTap</a>
+  </li>
   <li>Ondergetekende</li>
 </ul>
 
-<p>Deze Distinguished Patrons dragen elk $100.000 bij aan de missie:</p>
+<p>Deze Distinguished Patrons dragen elk 100.000 dollar bij aan de missie:</p>
 
 <ul>
-  <li><a href="https://x.com/ryanrhughes">Ryan R. Hughes</a>, partner bij <a href="https://heyoodle.com/">Oodle</a></li>
-  <li><a href="https://x.com/dxhuang">Ed Huang</a>, medeoprichter en CTO van <a href="https://www.pingcap.com">PingCAP</a></li>
-  <li><a href="https://www.linkedin.com/in/atreccani/">Adrien Treccani</a>, oprichter van <a href="https://ripple.com/products/custody/">Metaco</a></li>
-  <li><a href="https://x.com/mschoening">Max Schoening</a>, Hoofd Product bij <a href="https://www.notion.com">Notion</a></li>
+  <li>
+    <a href="https://x.com/ryanrhughes">Ryan R. Hughes</a>, partner bij
+    <a href="https://heyoodle.com/">Oodle</a>
+  </li>
+  <li>
+    <a href="https://x.com/dxhuang">Ed Huang</a>, medeoprichter en CTO van
+    <a href="https://www.pingcap.com">PingCAP</a>
+  </li>
+  <li>
+    <a href="https://www.linkedin.com/in/atreccani/">Adrien Treccani</a>,
+    oprichter van <a href="https://ripple.com/products/custody/">Metaco</a>
+  </li>
+  <li>
+    <a href="https://x.com/mschoening">Max Schoening</a>, Head of Product bij
+    <a href="https://www.notion.com">Notion</a>
+  </li>
 </ul>
 
-<p>En deze Distinguished Corporate Patrons dragen elk $100.000 per jaar bij, drie jaar lang:</p>
+<p>
+  En deze Distinguished Corporate Patrons dragen elk 100.000 dollar per jaar
+  bij, drie jaar lang:
+</p>
 
 <ul>
   <li><a href="https://1password.com">1Password</a></li>
@@ -38,13 +102,23 @@
   <li><a href="https://www.paywithfour.com/">Four Technologies</a></li>
 </ul>
 
-<p>Deze Founding Token Patron draagt $1,5 miljoen in tokens bij aan de missie:</p>
+<p>
+  Deze Founding Token Patron draagt 1,5 miljoen dollar in tokens bij aan de
+  missie:
+</p>
 
 <ul>
-  <li><a href="https://www.meta.com/superintelligence/">Meta Superintelligence Labs</a></li>
+  <li>
+    <a href="https://www.meta.com/superintelligence/"
+      >Meta Superintelligence Labs</a
+    >
+  </li>
 </ul>
 
-<p>En deze Distinguished Corporate Patrons dragen elk $150.000 in tokens bij, met verlenging in onderling overleg:</p>
+<p>
+  En deze Distinguished Corporate Patrons dragen elk 150.000 dollar in tokens
+  bij, met verlenging in onderling overleg:
+</p>
 
 <ul>
   <li><a href="https://www.anthropic.com">Anthropic</a></li>
@@ -53,20 +127,79 @@
   <li><a href="https://openrouter.ai/">OpenRouter</a></li>
 </ul>
 
-<p>Bijna 500 donateurs hebben via <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage">open mecenaat</a> ook ongeveer $60.000 bijgedragen, waarmee het totaal aan toezeggingen en donaties op ongeveer $15,5 miljoen komt.</p>
+<p>
+  Bijna 500 donateurs hebben via
+  <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage"
+    >open donateurschap</a
+  >
+  ook ongeveer 60.000 dollar bijgedragen, waarmee het totaal aan toezeggingen en
+  donaties op ongeveer 15,5 miljoen dollar komt.
+</p>
 
-<p>Dit is een belachelijk grote som geld, dus ik ben van plan ervoor te zorgen dat we er lang mee doen en er het maximale uithalen. Maar net zo belangrijk als dit ongelooflijke vangnet is de blijk van vertrouwen die deze toezeggingen afgeven.</p>
+<p>
+  Dit is een belachelijk bedrag, dus ik ga ervoor zorgen dat het lang meegaat en
+  dat we er het maximale uithalen. Maar minstens zo belangrijk als die
+  ongelooflijke buffer is het vertrouwen dat uit deze toezeggingen spreekt.
+</p>
 
-<p>We gaan de voorspelling van The Year of Linux on the Desktop waarmaken. Alle stukjes liggen nu op hun plek. Tijd om vol in te zetten!</p>
+<p>
+  We gaan de Profetie van het Jaar van Linux op de Desktop waarmaken. Alle
+  stukjes liggen nu op hun plek. Tijd om all-in te gaan!
+</p>
 
-<p><em>UPDATE: Drew en Peter <a href="/news/2026/08/omacom-foundation-funding-hits-10m/">werden op 24 augustus Founding Patrons</a>.</em></p>
+<p>
+  <em
+    >UPDATE: Drew en Peter
+    <a href="/news/2026/08/omacom-foundation-funding-hits-10m/"
+      >werden op 24 augustus Founding Patrons</a
+    >.</em
+  >
+</p>
 
-<p><em>UPDATE: Brian en Yunjie <a href="/news/2026/08/omacom-foundation-welcomes-brian-armstrong-and-yunjie-dai/">werden op 31 augustus Founding Patrons</a>.</em></p>
+<p>
+  <em
+    >UPDATE: Brian en Yunjie
+    <a
+      href="/news/2026/08/omacom-foundation-welcomes-brian-armstrong-and-yunjie-dai/"
+      >werden op 31 augustus Founding Patrons</a
+    >.</em
+  >
+</p>
 
-<p><em>UPDATE: 1Password en 37signals <a href="/news/2026/08/1password-and-37signals-become-distinguished-corporate-patrons/">werden op 31 augustus Distinguished Corporate Patrons</a>.</em></p>
+<p>
+  <em
+    >UPDATE: 1Password en 37signals
+    <a
+      href="/news/2026/08/1password-and-37signals-become-distinguished-corporate-patrons/"
+      >werden op 31 augustus Distinguished Corporate Patrons</a
+    >.</em
+  >
+</p>
 
-<p><em>UPDATE: Ryan, Ed, Adrien en Max <a href="/news/2026/09/omacom-foundation-reaches-13-million/">werden op 2 september Distinguished Patrons</a>.</em></p>
+<p>
+  <em
+    >UPDATE: Ryan, Ed, Adrien en Max
+    <a href="/news/2026/09/omacom-foundation-reaches-13-million/"
+      >werden op 2 september Distinguished Patrons</a
+    >.</em
+  >
+</p>
 
-<p><em>UPDATE: Meta Superintelligence Labs, Anthropic, OpenAI en Fireworks <a href="/news/2026/09/omacom-foundation-secures-tokens-from-leading-labs/">werden op 3 september Token Patrons</a>.</em></p>
+<p>
+  <em
+    >UPDATE: Meta Superintelligence Labs, Anthropic, OpenAI en Fireworks
+    <a href="/news/2026/09/omacom-foundation-secures-tokens-from-leading-labs/"
+      >werden op 3 september Token Patrons</a
+    >.</em
+  >
+</p>
 
-<p><em>UPDATE: OpenRouter, Four Technologies en bijna 500 donateurs <a href="/news/2026/09/omacom-foundation-raises-another-half-a-million-dollars/">voegden op 7 september nog eens een half miljoen dollar toe</a>.</em></p>
+<p>
+  <em
+    >UPDATE: OpenRouter, Four Technologies en bijna 500 donateurs
+    <a
+      href="/news/2026/09/omacom-foundation-raises-another-half-a-million-dollars/"
+      >voegden op 7 september nog eens een half miljoen dollar toe</a
+    >.</em
+  >
+</p>

--- a/src/i18n/nl/news/omacom-foundation-raises-another-half-a-million-dollars.html
+++ b/src/i18n/nl/news/omacom-foundation-raises-another-half-a-million-dollars.html
@@ -1,19 +1,81 @@
-<p>De <a href="/foundation/">Omacom Foundation</a> heeft nog eens een half miljoen dollar opgehaald! Met een nieuwe voorraad tokens, een driejarige zakelijke toezegging en duizenden dollars uit open patronage is dat ongeveer $510,000 extra voor mooie, leuke &amp; agentic Linux. Daarmee komt ons totaal aan toezeggingen en donaties op ongeveer $15.5 miljoen!</p>
+<p>
+  De <a href="/foundation/">Omacom Foundation</a> heeft nog eens een half
+  miljoen dollar opgehaald! Met een nieuwe voorraad tokens, een driejarige
+  zakelijke toezegging en duizenden dollars uit het open donateurschap is dat
+  ongeveer 510.000 dollar extra voor mooi, leuk &amp; agentic Linux. Daarmee
+  komt ons totaal aan toezeggingen en donaties op ongeveer 15,5 miljoen dollar!
+</p>
 
-<p>Ten eerste verwelkomen we <a href="https://openrouter.ai/">OpenRouter</a> als <a href="/patrons/#distinguished-corporate-patrons">Distinguished Corporate Patron</a> met $150,000 aan tokens. Zodra die toewijzing op is, kunnen we de regeling in onderling overleg verlengen. Deze tokens zullen de agents aandrijven die Omarchy bouwen, testen en onderhouden. Hoe meer we agents kunnen inzetten om bugs te fixen, bijdragen te reviewen en de distro te verbeteren, hoe sneller we ieders computer beter kunnen maken. Meer brandstof voor de missie!</p>
+<p>
+  Ten eerste verwelkomen we <a href="https://openrouter.ai/">OpenRouter</a> als
+  <a href="/patrons/#distinguished-corporate-patrons"
+    >Distinguished Corporate Patron</a
+  >
+  met 150.000 dollar aan tokens. Zodra dat tegoed op is, kunnen we de regeling
+  in onderling overleg verlengen. Op deze tokens draaien de agents die Omarchy
+  bouwen, testen en onderhouden. Hoe meer we agents kunnen inzetten om bugs te
+  fixen, bijdragen te reviewen en de distro te verbeteren, hoe sneller we ieders
+  computer beter kunnen maken. Meer brandstof voor de missie!
+</p>
 
-<p>We gaan de miljoenen dollars aan gedoneerde tokens ook via het uitstekende OpenRouter-platform laten lopen. Zodat we de juiste tokens van de juiste modellen aan de juiste teams kunnen toewijzen.</p>
+<p>
+  We gaan de miljoenen dollars aan gedoneerde tokens ook via het uitstekende
+  OpenRouter-platform laten lopen. Zodat we de juiste tokens van de juiste
+  modellen aan de juiste teams kunnen toewijzen.
+</p>
 
-<p>Dan is er <a href="https://www.paywithfour.com/">Four Technologies</a>, dat zich aansluit als <a href="/patrons/#distinguished-corporate-patrons">Distinguished Corporate Patron</a> met een toezegging van $100,000 per jaar voor drie jaar. Dat is $300,000 ter ondersteuning van de communityprojecten waarvan Omarchy afhankelijk is, de infrastructuur die het draaiende houdt, en het werk om mooie Linux bij meer mensen te brengen. Als bedrijven zich voor jaren vastleggen, geeft ons dat het vertrouwen om hetzelfde te doen.</p>
+<p>
+  Dan is er <a href="https://www.paywithfour.com/">Four Technologies</a>, dat
+  zich aansluit als
+  <a href="/patrons/#distinguished-corporate-patrons"
+    >Distinguished Corporate Patron</a
+  >
+  met een toezegging van 100.000 dollar per jaar voor drie jaar. Dat is 300.000
+  dollar voor de communityprojecten waarvan Omarchy afhankelijk is, de
+  infrastructuur die het draaiende houdt, en het werk om mooi Linux naar meer
+  mensen te brengen. Als bedrijven zich voor meerdere jaren vastleggen, geeft
+  ons dat het vertrouwen om hetzelfde te doen.
+</p>
 
 <p>Zo verwoordt het team van Four Technologies het:</p>
 
 <blockquote>
-  <p>We zijn een AI-forward fintechbedrijf, en bedrijven zoals Four Technologies kunnen alleen bouwen zoals wij dat doen dankzij open-source-infrastructuur die anderen eerst hebben gebouwd. Het ondersteunen van de Omacom Foundation is hoe wij daar geld achter zetten. Wij denken dat de volgende fase voor AI geen nieuwe app bovenop het besturingssysteem is, maar AI die direct in het besturingssysteem is ingebouwd, en dat is de weddenschap die Omarchy aangaat. We wilden deel uitmaken van de community die die weddenschap aangaat, en er niet alleen later van profiteren.</p>
+  <p>
+    We zijn een AI-forward fintechbedrijf, en bedrijven zoals Four Technologies
+    kunnen alleen bouwen zoals wij dat doen dankzij opensource-infrastructuur
+    die anderen eerst hebben gebouwd. Door de Omacom Foundation te steunen
+    zetten we daar geld achter. Wij denken dat de volgende fase voor AI geen
+    nieuwe app bovenop het besturingssysteem is, maar AI die direct in het
+    besturingssysteem is ingebouwd, en dat is de gok die Omarchy waagt. We
+    wilden deel uitmaken van de community die die gok waagt, en er niet alleen
+    later van profiteren.
+  </p>
 </blockquote>
 
-<p>En sinds <a href="/news/2026/09/omacom-patronage-is-open-to-everyone/">we patronage voor iedereen hebben opengesteld</a>, hebben we ongeveer $60,000 ontvangen van <a href="/patrons/#everyone">bijna 500 donateurs</a> via <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage">open patronage</a>. Dat is een ongelooflijke reactie van mensen die willen helpen dit mogelijk te maken. Elke bijdrage draagt bij aan wat we samen kunnen doen.</p>
+<p>
+  En sinds
+  <a href="/news/2026/09/omacom-patronage-is-open-to-everyone/"
+    >we het donateurschap voor iedereen hebben opengesteld</a
+  >, hebben we ongeveer 60.000 dollar ontvangen van
+  <a href="/patrons/#everyone">bijna 500 donateurs</a> via
+  <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage"
+    >het open donateurschap</a
+  >. Een ongelooflijke reactie van mensen die dit mee mogelijk willen maken.
+  Elke bijdrage draagt bij aan wat we samen kunnen doen.
+</p>
 
-<p>Tokens om mee te bouwen. Geld om de projecten te steunen waarvan we afhankelijk zijn. Mensen en bedrijven die bereid zijn iets te zetten achter hun geloof in Linux op de desktop. Zo blijven we doorgaan!</p>
+<p>
+  Tokens om mee te bouwen. Geld om de projecten te steunen waarvan we
+  afhankelijk zijn. Mensen en bedrijven die hun geloof in Linux op de desktop
+  kracht bijzetten. Zo gaan we door!
+</p>
 
-<p>Bedankt aan OpenRouter, Four Technologies en iedereen die patron is geworden. Als je je bij hen wilt aansluiten, schrijf naar <a href="mailto:david@omarchy.com">david@omarchy.com</a> voor founding en distinguished patronage, en <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage">doneer direct aan de open patronage</a>.</p>
+<p>
+  Bedankt aan OpenRouter, Four Technologies en iedereen die donateur is
+  geworden. Wil je je bij hen aansluiten? Mail
+  <a href="mailto:david@omarchy.com">david@omarchy.com</a> als je Founding of
+  Distinguished Patron wilt worden, of
+  <a href="https://www.zeffy.com/en-US/donation-form/omarchy-patronage"
+    >doneer rechtstreeks via het open donateurschap</a
+  >.
+</p>

--- a/src/i18n/nl/news/omacom-foundation-reaches-13-million.html
+++ b/src/i18n/nl/news/omacom-foundation-reaches-13-million.html
@@ -9,7 +9,7 @@
   <a href="https://x.com/ryanrhughes">Ryan R. Hughes</a> heeft hier geen
   introductie nodig. Hij zit in <a href="/teams/">Omarchy Core</a>, is sinds dag
   één mijn wingman op de distro en partner bij
-  <a href="https://heyoodle.com/">Oodle</a>. Nu steunt hij de foundation ook nog
+  <a href="https://heyoodle.com/">Oodle</a>. Nu steunt hij de stichting ook nog
   met zijn eigen geld. Dát is overtuiging!
 </p>
 
@@ -31,14 +31,14 @@
 <p>
   <a href="https://x.com/mschoening">Max Schoening</a> is Head of Product bij
   <a href="https://www.notion.com">Notion</a>, en daarvoor leidde hij design bij
-  Heroku en was hij VP of Design bij GitHub. Hij heeft meer van de tools waar
-  developers van houden vormgegeven dan de meeste mensen ooit zullen beseffen.
+  Heroku en was hij VP of Design bij GitHub. Hij heeft aan meer tools gewerkt
+  waar developers dol op zijn dan de meeste mensen ooit zullen weten.
 </p>
 
 <p>
   Samen met de twaalf Founding Patrons en onze twee Distinguished Corporate
-  Patrons zijn dat achttien geldschieters en 13 miljoen dollar toegezegd in nog
-  geen twee weken.
+  Patrons zijn dat achttien donateurs en 13 miljoen dollar toegezegd in nog geen
+  twee weken.
 </p>
 
 <p>Welkom aan boord, alle vier. De missie groeit!</p>

--- a/src/i18n/nl/news/omacom-foundation-secures-tokens-from-leading-labs.html
+++ b/src/i18n/nl/news/omacom-foundation-secures-tokens-from-leading-labs.html
@@ -11,11 +11,10 @@
 
 <p>
   Om Omarchy beter te blijven maken nu we honderdduizenden gebruikers en
-  mede-makers hebben aangetrokken, moeten de tokens blijven stromen. Zo
+  medebouwers hebben aangetrokken, moeten de tokens blijven stromen. Zo
   versnellen, verbeteren en verzilveren we al die geweldige bijdragen die maar
   blijven binnenkomen. We hebben nu al een backlog van ruim 1.600 PR’s, amper
-  een paar weken na de lancering! Daar komt niemand doorheen zonder hulp van
-  agents.
+  een paar weken na de lancering! Daar komt geen mens doorheen zonder agents.
 </p>
 
 <p>
@@ -27,8 +26,8 @@
   >, dat instapt als
   <a href="/patrons/#founding-token-patrons">Founding Token Patron</a> met 1,5
   miljoen dollar aan tokens! Hun nieuwe Meta Muse Spark-model zet fantastische
-  cijfers neer tegen een geweldige prijs. Dus 1,5 miljoen dollar is in feite
-  onbeperkt tokens! (We gaan desondanks ons best doen om ze op te maken!)
+  cijfers neer tegen een geweldige prijs. Dus 1,5 miljoen dollar is eigenlijk
+  gewoon onbeperkt tokens! (We gaan toch ons best doen om ze op te maken!)
 </p>
 
 <p>
@@ -39,15 +38,15 @@
     >Distinguished Token Patrons</a
   >
   met elk 150.000 dollar aan gedoneerde tokens. Die komen vooral goed van pas in
-  combinatie met de security clearance die nodig is om de guardrails los te
-  halen voor ons beveiligingsonderzoek en de bijbehorende fixes.
+  combinatie met de security clearance die nodig is om de guardrails uit te
+  zetten voor ons beveiligingsonderzoek en de bijbehorende fixes.
 </p>
 
 <p>
   En voor open-weight-modellen ben ik minstens zo blij om
   <a href="https://fireworks.ai">Fireworks</a> aan te kondigen, eveneens als
   Distinguished Token Patron, met een toezegging van 150.000 dollar aan tokens.
-  Zelf gebruik ik vooral de Kimi K-modellen veel, zeker in fast mode. Ook die
+  Zelf gebruik ik de Kimi K-modellen veel, zeker in fast mode. Ook die
   razendsnelle tokens gaan we goed gebruiken!
 </p>
 

--- a/src/i18n/nl/news/omacom-foundation-to-be-exclusive-hyprland-sponsor.html
+++ b/src/i18n/nl/news/omacom-foundation-to-be-exclusive-hyprland-sponsor.html
@@ -3,28 +3,29 @@
   <a href="/news/2026/08/omacom-foundation-launches-with-8-million/"
     >net voor de Omacom Foundation hebben opgehaald</a
   >
-  dan het meest cracked Linux-joch van Polen:
+  dan de meest cracked Linux-knul van Polen:
   <a href="https://x.com/vaxryy">Vaxry</a>!
 </p>
 
 <p>
   Als bedenker van <a href="https://hypr.land/">Hyprland</a> tekent hij voor een
   van de drie kerntechnologieën van Omarchy (Arch Linux/Hyprland/Quickshell), en
-  ik ben ontzettend trots om een exclusieve sponsoring aan te kondigen waarmee
-  hij zich volledig op de verdere ontwikkeling kan storten, zonder ook maar één
-  gedachte te hoeven wijden aan commerciële ontwikkeling of fondsenwerving.
+  ik ben ontzettend blij dat ik een exclusieve sponsoring kan aankondigen
+  waarmee hij zich volledig op de verdere ontwikkeling kan storten, zonder ook
+  maar één gedachte te hoeven wijden aan commerciële ontwikkeling of
+  fondsenwerving.
 </p>
 
 <p>
-  We gaan voor de lange termijn met Vaxry in zee, om de toekomst van Omarchy op
-  de lange duur veilig te stellen. De exclusieve sponsordeal loopt drie jaar,
+  We gaan voor de lange termijn met Vaxry in zee, om ook de toekomst van Omarchy
+  voor de lange termijn te borgen. De exclusieve sponsordeal loopt drie jaar,
   met een optie op nog eens twee.
 </p>
 
 <p>
   Dankzij de deal kan bovendien het bestaande
   <a href="https://hypr.land/news/hyprperks/">Hyprperks</a>-programma van
-  Hyprland gratis worden vrijgegeven, voor iedereen, want de betaalde
+  Hyprland gratis worden vrijgegeven, voor iedereen, omdat de betaalde
   abonnementen stoppen. Persoonlijke donaties blijft Hyprland wel gewoon
   accepteren, zodat wie dat wil kan meebouwen aan de ontwikkeling van het
   project en Vaxry en het team kan steunen.
@@ -35,7 +36,7 @@
   <a href="https://www.butterfly.so/">Butterfly</a> en
   <a href="https://frame.work/">Framework</a>, die Hyprland tot hier hebben
   geholpen. Geweldig dat de Omacom Foundation het stokje vanaf 10 oktober kan
-  overnemen en een van de beste ontwikkelaars van dit nieuwe Linux-moment de
+  overnemen en een van de beste ontwikkelaars van dit nieuwe Linux-tijdperk de
   kans geeft om all-in te gaan.
 </p>
 

--- a/src/i18n/nl/news/omacom-foundation-to-be-premier-mise-sponsor.html
+++ b/src/i18n/nl/news/omacom-foundation-to-be-premier-mise-sponsor.html
@@ -2,25 +2,25 @@
   Derde sponsoring de deur uit! De Omacom Foundation wordt hoofdsponsor van
   <a href="https://mise.jdx.dev/">mise</a>, en daarmee van
   <a href="https://x.com/jdxcode">jdx</a>, die jaren heeft gebouwd aan de tool
-  die het jongleren met verschillende versies van Ruby, Node en Go stilletjes
-  tot een feestje maakt, en die al je agent-tooling een upgradekanaal geeft dat
-  het shiptempo kan bijbenen.
+  die het beheren van verschillende versies van Ruby, Node en Go stilletjes tot
+  een feestje maakt, en die al je agent-tooling een upgradekanaal geeft dat het
+  releasetempo kan bijbenen.
 </p>
 
 <p>
   Wie Omarchy heeft gebruikt, heeft mise gebruikt, of je het nu doorhad of niet.
   Het beheert de taalruntimes, dus <code>mise use -g ruby</code> geeft je Ruby
-  zonder ook maar één regel PATH-archeologie. Maar waar ik me op dit moment het
-  drukst om maak, zijn de agents.
+  zonder ook maar één regel PATH-archeologie. Maar wat mij op dit moment het
+  meest interesseert, zijn de agents.
 </p>
 
 <p>
   Elke grote coding-agent-CLI in Omarchy wordt geleverd als lazy-loading
   mise-stub in <code>~/.local/bin/</code>. Claude Code, Codex, OpenCode,
   Antigravity, Copilot, Crush, Grok, Pi, Oh My Pi – ze staan er allemaal klaar
-  en kosten je niets, tot je er voor het eerst echt eentje intypt. Dan
-  installeert hij zichzelf en kun je aan de slag. Geen pakket om op te sporen,
-  geen versie om vast te pinnen, geen toolchain om over na te denken.
+  en kosten je niets, tot je er voor het eerst echt een intypt. Dan installeert
+  hij zichzelf en kun je aan de slag. Geen pakket om op te sporen, geen versie
+  om vast te pinnen, geen toolchain om over na te denken.
   <code>omarchy-mise-install &lt;package&gt;</code> verpakt elke andere CLI op
   dezelfde manier, en <code>omarchy update</code> houdt ze stuk voor stuk bij de
   tijd.
@@ -29,7 +29,7 @@
 <p>
   Dat is de snelle route. In <em>The Age of Agents</em> mag er tussen horen over
   een tool en hem draaien zo’n vier seconden zitten, en mise levert precies dat.
-  Niemand hoefde eerst iets voor een distro te packagen.
+  Niemand hoefde eerst een pakket voor een distro te maken.
 </p>
 
 <p>
@@ -42,8 +42,8 @@
 <p>
   En de interesse gaat twee kanten op: het verkeer naar mise is met 24% gestegen
   sinds de lancering van Omarchy! Een hoop mensen maken via ons voor het eerst
-  kennis met deze tool, en dat is precies het soort ding dat een sponsoring
-  hoort te erkennen in plaats van voor lief te nemen.
+  kennis met deze tool, en dat is precies wat een sponsoring hoort te erkennen
+  in plaats van als vanzelfsprekend te zien.
 </p>
 
 <p>

--- a/src/i18n/nl/news/omacom-foundation-to-be-premier-quickshell-sponsor.html
+++ b/src/i18n/nl/news/omacom-foundation-to-be-premier-quickshell-sponsor.html
@@ -12,7 +12,7 @@
 </p>
 
 <p>
-  Het bewijs zit in de plugins! In de week dat
+  De plugins zijn het bewijs! In de week dat
   <a href="https://github.com/omacom/omarchy/releases/tag/v4.0.0">Quattro</a>
   uit is, zijn er
   <a href="https://plugins.omarchy.org/">meer dan duizend plugins</a> gemaakt.
@@ -24,7 +24,7 @@
   Deze sponsoring is dus een beloning voor de uitzonderlijke bijdrage van
   outfoxxed aan Omarchy, en verankert de band met onze langetermijnplannen voor
   <em>The Age of Agents</em> (niet op Bluesky posten, ze worden daar helemaal
-  gek!). Hij is meteen voor drie jaar vastgelegd.
+  gek!). De sponsoring is meteen voor drie jaar vastgelegd.
 </p>
 
 <p>

--- a/src/i18n/nl/news/omacom-foundation-welcomes-brian-armstrong-and-yunjie-dai.html
+++ b/src/i18n/nl/news/omacom-foundation-welcomes-brian-armstrong-and-yunjie-dai.html
@@ -49,9 +49,9 @@
     Ik ben een game-ondernemer uit China, en mijn gezin en ik wonen nu in de VS.
     We maken games, en we runnen ook TapTap… Anders dan de App Store of Google
     Play nemen we geen omzetaandeel van ontwikkelaars, terwijl we toch op
-    serieuze schaal en winstgevend opereren. Dat instinct ligt dicht bij wat ik
-    altijd aan 37signals heb bewonderd: blijf onafhankelijk, verdien je eigen
-    kost, int geen tol alleen omdat het kan, en bouw iets dat nuttig genoeg is
+    serieuze schaal en winstgevend opereren. Die instelling ligt dicht bij wat
+    ik altijd aan 37signals heb bewonderd: blijf onafhankelijk, verdien je eigen
+    kost, vraag geen tol alleen omdat het kan, en bouw iets dat nuttig genoeg is
     dat mensen ervoor kiezen om te blijven.
   </p>
 </blockquote>
@@ -79,5 +79,5 @@
 
 <p>
   Beter had ik het niet kunnen zeggen. Welkom aan boord, Brian en Yunjie. Hijs
-  de rebellenvlag, we zetten koers naar de vervulling van de profetie!
+  de rebellenvlag, we zetten koers naar de vervulling van de Profetie!
 </p>

--- a/src/i18n/nl/news/omacom-patronage-is-open-to-everyone.html
+++ b/src/i18n/nl/news/omacom-patronage-is-open-to-everyone.html
@@ -8,19 +8,19 @@
 </p>
 
 <p>
-  Maar de foundation is er niet alleen voor
+  Maar de stichting is er niet alleen voor
   <a href="https://oligarchy.fyi">de Oligarchy</a> en de Corporate Patrons. Ze
-  is er voor iedereen. Voor iedereen die warmloopt voor mooie, leuke &amp;
-  agentic Linux.
+  is er voor iedereen. Voor iedereen die warmloopt voor mooi, leuk &amp; agentic
+  Linux.
 </p>
 
 <p>
   Dus vanaf vandaag
   <a href="https://donate.omarchy.org"
     >staat het donateurschap open voor iedereen</a
-  >. Er zijn vier niveaus: $16, $256, $2.048 en $8.192. De macht van de bits,
+  >. Er zijn vier niveaus: 16, 256, 2.048 en 8.192 dollar. Machten van twee,
   uiteraard! Elke donateur maakt deel uit van dezelfde missie, en elke dollar
-  koopt hetzelfde: een serieuze kans om de profetie van Linux op de desktop te
+  koopt hetzelfde: een serieuze kans om de Profetie van Linux op de desktop te
   vervullen!
 </p>
 
@@ -35,19 +35,19 @@
 </p>
 
 <p>
-  Het geld is al hard aan het werk. De foundation is de exclusieve sponsor van
+  Het geld is al hard aan het werk. De stichting is de exclusieve sponsor van
   <a href="/sponsorships/#hyprland">Hyprland</a> en hoofdsponsor van
   <a href="/sponsorships/#quickshell">Quickshell</a> en
   <a href="/sponsorships/#mise">mise</a>, drie van de pijlers waarop Omarchy is
   gebouwd. Ze financiert de <a href="/air/">Artists in Residence</a> die de
-  distro mooi maken. Ze houdt de lichten aan voor alle infrastructuur die een
+  distro mooi maken. Ze betaalt de rekeningen voor alle infrastructuur die een
   Linux-distributie nodig heeft. Ze organiseert de pluginwedstrijden, met
   binnenkort een nieuwe van 10.000 dollar en meer winnaars dan de eerste keer.
   En sinds vandaag heeft ze
   <a href="/news/2026/09/omacom-foundation-hires-krzysztof-wilczynski/"
     >haar eerste fulltime medewerker</a
   >: een Linux-kernelontwikkelaar die het werk aan de Omarchy Kernel leidt. En
-  van dit alles komt er nog veel meer aan!
+  daar komt nog veel meer van!
 </p>
 
 <p>

--- a/src/i18n/nl/news/omarchy-meetups-around-the-world.html
+++ b/src/i18n/nl/news/omarchy-meetups-around-the-world.html
@@ -8,17 +8,17 @@
 
 <p>
   Dit zijn evenementen van en door de community. Je hebt geen toestemming nodig
-  om er een te organiseren, niemand heeft een stad in bezit, en iedereen kan er
-  overal een op poten zetten. Praat over Omarchy, Linux, open source,
-  programmeren, customizen, of welke aanverwante hackercultuur mensen ook maar
-  warm maakt om computers weer leuk te maken.
+  om er een te organiseren, een stad is van niemand, en iedereen kan er overal
+  een op poten zetten. Praat over Omarchy, Linux, open source, programmeren,
+  customizen, of welke aanverwante hackercultuur mensen maar enthousiast maakt
+  om computers weer leuk te maken.
 </p>
 
 <p>
   Hou het open voor iedereen, wees eerlijk over sponsoring, en maak van de naam
   Omarchy geen evenementenbureau of verkooppraatje. Verder: gedraag je als
-  beschaafde volwassenen (met kinderlijke verwondering) en maak er wat moois
-  van.
+  beschaafde volwassenen (met kinderlijke verwondering) en maak er een mooie
+  avond van.
 </p>
 
 <p>

--- a/src/i18n/nl/news/omarchy-org-redesign-launches-with-29-languages.html
+++ b/src/i18n/nl/news/omarchy-org-redesign-launches-with-29-languages.html
@@ -1,17 +1,106 @@
-<p>De website voor een prachtige, leuke Linux-distributie hoort zelf ook mooi en leuk te zijn. Dus hebben we <a href="/">Omarchy.org</a> volledig opnieuw ontworpen, en we lanceren hem in 29 talen (want als je net ~$2m aan tokens hebt opgehaald, waarom in hemelsnaam ook niet?). Een beetje retro-magie, veel meer om te ontdekken, en een veel groter welkom aan de wereld.</p>
+<p>
+  De website van een mooie, leuke Linux-distributie hoort zelf ook mooi en leuk
+  te zijn. Dus hebben we <a href="/">Omarchy.org</a> volledig opnieuw ontworpen,
+  en we lanceren hem in 29 talen (want als je net zo'n 2 miljoen dollar aan
+  tokens hebt opgehaald, waarom ook niet, verdorie?). Een beetje retro-magie,
+  veel meer om te ontdekken, en een veel warmer welkom voor de wereld.
+</p>
 
-<p>Dit is een website die wil dat je met je computer speelt! De pixels, kleuren en animaties brengen de geest van Omarchy rechtstreeks naar de browser. Je kunt de sfeer proeven voordat je ook maar één ISO hebt gedownload. Het is ook mijn eigen persoonlijke verbinding met die vormende jaren in de pre-internet onlinewereld van ASCII-art, de Amiga-demoscene en die levendige esthetiek van de jaren 90. Meer kleur, minder polish. Meer pixels, minder zachte gradiënten.</p>
+<p>
+  Dit is een website die wil dat je met je computer speelt! De pixels, kleuren
+  en animaties brengen de geest van Omarchy rechtstreeks naar de browser. Je
+  proeft de sfeer al voordat je ook maar één ISO hebt gedownload. Het is ook
+  mijn eigen persoonlijke verbinding met die vormende jaren in de pre-internet
+  onlinewereld van ASCII-art, de Amiga-demoscene en die levendige esthetiek van
+  de jaren 90. Meer kleur, minder gelik. Meer pixels, minder zachte gradiënten.
+</p>
 
-<p>Er is nu ruimte om de editors, terminals, agents, games, Windows VM en hardware te laten zien die Omarchy elke dag nuttig maken. Bekijk <a href="/themes/">community-thema's</a>, vind een plugin, bekijk <a href="/workstations/">echte werkplekken</a>, of ontdek een meetup bij jou in de buurt. Maak kennis met de <a href="/teams/">mensen die eraan bouwen</a> en de <a href="/patrons/">patrons die het financieren</a>. We hebben eindelijk een voordeur met genoeg ruimte voor alles wat er binnen gebeurt.</p>
+<p>
+  Er is nu ruimte om de editors, terminals, agents, games, Windows VM en
+  hardware te laten zien die Omarchy elke dag nuttig maken. Bekijk
+  <a href="/themes/">communitythema's</a>, zoek een plugin, bekijk
+  <a href="/workstations/">echte werkplekken</a>, of ontdek een meetup bij jou
+  in de buurt. Maak kennis met de
+  <a href="/teams/">mensen die eraan bouwen</a> en de
+  <a href="/patrons/">donateurs die het betalen</a>. We hebben eindelijk een
+  voordeur met genoeg ruimte voor alles wat er binnen gebeurt.
+</p>
 
-<p>En die voordeur spreekt nu jouw taal. Arabisch, Bengaals, Catalaans, Deens, Engels, Filipijns, Fins, Frans, Grieks, Hindi, Hongaars, IJslands, Iers, Italiaans, Japans, Koreaans, Litouws, Pools, Portugees, Vereenvoudigd Chinees, Singalees, Spaans, Zweeds, Tamil, Thais, Turks, Urdu, Oezbeeks en Vietnamees. De hoofdsite en elk nieuwsbericht zijn vertaald. De handleiding is nog in het Engels; die pakken we hierna aan. Dit zijn eerste vertalingen, en correcties van native speakers zijn zeer welkom via <a href="https://github.com/omacom/omarchy-site">de siterepository</a>.</p>
+<p>
+  En die voordeur spreekt nu jouw taal. Arabisch, Bengaals, Catalaans, Deens,
+  Engels, Filipijns, Fins, Frans, Grieks, Hindi, Hongaars, IJslands, Iers,
+  Italiaans, Japans, Koreaans, Litouws, Pools, Portugees, Vereenvoudigd Chinees,
+  Singalees, Spaans, Zweeds, Tamil, Thais, Turks, Urdu, Oezbeeks en Vietnamees.
+  De hoofdsite en elk nieuwsbericht zijn vertaald. De handleiding is nog in het
+  Engels; die pakken we hierna aan. Dit zijn eerste vertalingen, en correcties
+  van native speakers zijn zeer welkom via
+  <a href="https://github.com/omacom/omarchy-site">de siterepository</a>.
+</p>
 
-<p>We hebben ook lokale domeinen: <a href="https://omarchy.ae">omarchy.ae</a>, <a href="https://omarchy.dk">omarchy.dk</a>, <a href="https://omarchy.fi">omarchy.fi</a>, <a href="https://omarchy.fr">omarchy.fr</a>, <a href="https://omarchy.gr">omarchy.gr</a>, <a href="https://omarchy.hu">omarchy.hu</a>, <a href="https://omarchy.in">omarchy.in</a>, <a href="https://omarchy.is">omarchy.is</a>, <a href="https://omarchy.jp">omarchy.jp</a>, <a href="https://omarchy.kr">omarchy.kr</a>, <a href="https://omarchy.mx">omarchy.mx</a>, <a href="https://omarchy.ph">omarchy.ph</a>, <a href="https://omarchy.pt">omarchy.pt</a>, <a href="https://omarchy.se">omarchy.se</a> en <a href="https://omarchy.tr">omarchy.tr</a>.</p>
+<p>
+  We hebben ook lokale domeinen: <a href="https://omarchy.ae">omarchy.ae</a>,
+  <a href="https://omarchy.dk">omarchy.dk</a>,
+  <a href="https://omarchy.fi">omarchy.fi</a>,
+  <a href="https://omarchy.fr">omarchy.fr</a>,
+  <a href="https://omarchy.gr">omarchy.gr</a>,
+  <a href="https://omarchy.hu">omarchy.hu</a>,
+  <a href="https://omarchy.in">omarchy.in</a>,
+  <a href="https://omarchy.is">omarchy.is</a>,
+  <a href="https://omarchy.jp">omarchy.jp</a>,
+  <a href="https://omarchy.kr">omarchy.kr</a>,
+  <a href="https://omarchy.mx">omarchy.mx</a>,
+  <a href="https://omarchy.ph">omarchy.ph</a>,
+  <a href="https://omarchy.pt">omarchy.pt</a>,
+  <a href="https://omarchy.se">omarchy.se</a> en
+  <a href="https://omarchy.tr">omarchy.tr</a>.
+</p>
 
-<p>Communityleden hebben genereus meer domeinen geregistreerd en aangeboden om ze naar ons door te verwijzen. Terwijl we de resterende lokale namen aansluiten, kun je <a href="https://bn.omarchy.org">bn.omarchy.org</a>, <a href="https://ca.omarchy.org">ca.omarchy.org</a>, <a href="https://ga.omarchy.org">ga.omarchy.org</a>, <a href="https://it.omarchy.org">it.omarchy.org</a>, <a href="https://lt.omarchy.org">lt.omarchy.org</a>, <a href="https://pl.omarchy.org">pl.omarchy.org</a>, <a href="https://si.omarchy.org">si.omarchy.org</a>, <a href="https://ta.omarchy.org">ta.omarchy.org</a>, <a href="https://th.omarchy.org">th.omarchy.org</a>, <a href="https://ur.omarchy.org">ur.omarchy.org</a>, <a href="https://uz.omarchy.org">uz.omarchy.org</a>, <a href="https://vi.omarchy.org">vi.omarchy.org</a> en <a href="https://zh.omarchy.org">zh.omarchy.org</a> gebruiken. Gebruik de wereldbol naast de themakiezer om tussen talen te wisselen.</p>
+<p>
+  Communityleden hebben gul extra domeinen geregistreerd en aangeboden die naar
+  ons door te verwijzen. Terwijl we de resterende lokale namen aansluiten, kun
+  je <a href="https://bn.omarchy.org">bn.omarchy.org</a>,
+  <a href="https://ca.omarchy.org">ca.omarchy.org</a>,
+  <a href="https://ga.omarchy.org">ga.omarchy.org</a>,
+  <a href="https://it.omarchy.org">it.omarchy.org</a>,
+  <a href="https://lt.omarchy.org">lt.omarchy.org</a>,
+  <a href="https://pl.omarchy.org">pl.omarchy.org</a>,
+  <a href="https://si.omarchy.org">si.omarchy.org</a>,
+  <a href="https://ta.omarchy.org">ta.omarchy.org</a>,
+  <a href="https://th.omarchy.org">th.omarchy.org</a>,
+  <a href="https://ur.omarchy.org">ur.omarchy.org</a>,
+  <a href="https://uz.omarchy.org">uz.omarchy.org</a>,
+  <a href="https://vi.omarchy.org">vi.omarchy.org</a> en
+  <a href="https://zh.omarchy.org">zh.omarchy.org</a> gebruiken. Gebruik de
+  wereldbol naast de themakiezer om tussen talen te wisselen.
+</p>
 
-<p>Dit herontwerp is voortgekomen uit een geweldige burst aan werk in de Omarchy Design-groep. <strong><a href="https://x.com/BarisGirismen">Barış Girişmen</a></strong> creëerde het ontwerp dat de basis werd van de nieuwe site, bouwde de pixel-grid-shader en dreef een enorm deel van de implementatie en polish aan. <strong><a href="https://x.com/hicsfh">Christoffer Hallas</a></strong> bracht prototypes, animatiewerk, thema-overgangen en een gestage stroom aan verfijningen. <strong><a href="https://x.com/captainscorch">Daniel Schmier</a></strong> droeg ontwerpen en implementatie bij voor de logo-, nieuws-, install-, team-, foundation- en testimonial-secties.</p>
+<p>
+  Dit herontwerp is voortgekomen uit een fantastische werksprint van de Omarchy
+  Design-groep.
+  <strong><a href="https://x.com/BarisGirismen">Barış Girişmen</a></strong>
+  creëerde het ontwerp dat de basis werd van de nieuwe site, bouwde de
+  pixel-grid-shader en trok een enorm deel van de implementatie en afwerking.
+  <strong><a href="https://x.com/hicsfh">Christoffer Hallas</a></strong> bracht
+  prototypes, animatiewerk, thema-overgangen en een gestage stroom aan
+  verfijningen.
+  <strong><a href="https://x.com/captainscorch">Daniel Schmier</a></strong>
+  droeg ontwerpen en implementatie bij voor de logo-, nieuws-, install-, team-,
+  foundation- en testimonial-secties.
+</p>
 
-<p>Bedankt ook aan <strong><a href="https://x.com/avillagran">Andrés Villagrán</a></strong>, <strong><a href="https://x.com/ryanrhughes">Ryan Hughes</a></strong>, <strong>Yam Catzenelson, Eric Carmichael, Wes Oudshoorn, Taha, Aloïs Deniel, Adrian Rangel, Niklas Jul, HANCORE, OldJobobo en Rick Blalock</strong> voor de concepten, experimenten, ideeën en feedback die ze onderweg hebben gedeeld. En aan iedereen die helpt lokale domeinen veilig te stellen en mensen in hun eigen taal te verwelkomen. Het was een plezier om dit allemaal samen te zien komen.</p>
+<p>
+  Bedankt ook aan
+  <strong><a href="https://x.com/avillagran">Andrés Villagrán</a></strong
+  >, <strong><a href="https://x.com/ryanrhughes">Ryan Hughes</a></strong
+  >,
+  <strong
+    >Yam Catzenelson, Eric Carmichael, Wes Oudshoorn, Taha, Aloïs Deniel, Adrian
+    Rangel, Niklas Jul, HANCORE, OldJobobo en Rick Blalock</strong
+  >
+  voor de concepten, experimenten, ideeën en feedback die ze onderweg hebben
+  gedeeld. En aan iedereen die helpt lokale domeinen te regelen en mensen in hun
+  eigen taal te verwelkomen. Het was een plezier om dit allemaal samen te zien
+  komen.
+</p>
 
-<p>Dus kies een thema. Por in de pixels. Computers moeten leuk zijn!</p>
+<p>Dus kies een thema. Klik op de pixels. Computers horen leuk te zijn!</p>

--- a/src/i18n/nl/news/quattro-crosses-200000-iso-downloads.html
+++ b/src/i18n/nl/news/quattro-crosses-200000-iso-downloads.html
@@ -4,8 +4,8 @@
     >Omarchy Quattro</a
   >
   in amper 18 dagen! Sinds Quattro uitkwam heeft gemiddeld elke 8 seconden
-  iemand een verse Omarchy binnengehaald. Op de piek leverden we 1.165 ISO’s in
-  één uur. Eén per 3 seconden!
+  iemand een verse Omarchy binnengehaald. Op het hoogtepunt leverden we 1.165
+  ISO’s in één uur. Eén per 3 seconden!
 </p>
 
 <p>
@@ -13,7 +13,7 @@
   leden heeft! Ruim de helft van de downloads komt van buiten de top vijf
   landen. En per hoofd van de bevolking lopen de Noordse landen voorop: IJsland,
   Noorwegen en Denemarken halen Omarchy allemaal ruim twee keer zo vaak binnen
-  als de Amerikanen. Vikingen for the win! (Al is de VS in absolute aantallen
+  als de Amerikanen. Lang leve de Vikingen! (Al is de VS in absolute aantallen
   nog altijd goed voor 28% van de downloads.)
 </p>
 
@@ -23,10 +23,10 @@
     href="/news/2026/08/1password-and-37signals-become-distinguished-corporate-patrons/"
     >1Password</a
   >
-  weet welke Linux-distro’s hun gebruikers draaien, en doordeweeks is Omarchy
+  weet welke Linux-distro’s zijn gebruikers draaien, en doordeweeks is Omarchy
   daar inmiddels de nummer 2, vóór Fedora. En in het weekend? Dan zijn we nummer
-  1! Mensen draaien Omarchy voor de lol. Als niemand ze voorschrijft wat ze
-  moeten gebruiken, kiezen ze dit.
+  1! Mensen draaien Omarchy voor de lol. Als niemand ze vertelt wat ze moeten
+  gebruiken, kiezen ze dit.
 </p>
 
 <p>

--- a/src/i18n/nl/news/the-first-plugin-competition-winners.html
+++ b/src/i18n/nl/news/the-first-plugin-competition-winners.html
@@ -16,7 +16,7 @@
     van Akshar Patel.</strong
   >
   Draai aan de wereldbol, land in een stad en luister mee naar wat ze daar
-  luisteren. Goed voor 2.500 dollar.
+  draaien. Goed voor 2.500 dollar.
 </p>
 
 <p>
@@ -43,7 +43,8 @@
     van GM.</strong
   >
   Batterijniveaus en met één klik overschakelen naar je AirPods, gewoon in de
-  balk. Zo’n ding dat je pas mist als je van een Mac komt. 500 dollar daarvoor.
+  balk. Zo’n ding dat je pas mist als je van een Mac komt. Daar staat 500 dollar
+  tegenover.
 </p>
 
 <p>
@@ -57,13 +58,12 @@
 
 <p>
   Gefeliciteerd, alle vier, en dank aan iedereen die iets heeft ingestuurd.
-  Kiezen was oprecht lastig, en dat is het beste probleem dat je kunt hebben.
+  Kiezen was echt lastig, en dat is het beste probleem dat je kunt hebben.
 </p>
 
 <p>
   En we doen dit nog een keer! Meer wedstrijden, meer prijzengeld, meer excuses
-  om iets belachelijks te bouwen voor een Linux-desktop. Hou deze plek in de
-  gaten.
+  om iets belachelijks te bouwen voor een Linux-desktop. Wordt vervolgd.
 </p>
 
 <p>

--- a/src/i18n/nl/news/the-first-plugin-competition.html
+++ b/src/i18n/nl/news/the-first-plugin-competition.html
@@ -1,16 +1,16 @@
 <p>
   De <a href="https://plugins.omarchy.org/">Omarchy Plugin Marketplace</a> telt
-  nu al ruim 500 plugins en groeit als een tierelier. We hebben een miljoen
-  ideeën om deze opzet te verbeteren, waaronder geautomatiseerde
-  beveiligingsreviews door agents, maar laten we voorlopig het perfecte niet de
-  vijand van het goede en het leuke laten zijn!
+  nu al ruim 500 plugins en groeit razendsnel. We hebben een miljoen ideeën om
+  deze opzet te verbeteren, waaronder geautomatiseerde beveiligingsreviews door
+  agents, maar laten we voorlopig het perfecte niet de vijand van het goede en
+  het leuke laten zijn!
 </p>
 
 <p>
   Dus om deze enorme creativiteitsexplosie te vieren organiseren we de eerste
   pluginwedstrijd, met
   <a href="https://x.com/dhh/status/2088362620617425277">de vier ruggen</a> die
-  ik vorige week ving door eindeloos over Omarchy te kletsen op X.
+  ik vorige week verdiende door eindeloos over Omarchy te kletsen op X.
 </p>
 
 <p>Dit zijn de regels:</p>
@@ -22,12 +22,12 @@
   </li>
   <li>
     De winnaars worden gekozen door het kersverse
-    <a href="/news/2026/09/the-omarchy-core-team/">Omarchy Core</a>, dat een
-    podium bij elkaar stemt.
+    <a href="/news/2026/09/the-omarchy-core-team/">Omarchy Core</a>, dat door te
+    stemmen een podium samenstelt.
   </li>
   <li>
-    Het prijzengeld is $2.500 voor de eerste plaats, $1.000 voor de tweede en
-    $500 voor de derde.
+    Het prijzengeld is 2.500 dollar voor de eerste plaats, 1.000 dollar voor de
+    tweede en 500 dollar voor de derde.
   </li>
   <li>
     Om je prijzengeld te innen moet je een betaling kunnen ontvangen via Zelle,

--- a/src/i18n/nl/news/the-omarchy-core-team.html
+++ b/src/i18n/nl/news/the-omarchy-core-team.html
@@ -38,7 +38,7 @@
   <a href="https://github.com/omacom/omarchy/pull/6463">wifi-QR-codes</a> en
   <a href="https://x.com/tobi/status/2089812224869044678?s=20"
     >de agentconsole in Quake-stijl</a
-  >. En toevallig is hij ook mijn co-rijder in
+  >. En toevallig is hij ook mijn co-coureur in
   <a href="https://www.youtube.com/watch?v=-C4icxRS4xw"
     >de #11 Shopify Racing LMP2</a
   >
@@ -61,9 +61,9 @@
 
 <p>
   <a href="https://github.com/HANCORE-linux">HANCORE</a> is een
-  werktuigbouwkundig ingenieur die op de een of andere manier is uitgegroeid tot
-  een van de bepalende esthetische krachten in de Omarchy-community. Hij heeft
-  een absurd aantal thema’s gemaakt, waaronder Last Horizon en Solitude, dat
+  werktuigbouwkundige die op de een of andere manier is uitgegroeid tot een van
+  de bepalende esthetische krachten in de Omarchy-community. Hij heeft een
+  absurd aantal thema’s gemaakt, waaronder Last Horizon en Solitude, dat
   standaard in Omarchy zit. Nu helpt hij
   <a href="https://plugins.omarchy.org/">het pluginecosysteem</a> rond Quattro
   in goede banen te leiden. Omarchy heeft altijd volgehouden dat een computer
@@ -84,8 +84,8 @@
 
 <p>
   Deze vijf doen het werk al lang. Dit maakt het alleen officieel. Samen met mij
-  is dit een fenomenaal eerste Core Team. Maar het blijft niet bij één team. Hou
-  de aankondiging over de Omarchy Rangers in de gaten!
+  is dit een fenomenaal eerste Core Team. Maar het blijft niet bij één team.
+  Binnenkort meer over de Omarchy Rangers!
 </p>
 
 <p>


### PR DESCRIPTION
Follow-up to #243, which covered the Dutch UI and main-page prose. This one covers all 22 news articles. A native Dutch speaker read each article beside the English source and approved every edit; Claude applied them.

What the machine draft got wrong, with examples:

- Voice. «Zo blijven we doorgaan!» is now «Zo gaan we door!», «Het bewijs zit in de plugins!» is «De plugins zijn het bewijs!», «Watch this space» became «Wordt vervolgd.», and «Tijd om vol in te zetten!» is DHH's own «Tijd om all-in te gaan!». The redesign post ended on «Por in de pixels», which is not Dutch; it now reads «Klik op de pixels. Computers horen leuk te zijn!».
- Meaning slips. «waar ik me het drukst om maak» means *what worries me most*, not *what I care most about*. «het loodgieterswerk dat Linux verbindt met je GPU» is now «de bedrading tussen Linux en je GPU». «Kies je stage!» on the badges page was fixed in #243; the same rally metaphor is consistent here.
- Calques: «een geweldige burst aan werk», «minder polish», «hang rond», «Het landde in Quattro», «één commando verderop», «Vind een plugin».
- Terms aligned with the main site: *open donateurschap* for open patronage (the draft used «open patronage», «open mecenaat» and «open steunprogramma» in three different articles), *stichting* for the generic foundation, *donateur* for the generic patron, the capitalized *Profetie*, *opensource* as one word.
- Money per `docs/translations.md`: no bare `$`. The two bot-written articles still had `$150,000`-style amounts with English separators; all amounts are now «150.000 dollar», «15,5 miljoen dollar».
- One title in `news.json`: «schroeft het bestedingstempo op» is now «Omacom Foundation versnelt de bestedingen». Source hashes are untouched.

The two articles the translation bot wrote after #215 (`omacom-foundation-launches-with-8-million`, `omacom-foundation-raises-another-half-a-million-dollars`) were long single-line paragraphs; Prettier wraps them like every other article, which is most of the line count in this diff.

Checks: `npm run check:translations -- --strict-site --strict-news nl` (304 UI messages, 22 news articles), `npm run build:locale -- nl`, `scripts/verify-locales.py nl` (39 pages, 22 RSS articles) and `prettier --check` pass. Every article was reviewed in the local Dutch preview. Links, images and tag structure are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2ht7n7vD54HXt4CZgP2Xb
