### PR TITLE
Fix typo in dual-boot installation instructions

### DIFF
--- a/manual/dual-boot-install/index.html
+++ b/manual/dual-boot-install/index.html
@@ -93,7 +93,7 @@
 
 <p><img src="/manual/images/dual-boot-5.webp" alt="dual-boot-5" /></p>
 
-<p>Confirm that everything looks good and wait for the install to finish like normal. This is also where you could elect to install unencrypted (not recommended) just like on a full-drive install.
+<p>Confirm that everything looks good and wait for the install to finish like normal. This is also where you could select to install unencrypted (not recommended) just like on a full-drive install.
  <img src="/manual/images/dual-boot-6.webp" alt="dual-boot-6" /></p>
 
 <h2 id="adding-other-installs-to-the-bootloader">Adding Other Installs to the Bootloader <a class="manual__heading-link" href="#adding-other-installs-to-the-bootloader" aria-label="Link to this section">#</a></h2>


### PR DESCRIPTION
Only fixed typo. Nothing else.