### PR TITLE
Update homepage download to Omarchy 4.0.3

### DIFF
--- a/scripts/refresh-data.mjs
+++ b/scripts/refresh-data.mjs
@@ -120,15 +120,26 @@ const version = String(release.tag_name ?? '').replace(/^v/, '')
 if (!/^\d+\.\d+\.\d+$/.test(version)) {
   throw new Error(`unexpected release tag: ${release.tag_name}`)
 }
-await writeFile(
-  path.join(OUT, 'version.json'),
-  JSON.stringify(
-    { version, isoUrl: `https://iso.omarchy.org/omarchy-${version}.iso` },
-    null,
-    1,
-  ),
-)
-console.log(`version.json: ${version}`)
+const versionPath = path.join(OUT, 'version.json')
+const currentRelease = JSON.parse(await readFile(versionPath, 'utf8'))
+// An ISO can be published before GitHub marks its release as latest.
+if (
+  version.localeCompare(currentRelease.version, 'en', { numeric: true }) < 0
+) {
+  console.log(
+    `version.json: keeping ${currentRelease.version} (GitHub latest is ${version})`,
+  )
+} else {
+  await writeFile(
+    versionPath,
+    JSON.stringify(
+      { version, isoUrl: `https://iso.omarchy.org/omarchy-${version}.iso` },
+      null,
+      1,
+    ),
+  )
+  console.log(`version.json: ${version}`)
+}
 
 // Refresh GitHub figures; foundation and download announcements are maintained separately.
 const MOMENTUM = path.join(OUT, 'momentum.json')

--- a/src/data/version.json
+++ b/src/data/version.json
@@ -1,4 +1,4 @@
 {
- "version": "4.0.2",
- "isoUrl": "https://iso.omarchy.org/omarchy-4.0.2.iso"
+ "version": "4.0.3",
+ "isoUrl": "https://iso.omarchy.org/omarchy-4.0.3.iso"
 }


### PR DESCRIPTION
Update the homepage download from Omarchy 4.0.2 to 4.0.3. The existing checksum and signature links follow the new ISO URL across all languages.

Keep a newer published ISO version when the scheduled refresh sees an older GitHub release. GitHub currently reports 4.0.2 as latest, which would otherwise revert this update.

Verified that the ISO and signature URLs return HTTP 200 and the published checksum file contains:

```text
03d60bc74306dca51f96e1a84b690871d8d606826b260edd0208962da8507d14  omarchy-4.0.3.iso
```

Validation: lint, typecheck, all 52 tests, production build, and parity passed (4,104 addresses). Checked all three links in the built homepage and exercised the refresh with older, equal, newer, multi-digit, and major versions.
