### PR TITLE
Tidy up the language dropdown

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { hasTranslation, language, locale, locales, t } from '@/i18n/site'
+import { hasTranslation, language, locale, sortedLocales, t } from '@/i18n/site'
 
 function flag(domain: string, countryCode?: string) {
   const country = countryCode ?? new URL(domain).hostname.split('.').at(-1)!
@@ -59,7 +59,7 @@ export function LanguageSwitcher({ path }: { path: string }) {
                 running underneath it. */}
             <ScrollArea scrollbarGutter>
               <nav aria-label={t('Language')}>
-                {Object.entries(locales).map(([code, entry]) => {
+                {sortedLocales.map(([code, entry]) => {
                   const destination = entry.domain
                   return (
                     <a

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@base-ui/react/popover'
 import { useState } from 'react'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { hasTranslation, language, locale, locales, t } from '@/i18n/site'
 
 function flag(domain: string, countryCode?: string) {
@@ -44,30 +45,40 @@ export function LanguageSwitcher({ path }: { path: string }) {
           sideOffset={10}
           className="z-[100]"
         >
-          <Popover.Popup className="max-h-[min(70svh,var(--available-height))] w-72 max-w-[calc(100vw-2rem)] overflow-y-auto border border-border-subtle bg-bg p-2 text-text shadow-xl">
-            <Popover.Title className="px-3 py-2 text-sm text-text-muted">
+          {/* The list scrolls inside the same ScrollArea the manual's chapter
+              list uses, so the bar is the site's thin one rather than the
+              browser's. The popup is a column of a set height, which the
+              area needs to know how far it may scroll. The positioner's
+              available height has a fallback so the height never resolves
+              to nothing before the variable is set. */}
+          <Popover.Popup className="flex h-[min(70svh,var(--available-height,70svh))] w-72 max-w-[calc(100vw-2rem)] flex-col border border-border-subtle bg-bg text-text shadow-xl">
+            <Popover.Title className="shrink-0 px-4 py-2.5 text-sm text-text-muted">
               {t('Language')}
             </Popover.Title>
-            <nav aria-label={t('Language')}>
-              {Object.entries(locales).map(([code, entry]) => {
-                const destination = entry.domain
-                return (
-                  <a
-                    key={code}
-                    href={`${destination}${hasTranslation(code, path) ? path + suffix : '/'}`}
-                    hrefLang={code}
-                    lang={code}
-                    aria-current={code === language ? 'true' : undefined}
-                    className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-ring aria-current:bg-surface-2"
-                  >
-                    <span aria-hidden="true" className="text-xl">
-                      {flag(entry.domain, entry.flag)}
-                    </span>
-                    <span dir="auto">{entry.name}</span>
-                  </a>
-                )
-              })}
-            </nav>
+            {/* A gutter for the bar, so the rows end before it rather than
+                running underneath it. */}
+            <ScrollArea scrollbarGutter>
+              <nav aria-label={t('Language')}>
+                {Object.entries(locales).map(([code, entry]) => {
+                  const destination = entry.domain
+                  return (
+                    <a
+                      key={code}
+                      href={`${destination}${hasTranslation(code, path) ? path + suffix : '/'}`}
+                      hrefLang={code}
+                      lang={code}
+                      aria-current={code === language ? 'true' : undefined}
+                      className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-surface-2 focus-visible:outline-2 focus-visible:outline-ring aria-current:bg-surface-2"
+                    >
+                      <span aria-hidden="true" className="text-xl">
+                        {flag(entry.domain, entry.flag)}
+                      </span>
+                      <span dir="auto">{entry.name}</span>
+                    </a>
+                  )
+                })}
+              </nav>
+            </ScrollArea>
           </Popover.Popup>
         </Popover.Positioner>
       </Popover.Portal>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,4 +1,4 @@
-import { t, language, locales, hasTranslation } from '@/i18n/site'
+import { t, language, sortedLocales, hasTranslation } from '@/i18n/site'
 import { Link } from '@tanstack/react-router'
 import { OmarchyWordmark } from '@/components/Brand'
 import { PixelBackdrop } from '@/components/HeroShader'
@@ -159,7 +159,7 @@ export function SiteFooter({ path }: { path: string }) {
           aria-label={t('Language')}
           className="mt-8 flex flex-wrap gap-x-4 gap-y-2 text-sm"
         >
-          {Object.entries(locales)
+          {sortedLocales
             .filter(([code]) => hasTranslation(code, currentPath))
             .map(([code, entry]) => (
               <a

--- a/src/i18n/site.ts
+++ b/src/i18n/site.ts
@@ -16,6 +16,18 @@ export const language = import.meta.env?.PUBLIC_SITE_LOCALE || 'en'
 if (!locales[language]) throw new Error(`Unknown site language: ${language}`)
 export const locale = locales[language]
 export const siteUrl = locale.domain
+
+/**
+ * The languages in the order a list shows them: English first, since it is
+ * the source, then the rest by their own name. The registry is in the order
+ * the languages arrived, which reads as no order at all.
+ */
+const byName = new Intl.Collator('en').compare
+export const sortedLocales: Array<[string, Locale]> = Object.entries(
+  locales,
+).sort(([a, la], [b, lb]) =>
+  a === 'en' ? -1 : b === 'en' ? 1 : byName(la.name, lb.name),
+)
 export const contentLocale = locale.contentLocale ?? language
 
 /** English is the source copy; each language keeps its own reviewed catalogue. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -1141,6 +1141,7 @@ h6 {
    be seen in the same frame. */
 [data-nav-blend] nav[aria-label='Main'] a,
 [data-nav-blend] [data-nav-glyph]:hover,
+[data-nav-blend] [data-nav-glyph][aria-expanded='true'],
 [data-nav-blend] [data-nav-toggle]:hover {
   background-color: transparent;
   transition: none;


### PR DESCRIPTION
A few fixes for the language dropdown in the bar.

The list scrolls inside the same ScrollArea the manual's chapter list uses, so it gets the site's thin bar instead of the browser's default one. The bar sits against the popup's edge with a gutter, so rows end before it instead of running underneath. The popup's inner padding is gone and each row has a bit more room inside. The popup's height has a fallback, so the list can never come out unconstrained before the positioner has measured.

Over the hero, with the list open and the pointer off the bar, the globe used to disappear behind its open-state chip. The chip now drops while the labels are blended, the same as it already did on hover.

The languages are sorted by name, in the dropdown and in the footer. English comes first, being the source, then the rest by their own name.