### PR TITLE
Give the header and footer wordmarks the gradient

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,6 +1,6 @@
 import { t, language, locales, hasTranslation } from '@/i18n/site'
 import { Link } from '@tanstack/react-router'
-import { OmarchyWordmark } from '@/components/Brand'
+import { OmarchyWordmark, WORDMARK_BANDS } from '@/components/Brand'
 import { PixelBackdrop } from '@/components/HeroShader'
 import {
   CloudflareMark,
@@ -82,7 +82,10 @@ export function SiteFooter({ path }: { path: string }) {
               data-quiet
               className={`group block ${focusRing}`}
             >
-              <OmarchyWordmark className="h-6 w-auto text-brand transition-colors duration-150 ease-out group-hover:text-(--t-field-hover)" />
+              <OmarchyWordmark
+                className="h-6 w-auto text-[color:var(--t-field-lit)] transition-[filter] duration-150 ease-out group-hover:brightness-125"
+                background={WORDMARK_BANDS}
+              />
             </Link>
             <p
               data-quiet

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -11,7 +11,11 @@ import {
   RssIcon,
   SearchIcon,
 } from '@/components/icons'
-import { OmarchyMarkDrawn, OmarchyWordmark } from '@/components/Brand'
+import {
+  OmarchyMarkDrawn,
+  OmarchyWordmark,
+  WORDMARK_BANDS,
+} from '@/components/Brand'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
 import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { MusicMenuControl } from '@/components/MusicControl'
@@ -443,7 +447,10 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
       className="mark-draw-trigger relative flex items-center"
     >
       <OmarchyMarkDrawn className="size-[22px] shrink-0 transition-opacity duration-150 ease-out max-sm:group-data-[nav-past-hero]/bar:opacity-0 lg:size-[calc(var(--pxc)*2)]" />
-      <OmarchyWordmark className="absolute top-1/2 left-0 w-28 -translate-y-1/2 text-brand opacity-0 transition-opacity duration-150 ease-out group-data-[nav-past-hero]/bar:opacity-100 sm:hidden" />
+      <OmarchyWordmark
+        className="absolute top-1/2 left-0 w-28 -translate-y-1/2 text-[color:var(--t-field-lit)] opacity-0 transition-opacity duration-150 ease-out group-data-[nav-past-hero]/bar:opacity-100 sm:hidden"
+        background={WORDMARK_BANDS}
+      />
     </Link>
   )
 


### PR DESCRIPTION
The wordmark at the top of the news pages has the banded gradient, but the two other wordmarks on the site were a flat brand color: the one that shows in the header on phones once you scroll past the hero, and the one in the footer. Now all three match on every theme. The footer hover used to swap to the hover color, which a gradient cannot show, so it brightens the gradient a little instead. Nothing about when or how the header wordmark appears changes.