### PR TITLE
Add an overhead rally easter egg behind the Konami code

### DIFF
--- a/src/components/Rally.tsx
+++ b/src/components/Rally.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { advanceKonami } from '@/lib/konami'
+
+type Game = typeof import('./RallyGame').RallyGame
+
+/** Only the code listener ships initially; the game loads after the secret. */
+export function Rally() {
+  const [Game, setGame] = useState<Game | null>(null)
+  useEffect(() => {
+    let keys: string[] = [],
+      loading = false,
+      alive = true
+    let lastKey = 0
+    const listener = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      if (Game || loading || event.repeat || event.isComposing) return
+      if (
+        event.metaKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        target?.closest(
+          'input, textarea, select, [contenteditable], [role="dialog"]',
+        ) ||
+        document.querySelector('dialog[open]')
+      ) {
+        keys = []
+        return
+      }
+      if (performance.now() - lastKey > 3000) keys = []
+      lastKey = performance.now()
+      const result = advanceKonami(keys, event.key)
+      keys = result.keys
+      if (!result.hit) return
+      event.preventDefault()
+      loading = true
+      void import('./RallyGame')
+        .then((module) => {
+          if (alive) setGame(() => module.RallyGame)
+        })
+        .catch(() => {
+          loading = false
+        })
+    }
+    window.addEventListener('keydown', listener)
+    return () => {
+      alive = false
+      window.removeEventListener('keydown', listener)
+    }
+  }, [Game])
+  return Game ? <Game onClose={() => setGame(null)} /> : null
+}

--- a/src/components/RallyGame.tsx
+++ b/src/components/RallyGame.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
 import { PICKER_STATE_EVENT, THEME_EVENT } from '@/lib/theme'
+import { t } from '@/i18n/site'
 import {
   Dialog,
   DialogPortal,
@@ -40,6 +41,15 @@ const INITIAL: View = {
 const MAP_PATH = STAGE.filter((_, i) => i % 3 === 0)
   .map((p, i) => `${i ? 'L' : 'M'}${p.x},${p.y}`)
   .join(' ')
+// The stage library stays free of the catalogue so Node can test it.
+const PACE_NOTES: Record<string, string> = {
+  'Finish ahead': t('Finish ahead'),
+  'Flat out': t('Flat out'),
+  'Tight left': t('Tight left'),
+  'Tight right': t('Tight right'),
+  'Easy left': t('Easy left'),
+  'Easy right': t('Easy right'),
+}
 
 export function RallyGame({ onClose }: { onClose: () => void }) {
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null)
@@ -211,18 +221,18 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
               disabled={!view.audioAvailable}
               aria-label={
                 !view.audioAvailable
-                  ? 'Rally sound unavailable'
+                  ? t('Rally sound unavailable')
                   : view.muted
-                    ? 'Unmute rally sound'
-                    : 'Mute rally sound'
+                    ? t('Unmute rally sound')
+                    : t('Mute rally sound')
               }
               aria-pressed={!view.muted && view.audioAvailable}
               title={
                 !view.audioAvailable
-                  ? 'Sound unavailable'
+                  ? t('Sound unavailable')
                   : view.muted
-                    ? 'Sound off'
-                    : 'Sound on'
+                    ? t('Sound off')
+                    : t('Sound on')
               }
             >
               {view.muted || !view.audioAvailable ? (
@@ -231,28 +241,29 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
                 <VolumeIcon />
               )}
             </button>
-            <DialogClose className="rally-exit" aria-label="Close rally">
+            <DialogClose className="rally-exit" aria-label={t('Close rally')}>
               ESC <span aria-hidden="true">×</span>
             </DialogClose>
           </header>
           <DialogDescription className="sr-only">
-            A timed gravel rally. Use W or up to accelerate, S or down to brake
-            and reverse, A/D or left/right to steer, Space for the handbrake, P
-            to pause, R to recover with a three-second penalty, Enter to start
-            or resume, and Escape to exit.
+            {t(
+              'A timed gravel rally. Use W or up to accelerate, S or down to brake and reverse, A/D or left/right to steer, Space for the handbrake, P to pause, R to recover with a three-second penalty, Enter to start or resume, and Escape to exit.',
+            )}
           </DialogDescription>
           <div className={`rally-stage rally-stage--${view.phase}`}>
             <canvas
               ref={setCanvas}
               className="rally-canvas"
               tabIndex={0}
-              aria-label="Rally course. Driving controls are described above."
+              aria-label={t(
+                'Rally course. Driving controls are described above.',
+              )}
             />
             <div className="rally-grain" aria-hidden="true" />
             {view.phase === 'ready' && (
               <div className="rally-intro">
                 <div className="rally-eyebrow">
-                  <span /> SECRET STAGE UNLOCKED
+                  <span /> {t('Secret stage unlocked')}
                 </div>
                 <h2>
                   <span className="sr-only">Omarchy Rally</span>
@@ -262,16 +273,17 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
                   </span>
                 </h2>
                 <p>
-                  A gravel sprint through the pines.
+                  {t('A gravel sprint through the pines.')}
                   <br />
-                  Keep it tidy. Or take it sideways.
+                  {t('Keep it tidy. Or take it sideways.')}
                 </p>
                 <div className="rally-stage-label">
                   <span>01</span>
                   <div>
-                    <strong>NORTH FOREST</strong>
+                    <strong>{t('North Forest')}</strong>
                     <small>
-                      {stageKm} KM <b>·</b> GRAVEL <b>·</b> TIME ATTACK
+                      {stageKm} km <b>·</b> {t('Gravel')} <b>·</b>{' '}
+                      {t('Time attack')}
                     </small>
                   </div>
                 </div>
@@ -280,40 +292,40 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
                   className="rally-primary"
                   onClick={() => engine.current?.start()}
                 >
-                  Start your engine <span aria-hidden="true">↗</span>
+                  {t('Start your engine')} <span aria-hidden="true">↗</span>
                 </button>
                 <div className="rally-best">
                   {view.best
-                    ? `PERSONAL BEST  ${formatTime(view.best)}`
-                    : 'NO RECORD. YOUR ROAD.'}
+                    ? `${t('Personal best')}  ${formatTime(view.best)}`
+                    : t('No record. Your road.')}
                 </div>
               </div>
             )}
             {isDriving && (
               <>
                 <div className="rally-clock">
-                  <span>STAGE TIME</span>
+                  <span>{t('Stage time')}</span>
                   <strong>{formatTime(view.time)}</strong>
                   <small>
                     {view.best
-                      ? `BEST ${formatTime(view.best)}`
-                      : 'SET THE FIRST TIME'}
+                      ? `${t('Best')} ${formatTime(view.best)}`
+                      : t('Set the first time')}
                   </small>
                 </div>
                 <div className="rally-pace">
                   <strong aria-hidden="true">{note.arrow}</strong>
-                  <span>{note.text}</span>
+                  <span>{PACE_NOTES[note.text] ?? note.text}</span>
                 </div>
                 <button
                   className="rally-pause"
                   onClick={() => engine.current?.pause()}
-                  aria-label="Pause rally"
+                  aria-label={t('Pause rally')}
                 >
                   Ⅱ
                 </button>
                 <div className="rally-speed">
                   <strong>{String(view.speed).padStart(3, '0')}</strong>
-                  <span>KM/H</span>
+                  <span>{t('km/h')}</span>
                   <div className="rally-revs">
                     {Array.from({ length: 12 }, (_, i) => (
                       <i key={i} className={view.speed > i * 13 ? 'lit' : ''} />
@@ -322,7 +334,7 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
                 </div>
                 <div
                   className="rally-map"
-                  aria-label={`Stage ${Math.round(completion)} percent complete`}
+                  aria-label={`${t('Stage progress')}: ${Math.round(completion)}%`}
                 >
                   <svg viewBox="-100 -3950 1900 4300" aria-hidden="true">
                     <path
@@ -361,16 +373,16 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
                     {(
                       Math.max(0, STAGE_LENGTH - point.distance) / 3000
                     ).toFixed(1)}{' '}
-                    KM TO GO
+                    {t('km to go')}
                   </span>
                 </div>
                 {(view.offroad || view.penalty) && (
                   <div className="rally-warning" role="status">
                     {view.penalty ? (
-                      '+3 SEC · BACK ON TRACK'
+                      t('+3 sec · Back on track')
                     ) : (
                       <button onClick={() => engine.current?.recover()}>
-                        OFF ROAD · RECOVER +3S
+                        {t('Off road · Recover +3s')}
                       </button>
                     )}
                   </div>
@@ -380,27 +392,27 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
             {view.phase === 'countdown' && (
               <div className="rally-countdown" aria-live="polite">
                 <strong>{view.countdown}</strong>
-                <span>GET READY</span>
+                <span>{t('Get ready')}</span>
               </div>
             )}
             {view.phase === 'paused' && (
               <div className="rally-scrim">
                 <div className="rally-card">
-                  <div className="rally-eyebrow">TAKE A BREATHER</div>
-                  <h2>In the service park.</h2>
-                  <p>The clock is stopped.</p>
+                  <div className="rally-eyebrow">{t('Take a breather')}</div>
+                  <h2>{t('In the service park.')}</h2>
+                  <p>{t('The clock is stopped.')}</p>
                   <button
                     ref={primaryRef}
                     className="rally-primary"
                     onClick={() => engine.current?.resume()}
                   >
-                    Back to the stage <span>↗</span>
+                    {t('Back to the stage')} <span>↗</span>
                   </button>
                   <button
                     className="rally-secondary"
                     onClick={() => engine.current?.start()}
                   >
-                    Restart stage
+                    {t('Restart stage')}
                   </button>
                 </div>
               </div>
@@ -409,44 +421,47 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
               <div className="rally-scrim">
                 <div className="rally-card">
                   <div className="rally-eyebrow">
-                    {view.record ? 'NEW PERSONAL BEST' : 'STAGE COMPLETE'}
+                    {view.record ? t('New personal best') : t('Stage complete')}
                   </div>
-                  <h2>That’s a wrap.</h2>
+                  <h2>{t('That’s a wrap.')}</h2>
                   <div className="rally-result">{formatTime(view.time)}</div>
                   <p>
-                    North Forest <b>·</b> {stageKm} km of gravel
+                    {t('North Forest')} <b>·</b> {stageKm} {t('km of gravel')}
                   </p>
                   <button
                     ref={primaryRef}
                     className="rally-primary"
                     onClick={() => engine.current?.start()}
                   >
-                    One more run <span>↗</span>
+                    {t('One more run')} <span>↗</span>
                   </button>
                   <DialogClose className="rally-secondary">
-                    Back to Omarchy
+                    {t('Back to Omarchy')}
                   </DialogClose>
                 </div>
               </div>
             )}
             {isDriving && (
-              <div className="rally-touch" aria-label="Touch driving controls">
+              <div
+                className="rally-touch"
+                aria-label={t('Touch driving controls')}
+              >
                 <div>
-                  <button aria-label="Steer left" {...touch('a')}>
+                  <button aria-label={t('Steer left')} {...touch('a')}>
                     ←
                   </button>
-                  <button aria-label="Steer right" {...touch('d')}>
+                  <button aria-label={t('Steer right')} {...touch('d')}>
                     →
                   </button>
                 </div>
                 <div>
                   <button className="rally-touch-drift" {...touch(' ')}>
-                    DRIFT
+                    {t('Drift')}
                   </button>
-                  <button aria-label="Brake and reverse" {...touch('s')}>
+                  <button aria-label={t('Brake and reverse')} {...touch('s')}>
                     ↓
                   </button>
-                  <button aria-label="Accelerate" {...touch('w')}>
+                  <button aria-label={t('Accelerate')} {...touch('w')}>
                     ↑
                   </button>
                 </div>
@@ -455,21 +470,23 @@ export function RallyGame({ onClose }: { onClose: () => void }) {
           </div>
           <footer className="rally-footer">
             <span>
-              <kbd>WASD</kbd> / <kbd>↑ ↓ ← →</kbd> DRIVE
+              <kbd>WASD</kbd> / <kbd>↑ ↓ ← →</kbd> {t('Drive')}
             </span>
             <span>
-              <kbd>SPACE</kbd> HANDBRAKE
+              <kbd>SPACE</kbd> {t('Handbrake')}
             </span>
             <span>
-              <kbd>R</kbd> RECOVER +3S
+              <kbd>R</kbd> {t('Recover')} +3s
             </span>
             <span>
-              <kbd>P</kbd> PAUSE
+              <kbd>P</kbd> {t('Pause')}
             </span>
             <span>
-              <kbd>ENTER</kbd> START
+              <kbd>ENTER</kbd> {t('Start')}
             </span>
-            <span className="rally-footer-tag">BUILT FOR THE DETOUR.</span>
+            <span className="rally-footer-tag">
+              {t('Built for the detour.')}
+            </span>
           </footer>
         </DialogPrimitive.Popup>
       </DialogPortal>

--- a/src/components/RallyGame.tsx
+++ b/src/components/RallyGame.tsx
@@ -1,0 +1,478 @@
+import { useEffect, useRef, useState } from 'react'
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
+import { PICKER_STATE_EVENT, THEME_EVENT } from '@/lib/theme'
+import {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { PixelLabel } from '@/components/PixelLabel'
+import { VolumeIcon, VolumeOffIcon } from '@/components/icons'
+import { DRIVING_KEYS, RallyEngine } from '@/lib/rally-engine'
+import type { View } from '@/lib/rally-engine'
+import {
+  STAGE,
+  STAGE_LENGTH,
+  formatTime,
+  paceNote,
+  stageKm,
+} from '@/lib/rally-stage'
+// Astro hoists CSS from dynamic imports into every page. Inlining keeps it
+// in the lazy chunk so only players download it.
+import rallyStyles from './rally.css?inline'
+
+const INITIAL: View = {
+  phase: 'ready',
+  countdown: 3,
+  time: 0,
+  speed: 0,
+  progress: 0,
+  offroad: false,
+  penalty: false,
+  best: null,
+  record: false,
+  muted: false,
+  audioAvailable: true,
+}
+const MAP_PATH = STAGE.filter((_, i) => i % 3 === 0)
+  .map((p, i) => `${i ? 'L' : 'M'}${p.x},${p.y}`)
+  .join(' ')
+
+export function RallyGame({ onClose }: { onClose: () => void }) {
+  const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null)
+  const engine = useRef<RallyEngine | null>(null)
+  const [view, setView] = useState<View>(INITIAL)
+  const pickerOpenRef = useRef(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [restoreFocus] = useState(
+    () => document.activeElement as HTMLElement | null,
+  )
+  // Whichever card is showing, its primary action takes focus so Enter and
+  // Space act on it without reaching for the mouse.
+  const primaryRef = useRef<HTMLButtonElement | null>(null)
+  const settled =
+    view.phase === 'ready' ||
+    view.phase === 'paused' ||
+    view.phase === 'finished'
+  useEffect(() => {
+    if (settled && !pickerOpenRef.current)
+      primaryRef.current?.focus({ preventScroll: true })
+  }, [settled, view.phase])
+
+  useEffect(() => {
+    if (!canvas) return
+    // An easter egg that cannot draw should get out of the way, not explain.
+    const fail = (error: unknown) => {
+      console.error('Rally could not draw', error)
+      onClose()
+    }
+    let game: RallyEngine
+    try {
+      game = new RallyEngine(canvas, setView, fail)
+    } catch (error) {
+      fail(error)
+      return
+    }
+    engine.current = game
+    setView(game.view)
+
+    let pickerFocusFrame = 0
+    const onPickerState = (event: Event) => {
+      const { open } = (event as CustomEvent<{ open: boolean }>).detail
+      pickerOpenRef.current = open
+      setPickerOpen(open)
+      if (open) game.pause()
+      // The picker focuses itself. Closing it returns to the paused game once
+      // the rally's focus trap is back; resuming is an explicit action.
+      cancelAnimationFrame(pickerFocusFrame)
+      if (!open)
+        pickerFocusFrame = requestAnimationFrame(() =>
+          (primaryRef.current ?? canvas).focus({ preventScroll: true }),
+        )
+    }
+    const refreshTheme = () => game.refreshPalette()
+    const themeObserver = new MutationObserver(refreshTheme)
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    })
+    const keydown = (event: KeyboardEvent) => {
+      if (pickerOpenRef.current) return
+      if (event.metaKey || event.ctrlKey || event.altKey || event.isComposing) {
+        game.releaseAll()
+        return
+      }
+      const key = event.key.toLowerCase()
+      if (key === 'escape') {
+        game.releaseAll()
+        return
+      }
+      // Let focused buttons keep their native Space and Enter behaviour.
+      if (
+        (key === ' ' || key === 'enter') &&
+        (event.target as HTMLElement)?.closest('button')
+      )
+        return
+      if (key === 'enter') {
+        if (!event.repeat && game.proceed()) event.preventDefault()
+        return
+      }
+      if (!DRIVING_KEYS.has(key) && key !== 'p' && key !== 'r') return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      if (event.repeat) return
+      if (key === 'p') {
+        if (game.view.phase === 'paused') game.resume()
+        else game.pause()
+      } else if (key === 'r') game.recover()
+      else if (key === ' ') {
+        // Space starts or resumes from a card and is the handbrake while driving.
+        if (!game.proceed()) game.press(key)
+      } else game.press(key)
+    }
+    const keyup = (event: KeyboardEvent) =>
+      game.release(event.key.toLowerCase())
+    const pause = () => game.pause()
+    const visibility = () => {
+      if (document.hidden) game.pause()
+    }
+    window.addEventListener(PICKER_STATE_EVENT, onPickerState)
+    window.addEventListener(THEME_EVENT, refreshTheme)
+    window.addEventListener('keydown', keydown, true)
+    window.addEventListener('keyup', keyup)
+    window.addEventListener('blur', pause)
+    document.addEventListener('visibilitychange', visibility)
+    return () => {
+      game.dispose()
+      engine.current = null
+      cancelAnimationFrame(pickerFocusFrame)
+      themeObserver.disconnect()
+      window.removeEventListener(PICKER_STATE_EVENT, onPickerState)
+      window.removeEventListener(THEME_EVENT, refreshTheme)
+      window.removeEventListener('keydown', keydown, true)
+      window.removeEventListener('keyup', keyup)
+      window.removeEventListener('blur', pause)
+      document.removeEventListener('visibilitychange', visibility)
+    }
+  }, [canvas])
+
+  const touch = (key: string) => ({
+    onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (pickerOpenRef.current) return
+      event.preventDefault()
+      event.currentTarget.setPointerCapture(event.pointerId)
+      engine.current?.press(key)
+    },
+    onPointerUp: () => engine.current?.release(key),
+    onPointerCancel: () => engine.current?.release(key),
+    onLostPointerCapture: () => engine.current?.release(key),
+  })
+  const note = paceNote(view.progress)
+  const isDriving = view.phase === 'racing' || view.phase === 'countdown'
+  const point = STAGE[view.progress]
+  const completion = Math.min(100, (point.distance / STAGE_LENGTH) * 100)
+
+  return (
+    <Dialog
+      open
+      modal={!pickerOpen}
+      disablePointerDismissal={pickerOpen}
+      onOpenChange={(open, details) => {
+        if (pickerOpenRef.current) {
+          details.cancel()
+          details.allowPropagation()
+          return
+        }
+        if (!open) onClose()
+      }}
+    >
+      <DialogPortal>
+        <style>{rallyStyles}</style>
+        <DialogOverlay className="rally-backdrop" />
+        <DialogPrimitive.Popup
+          className="rally-dialog"
+          initialFocus={primaryRef}
+          finalFocus={() => restoreFocus}
+        >
+          <header className="rally-header">
+            <div className="rally-brand">
+              <span className="rally-checker" aria-hidden="true" />
+              <DialogTitle>
+                OMARCHY <span>RALLY</span>
+              </DialogTitle>
+            </div>
+            <span className="rally-edition">QUATTRO / 04</span>
+            <button
+              className="rally-sound"
+              onClick={() => engine.current?.toggleSound()}
+              disabled={!view.audioAvailable}
+              aria-label={
+                !view.audioAvailable
+                  ? 'Rally sound unavailable'
+                  : view.muted
+                    ? 'Unmute rally sound'
+                    : 'Mute rally sound'
+              }
+              aria-pressed={!view.muted && view.audioAvailable}
+              title={
+                !view.audioAvailable
+                  ? 'Sound unavailable'
+                  : view.muted
+                    ? 'Sound off'
+                    : 'Sound on'
+              }
+            >
+              {view.muted || !view.audioAvailable ? (
+                <VolumeOffIcon />
+              ) : (
+                <VolumeIcon />
+              )}
+            </button>
+            <DialogClose className="rally-exit" aria-label="Close rally">
+              ESC <span aria-hidden="true">×</span>
+            </DialogClose>
+          </header>
+          <DialogDescription className="sr-only">
+            A timed gravel rally. Use W or up to accelerate, S or down to brake
+            and reverse, A/D or left/right to steer, Space for the handbrake, P
+            to pause, R to recover with a three-second penalty, Enter to start
+            or resume, and Escape to exit.
+          </DialogDescription>
+          <div className={`rally-stage rally-stage--${view.phase}`}>
+            <canvas
+              ref={setCanvas}
+              className="rally-canvas"
+              tabIndex={0}
+              aria-label="Rally course. Driving controls are described above."
+            />
+            <div className="rally-grain" aria-hidden="true" />
+            {view.phase === 'ready' && (
+              <div className="rally-intro">
+                <div className="rally-eyebrow">
+                  <span /> SECRET STAGE UNLOCKED
+                </div>
+                <h2>
+                  <span className="sr-only">Omarchy Rally</span>
+                  <span aria-hidden="true">
+                    <PixelLabel text="OMARCHY" cell={6} />
+                    <PixelLabel text="RALLY" cell={9} />
+                  </span>
+                </h2>
+                <p>
+                  A gravel sprint through the pines.
+                  <br />
+                  Keep it tidy. Or take it sideways.
+                </p>
+                <div className="rally-stage-label">
+                  <span>01</span>
+                  <div>
+                    <strong>NORTH FOREST</strong>
+                    <small>
+                      {stageKm} KM <b>·</b> GRAVEL <b>·</b> TIME ATTACK
+                    </small>
+                  </div>
+                </div>
+                <button
+                  ref={primaryRef}
+                  className="rally-primary"
+                  onClick={() => engine.current?.start()}
+                >
+                  Start your engine <span aria-hidden="true">↗</span>
+                </button>
+                <div className="rally-best">
+                  {view.best
+                    ? `PERSONAL BEST  ${formatTime(view.best)}`
+                    : 'NO RECORD. YOUR ROAD.'}
+                </div>
+              </div>
+            )}
+            {isDriving && (
+              <>
+                <div className="rally-clock">
+                  <span>STAGE TIME</span>
+                  <strong>{formatTime(view.time)}</strong>
+                  <small>
+                    {view.best
+                      ? `BEST ${formatTime(view.best)}`
+                      : 'SET THE FIRST TIME'}
+                  </small>
+                </div>
+                <div className="rally-pace">
+                  <strong aria-hidden="true">{note.arrow}</strong>
+                  <span>{note.text}</span>
+                </div>
+                <button
+                  className="rally-pause"
+                  onClick={() => engine.current?.pause()}
+                  aria-label="Pause rally"
+                >
+                  Ⅱ
+                </button>
+                <div className="rally-speed">
+                  <strong>{String(view.speed).padStart(3, '0')}</strong>
+                  <span>KM/H</span>
+                  <div className="rally-revs">
+                    {Array.from({ length: 12 }, (_, i) => (
+                      <i key={i} className={view.speed > i * 13 ? 'lit' : ''} />
+                    ))}
+                  </div>
+                </div>
+                <div
+                  className="rally-map"
+                  aria-label={`Stage ${Math.round(completion)} percent complete`}
+                >
+                  <svg viewBox="-100 -3950 1900 4300" aria-hidden="true">
+                    <path
+                      d={MAP_PATH}
+                      fill="none"
+                      stroke="var(--rally-text)"
+                      strokeOpacity="0.25"
+                      strokeWidth="55"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d={MAP_PATH}
+                      fill="none"
+                      stroke="var(--rally-text)"
+                      strokeWidth="32"
+                      strokeLinecap="round"
+                      pathLength="100"
+                      strokeDasharray={`${completion} 100`}
+                    />
+                    <circle
+                      cx={STAGE.at(-1)!.x}
+                      cy={STAGE.at(-1)!.y}
+                      r="64"
+                      fill="var(--rally-text)"
+                    />
+                    <circle
+                      cx={point.x}
+                      cy={point.y}
+                      r="83"
+                      fill="var(--rally-accent)"
+                      stroke="var(--rally-bg)"
+                      strokeWidth="30"
+                    />
+                  </svg>
+                  <span>
+                    {(
+                      Math.max(0, STAGE_LENGTH - point.distance) / 3000
+                    ).toFixed(1)}{' '}
+                    KM TO GO
+                  </span>
+                </div>
+                {(view.offroad || view.penalty) && (
+                  <div className="rally-warning" role="status">
+                    {view.penalty ? (
+                      '+3 SEC · BACK ON TRACK'
+                    ) : (
+                      <button onClick={() => engine.current?.recover()}>
+                        OFF ROAD · RECOVER +3S
+                      </button>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+            {view.phase === 'countdown' && (
+              <div className="rally-countdown" aria-live="polite">
+                <strong>{view.countdown}</strong>
+                <span>GET READY</span>
+              </div>
+            )}
+            {view.phase === 'paused' && (
+              <div className="rally-scrim">
+                <div className="rally-card">
+                  <div className="rally-eyebrow">TAKE A BREATHER</div>
+                  <h2>In the service park.</h2>
+                  <p>The clock is stopped.</p>
+                  <button
+                    ref={primaryRef}
+                    className="rally-primary"
+                    onClick={() => engine.current?.resume()}
+                  >
+                    Back to the stage <span>↗</span>
+                  </button>
+                  <button
+                    className="rally-secondary"
+                    onClick={() => engine.current?.start()}
+                  >
+                    Restart stage
+                  </button>
+                </div>
+              </div>
+            )}
+            {view.phase === 'finished' && (
+              <div className="rally-scrim">
+                <div className="rally-card">
+                  <div className="rally-eyebrow">
+                    {view.record ? 'NEW PERSONAL BEST' : 'STAGE COMPLETE'}
+                  </div>
+                  <h2>That’s a wrap.</h2>
+                  <div className="rally-result">{formatTime(view.time)}</div>
+                  <p>
+                    North Forest <b>·</b> {stageKm} km of gravel
+                  </p>
+                  <button
+                    ref={primaryRef}
+                    className="rally-primary"
+                    onClick={() => engine.current?.start()}
+                  >
+                    One more run <span>↗</span>
+                  </button>
+                  <DialogClose className="rally-secondary">
+                    Back to Omarchy
+                  </DialogClose>
+                </div>
+              </div>
+            )}
+            {isDriving && (
+              <div className="rally-touch" aria-label="Touch driving controls">
+                <div>
+                  <button aria-label="Steer left" {...touch('a')}>
+                    ←
+                  </button>
+                  <button aria-label="Steer right" {...touch('d')}>
+                    →
+                  </button>
+                </div>
+                <div>
+                  <button className="rally-touch-drift" {...touch(' ')}>
+                    DRIFT
+                  </button>
+                  <button aria-label="Brake and reverse" {...touch('s')}>
+                    ↓
+                  </button>
+                  <button aria-label="Accelerate" {...touch('w')}>
+                    ↑
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          <footer className="rally-footer">
+            <span>
+              <kbd>WASD</kbd> / <kbd>↑ ↓ ← →</kbd> DRIVE
+            </span>
+            <span>
+              <kbd>SPACE</kbd> HANDBRAKE
+            </span>
+            <span>
+              <kbd>R</kbd> RECOVER +3S
+            </span>
+            <span>
+              <kbd>P</kbd> PAUSE
+            </span>
+            <span>
+              <kbd>ENTER</kbd> START
+            </span>
+            <span className="rally-footer-tag">BUILT FOR THE DETOUR.</span>
+          </footer>
+        </DialogPrimitive.Popup>
+      </DialogPortal>
+    </Dialog>
+  )
+}

--- a/src/components/rally.css
+++ b/src/components/rally.css
@@ -612,3 +612,19 @@
   text-decoration: underline;
   text-underline-offset: 3px;
 }
+
+/* Copy is authored in sentence case so translations read naturally; the HUD sets it in caps. */
+.rally-eyebrow,
+.rally-stage-label strong,
+.rally-stage-label small,
+.rally-best,
+.rally-clock span,
+.rally-clock small,
+.rally-speed > span,
+.rally-map > span,
+.rally-warning,
+.rally-countdown span,
+.rally-footer,
+.rally-touch-drift {
+  text-transform: uppercase;
+}

--- a/src/components/rally.css
+++ b/src/components/rally.css
@@ -1,0 +1,614 @@
+.rally-dialog {
+  --rally-text: var(--t-text);
+  --rally-bg: var(--t-bg);
+  --rally-accent: var(--t-brand);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: var(--z-rally);
+  outline: none;
+  width: min(1160px, calc(100vw - 48px));
+  border: 1px solid var(--t-border-strong);
+  border-radius: 3px;
+  background: var(--rally-bg);
+  color: var(--rally-text);
+  box-shadow: 0 36px 120px #0009;
+  overflow: hidden;
+  font-family: 'JetBrains Mono Variable', monospace;
+}
+.rally-header {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  min-height: 62px;
+  padding: 0 24px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--rally-text) 15%, transparent);
+}
+.rally-brand {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+.rally-brand h2 {
+  font:
+    700 14px 'JetBrains Mono Variable',
+    monospace;
+  letter-spacing: 0.09em;
+}
+.rally-brand h2 span {
+  color: var(--rally-accent);
+}
+.rally-checker {
+  width: 20px;
+  height: 20px;
+  background: conic-gradient(
+      var(--rally-text) 25%,
+      transparent 0 50%,
+      var(--rally-text) 0 75%,
+      transparent 0
+    )
+    0 0 / 10px 10px;
+}
+.rally-edition {
+  margin-left: auto;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: var(--t-text-secondary);
+}
+.rally-exit {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border-left: 1px solid color-mix(in srgb, var(--rally-text) 15%, transparent);
+  padding-left: 24px;
+  color: var(--t-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  min-height: 44px;
+}
+.rally-exit span {
+  font-size: 26px;
+  color: var(--rally-text);
+}
+.rally-sound {
+  display: grid;
+  place-items: center;
+  min-width: 44px;
+  height: 44px;
+  color: var(--rally-accent);
+  cursor: pointer;
+}
+.rally-sound svg {
+  width: 20px;
+  height: 20px;
+}
+.rally-sound[aria-pressed='false'] {
+  color: var(--t-text-secondary);
+}
+.rally-sound:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.rally-stage {
+  height: min(650px, calc(100dvh - 180px));
+  min-height: 340px;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+.rally-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  outline: none;
+}
+.rally-grain {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.15;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0 3px,
+    color-mix(in srgb, var(--rally-bg) 13%, transparent) 3px 4px
+  );
+}
+.rally-stage--ready::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--rally-bg) 97%, transparent),
+    color-mix(in srgb, var(--rally-bg) 85%, transparent) 35%,
+    transparent 80%
+  );
+  pointer-events: none;
+}
+.rally-intro {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  left: 6%;
+  transform: translateY(-50%);
+  width: 375px;
+  max-width: 85%;
+}
+.rally-eyebrow {
+  color: var(--rally-accent);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.rally-eyebrow > span {
+  width: 6px;
+  height: 6px;
+  background: currentColor;
+}
+.rally-intro h2 {
+  margin: 28px 0 25px;
+}
+.rally-intro h2 svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 12px;
+}
+.rally-intro p,
+.rally-card p {
+  font:
+    16px/1.7 'Geist Variable',
+    sans-serif;
+  color: var(--t-text-secondary);
+}
+.rally-stage-label {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  padding: 23px 0;
+  margin-top: 10px;
+}
+.rally-stage-label > span {
+  border: 1px solid color-mix(in srgb, var(--rally-text) 38%, transparent);
+  padding: 7px 10px;
+  font-size: 20px;
+}
+.rally-stage-label strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+}
+.rally-stage-label small {
+  display: block;
+  font-size: 12px;
+  color: var(--t-text-secondary);
+  margin-top: 6px;
+}
+.rally-stage-label b,
+.rally-card b {
+  padding: 0 5px;
+}
+.rally-primary {
+  background: var(--rally-accent);
+  color: var(--t-brand-ink);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  width: 100%;
+  padding: 17px 20px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+.rally-primary:hover {
+  background: color-mix(in srgb, var(--rally-accent), var(--rally-text) 20%);
+}
+.rally-primary span {
+  font-size: 20px;
+}
+.rally-best {
+  font-size: 12px;
+  color: var(--t-text-secondary);
+  margin-top: 18px;
+  letter-spacing: 0.03em;
+}
+.rally-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 20px;
+  padding: 16px 24px;
+  border-top: 1px solid color-mix(in srgb, var(--rally-text) 15%, transparent);
+  font-size: 12px;
+  color: var(--t-text-secondary);
+}
+.rally-footer span {
+  white-space: nowrap;
+}
+.rally-footer kbd {
+  color: var(--rally-text);
+  font-family: inherit;
+  font-size: 12px;
+}
+.rally-footer-tag {
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.6;
+}
+.rally-clock {
+  position: absolute;
+  top: 25px;
+  left: 28px;
+  display: flex;
+  flex-direction: column;
+  text-shadow: 0 2px 12px var(--rally-bg);
+}
+.rally-clock > span,
+.rally-clock small {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+}
+.rally-clock strong {
+  font-size: 36px;
+  line-height: 1.35;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.rally-clock small {
+  color: var(--t-text-secondary);
+}
+.rally-pace {
+  position: absolute;
+  top: 23px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: color-mix(in srgb, var(--rally-bg) 94%, transparent);
+  padding: 10px 22px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid color-mix(in srgb, var(--rally-text) 19%, transparent);
+  min-width: 130px;
+}
+.rally-pace strong {
+  font-size: 39px;
+  color: var(--rally-accent);
+  line-height: 1.1;
+  font-family: sans-serif;
+}
+.rally-pace span {
+  margin-top: 6px;
+  font-size: 14px;
+}
+.rally-pause {
+  position: absolute;
+  top: 25px;
+  right: 28px;
+  border: 1px solid color-mix(in srgb, var(--rally-text) 25%, transparent);
+  width: 44px;
+  height: 44px;
+  cursor: pointer;
+  background: color-mix(in srgb, var(--rally-bg) 94%, transparent);
+  font-size: 18px;
+}
+.rally-speed {
+  position: absolute;
+  left: 28px;
+  bottom: 30px;
+  text-shadow: 0 2px 10px var(--rally-bg);
+}
+.rally-speed strong {
+  font-size: 54px;
+  font-weight: 600;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.rally-speed > span {
+  font-size: 12px;
+  margin-left: 8px;
+}
+.rally-revs {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+}
+.rally-revs i {
+  width: 12px;
+  height: 5px;
+  background: color-mix(in srgb, var(--rally-text) 19%, transparent);
+}
+.rally-revs .lit {
+  background: var(--rally-text);
+}
+.rally-revs .lit:nth-last-child(-n + 3) {
+  background: var(--rally-accent);
+}
+.rally-map {
+  position: absolute;
+  right: 27px;
+  bottom: 28px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 9px;
+  padding: 15px 12px 10px;
+  background: color-mix(in srgb, var(--rally-bg) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--rally-text) 19%, transparent);
+}
+.rally-map svg {
+  width: 82px;
+  height: 140px;
+}
+.rally-map span {
+  font-size: 12px;
+  color: var(--t-text-secondary);
+}
+.rally-warning {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--rally-accent);
+  color: var(--t-brand-ink);
+  padding: 8px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.rally-countdown {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-shadow: 0 4px 30px var(--rally-bg);
+}
+.rally-countdown strong {
+  font-size: 110px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+.rally-countdown span {
+  font-size: 14px;
+  letter-spacing: 0.2em;
+}
+.rally-scrim {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--rally-bg) 94%, transparent);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+.rally-card {
+  position: relative;
+  width: min(380px, 100%);
+}
+.rally-card h2 {
+  font:
+    600 34px/1.2 'Geist Variable',
+    sans-serif;
+  letter-spacing: -0.025em;
+  margin: 20px 0 13px;
+}
+.rally-card .rally-primary {
+  margin-top: 26px;
+}
+.rally-secondary {
+  display: block;
+  width: 100%;
+  padding: 16px 0;
+  font-size: 14px;
+  color: var(--t-text-secondary);
+  cursor: pointer;
+}
+.rally-secondary:hover {
+  color: var(--rally-text);
+}
+.rally-result {
+  font-size: 54px;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  color: var(--rally-accent);
+}
+.rally-touch {
+  display: none;
+}
+.rally-dialog button:focus-visible {
+  outline: 2px solid var(--rally-text);
+  outline-offset: -5px;
+}
+@media (pointer: coarse) {
+  .rally-touch {
+    position: absolute;
+    bottom: 18px;
+    left: 18px;
+    right: 18px;
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .rally-touch > div {
+    display: flex;
+    gap: 8px;
+  }
+  .rally-touch button {
+    width: 52px;
+    height: 52px;
+    border: 1px solid color-mix(in srgb, var(--rally-text) 44%, transparent);
+    background: color-mix(in srgb, var(--rally-bg) 94%, transparent);
+    font-size: 24px;
+    touch-action: none;
+    user-select: none;
+  }
+  .rally-touch button:active {
+    background: var(--rally-accent);
+    color: var(--t-brand-ink);
+  }
+  .rally-touch .rally-touch-drift {
+    width: 60px;
+    font-size: 12px;
+  }
+  .rally-speed {
+    bottom: 90px;
+  }
+  .rally-map {
+    bottom: 90px;
+  }
+  .rally-warning {
+    bottom: 85px;
+  }
+}
+@media (max-width: 700px) {
+  .rally-dialog {
+    width: 100vw;
+    height: 100dvh;
+    border: 0;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .rally-header {
+    padding: max(8px, env(safe-area-inset-top)) 16px 8px;
+    min-height: 58px;
+    gap: 12px;
+  }
+  .rally-edition {
+    display: none;
+  }
+  .rally-exit {
+    margin-left: auto;
+    padding-left: 14px;
+  }
+  .rally-stage {
+    flex: 1;
+    min-height: 0;
+    height: auto;
+  }
+  .rally-intro {
+    left: 8%;
+    width: 340px;
+  }
+  .rally-intro h2 {
+    margin: 22px 0;
+  }
+  .rally-intro h2 svg {
+    max-width: 90%;
+  }
+  .rally-stage--ready::after {
+    background: color-mix(in srgb, var(--rally-bg) 88%, transparent);
+  }
+  .rally-footer {
+    gap: 8px 16px;
+    padding: 12px 16px max(12px, env(safe-area-inset-bottom));
+    font-size: 12px;
+  }
+  .rally-footer-tag {
+    display: none;
+  }
+  .rally-clock {
+    left: 18px;
+    top: 18px;
+  }
+  .rally-clock strong {
+    font-size: 27px;
+  }
+  .rally-pace {
+    left: auto;
+    right: 16px;
+    top: 75px;
+    transform: none;
+    min-width: 100px;
+    padding: 8px 12px;
+  }
+  .rally-pace strong {
+    font-size: 28px;
+  }
+  .rally-pause {
+    right: 16px;
+    top: 18px;
+  }
+  .rally-speed {
+    left: 18px;
+  }
+  .rally-speed strong {
+    font-size: 38px;
+  }
+  .rally-revs {
+    gap: 3px;
+  }
+  .rally-revs i {
+    width: 8px;
+  }
+  .rally-map {
+    right: 18px;
+    padding: 9px;
+  }
+  .rally-map svg {
+    height: 100px;
+    width: 55px;
+  }
+  .rally-warning {
+    bottom: 170px;
+  }
+}
+@media (max-height: 650px) and (min-width: 701px) {
+  .rally-dialog {
+    width: min(1160px, calc(100vw - 24px));
+  }
+  .rally-stage {
+    height: calc(100dvh - 122px);
+    min-height: 240px;
+  }
+  .rally-header {
+    min-height: 46px;
+  }
+  .rally-footer {
+    padding-block: 10px;
+  }
+  .rally-intro {
+    width: 520px;
+  }
+  .rally-intro h2 {
+    margin: 14px 0;
+  }
+  .rally-intro h2 svg {
+    display: inline-block;
+    height: 33px;
+    width: auto;
+    margin: 0 18px 0 0;
+  }
+  .rally-intro p {
+    font-size: 14px;
+  }
+  .rally-stage-label {
+    padding: 10px 0;
+    margin-top: 0;
+  }
+  .rally-primary {
+    padding: 11px 16px;
+  }
+  .rally-best {
+    margin-top: 10px;
+  }
+}
+
+.rally-backdrop {
+  z-index: var(--z-rally);
+  background: color-mix(in srgb, var(--t-bg-deep) 75%, transparent);
+}
+.rally-warning button {
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,6 +8,7 @@ import { SiteFooter } from '@/components/SiteFooter'
 import { ThemePicker } from '@/components/ThemePicker'
 import { SearchPalette } from '@/components/SearchPalette'
 import { PixelSnap } from '@/components/PixelSnap'
+import { Rally } from '@/components/Rally'
 import { MusicControl } from '@/components/MusicControl'
 import { themeInitScript } from '@/lib/theme'
 import { etchInitScript } from '@/lib/etch'
@@ -90,6 +91,7 @@ const ogImage = socialImage(path)
     <SearchPalette client:load />
     <MusicControl client:load path={Astro.url.pathname} transition:persist="music-control" />
     <PixelSnap client:load />
+    <Rally client:idle />
     <script>
       import type { TransitionBeforeSwapEvent } from 'astro:transitions/client'
       import { readTheme } from '@/lib/theme'

--- a/src/lib/konami.ts
+++ b/src/lib/konami.ts
@@ -1,0 +1,26 @@
+const codes = [
+  [
+    'ArrowUp',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowLeft',
+    'ArrowRight',
+    'b',
+    'a',
+  ],
+  ['k', 'k', 'j', 'j', 'h', 'l', 'h', 'l', 'b', 'a'],
+]
+
+/** Retain the matching suffix, including overlapping starts such as up/up/up. */
+export function advanceKonami(buffer: string[], key: string) {
+  const keys = [...buffer, key.length === 1 ? key.toLowerCase() : key].slice(
+    -10,
+  )
+  const hit = codes.some((code) =>
+    code.every((value, index) => keys[index] === value),
+  )
+  return { keys: hit ? [] : keys, hit }
+}

--- a/src/lib/rally-audio.test.ts
+++ b/src/lib/rally-audio.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { startingEngine, stepEngine } from './rally-audio.ts'
+import { startingCar } from './rally-stage.ts'
+import type { Car, Controls } from './rally-stage.ts'
+
+const input = { throttle: false, brake: false, steer: 0, drift: false }
+const atSpeed = (speed: number) => ({ ...startingCar(), angle: 0, vx: speed })
+function run(
+  car: Car,
+  controls: Controls = input,
+  engine = startingEngine(),
+  seconds = 1,
+) {
+  let voice = stepEngine(engine, car, controls, 0)
+  for (let i = 0; i < Math.round(seconds * 120); i++)
+    voice = stepEngine(engine, car, controls, 1 / 120)
+  return { engine, voice }
+}
+
+test('idle has a low exhaust pulse without gravel or tyre noise', () => {
+  const { voice } = run(startingCar())
+  assert.ok(voice.frequency * 5 > 30 && voice.frequency * 5 < 60)
+  assert.equal(voice.gravel, 0)
+  assert.equal(voice.scrub, 0)
+  assert.equal(run(startingCar(), { ...input, drift: true }).voice.scrub, 0)
+})
+
+test('throttle builds revs progressively rather than jumping immediately', () => {
+  const engine = startingEngine(),
+    initial = engine.rpm
+  const first = stepEngine(
+    engine,
+    startingCar(),
+    { ...input, throttle: true },
+    1 / 120,
+  )
+  assert.ok(engine.rpm > initial && engine.rpm < initial + 100)
+  const sustained = run(
+    startingCar(),
+    { ...input, throttle: true },
+    engine,
+  ).voice
+  assert.ok(sustained.frequency > first.frequency * 2)
+  assert.ok(sustained.engine > first.engine)
+})
+
+test('upshift drops revs and does not chatter when speed crosses the same threshold', () => {
+  const { engine } = run(atSpeed(69), { ...input, throttle: true })
+  assert.equal(engine.gear, 0)
+  const highRpm = engine.rpm
+  stepEngine(engine, atSpeed(72), { ...input, throttle: true }, 1 / 120)
+  assert.equal(engine.gear, 1)
+  assert.ok(engine.shift > 0)
+  for (let i = 0; i < 240; i++) {
+    stepEngine(
+      engine,
+      atSpeed(i % 2 ? 69 : 72),
+      { ...input, throttle: true },
+      1 / 120,
+    )
+    assert.equal(engine.gear, 1)
+  }
+  assert.equal(engine.shift, 0)
+  assert.ok(engine.rpm < highRpm - 1000)
+  run(atSpeed(45), input, engine)
+  assert.equal(engine.gear, 0)
+})
+
+test('a sideways slide increases surface noise without raising engine revs', () => {
+  const car = atSpeed(160),
+    straight = run(car)
+  const slide = run({ ...car, vy: 80 })
+  assert.equal(straight.engine.rpm, slide.engine.rpm)
+  assert.equal(straight.voice.scrub, 0)
+  assert.ok(slide.voice.scrub > straight.voice.scrub)
+  assert.ok(run({ ...car, offroad: true }).voice.gravel > straight.voice.gravel)
+  assert.ok(run(car, { ...input, drift: true }).voice.scrub > 0)
+})
+
+test('turbo spools under load and releases once on lift-off', () => {
+  const car = atSpeed(160)
+  const { engine } = run(car, { ...input, throttle: true }, startingEngine(), 3)
+  assert.ok(engine.boost > 0.5)
+  assert.equal(stepEngine(engine, car, input, 1 / 120).lift, true)
+  assert.equal(stepEngine(engine, car, input, 1 / 120).lift, false)
+  run(car, input, engine)
+  assert.ok(engine.boost < 0.01)
+  const idle = run(startingCar(), { ...input, throttle: true }).engine
+  assert.equal(stepEngine(idle, startingCar(), input, 1 / 120).lift, false)
+})
+
+test('reverse cannot use forward gears and all sound parameters remain bounded', () => {
+  const engine = startingEngine()
+  engine.gear = 4
+  for (let speed = -55; speed <= 300; speed += 5) {
+    for (const throttle of [false, true]) {
+      const { voice } = run(
+        { ...atSpeed(speed), vy: 30, offroad: true },
+        { ...input, throttle, drift: true },
+        engine,
+      )
+      for (const value of Object.values(voice)) {
+        if (typeof value === 'number')
+          assert.ok(Number.isFinite(value) && value >= 0)
+      }
+      if (speed < 0) assert.equal(engine.gear, 0)
+      assert.ok(engine.rpm >= 950 && engine.rpm <= 6900)
+      assert.ok(voice.engine <= 0.2)
+      assert.ok(voice.gravel <= 0.17)
+      assert.ok(voice.scrub <= 0.12)
+      assert.ok(voice.cutoff < 4000)
+    }
+  }
+})

--- a/src/lib/rally-audio.ts
+++ b/src/lib/rally-audio.ts
@@ -1,0 +1,377 @@
+import { clamp } from './rally-stage.ts'
+import type { Car, Controls } from './rally-stage.ts'
+
+export const RALLY_MUTE_KEY = 'omarchy-rally-muted'
+
+export function readRallyMuted() {
+  try {
+    return localStorage.getItem(RALLY_MUTE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export type EngineState = {
+  gear: number
+  rpm: number
+  throttle: number
+  boost: number
+  shift: number
+  cooldown: number
+  wasThrottle: boolean
+}
+
+export const startingEngine = (): EngineState => ({
+  gear: 0,
+  rpm: 950,
+  throttle: 0,
+  boost: 0,
+  shift: 0,
+  cooldown: 0,
+  wasThrottle: false,
+})
+
+const GEAR_RATIOS = [88, 51, 35, 27, 22]
+
+/** The gearbox has memory, so a corner cannot chatter between two gear sounds. */
+export function stepEngine(
+  engine: EngineState,
+  car: Car,
+  input: Controls,
+  dt: number,
+) {
+  dt = clamp(dt, 0, 0.1)
+  const forward = car.vx * Math.cos(car.angle) + car.vy * Math.sin(car.angle)
+  const speed = Math.hypot(car.vx, car.vy)
+  const wheelSpeed = Math.abs(forward)
+  engine.shift = Math.max(0, engine.shift - dt)
+  engine.cooldown = Math.max(0, engine.cooldown - dt)
+  if (forward < -5 || wheelSpeed < 8) engine.gear = 0
+  if (engine.cooldown === 0 && forward >= 8) {
+    const wheelRpm = wheelSpeed * GEAR_RATIOS[engine.gear]
+    const previousGear = engine.gear
+    if (wheelRpm > 6200 && engine.gear < 4) engine.gear++
+    else if (wheelRpm < 2600 && engine.gear > 0) engine.gear--
+    if (engine.gear !== previousGear) {
+      engine.shift = 0.13
+      engine.cooldown = 0.45
+    }
+  }
+  engine.throttle +=
+    (Number(input.throttle) - engine.throttle) * (1 - Math.exp(-dt * 8))
+  // Slip can make gravel louder without falsely revving the driven wheels.
+  const freeRev = 950 + engine.throttle * 1700
+  const wheelRpm = wheelSpeed * GEAR_RATIOS[engine.gear]
+  const targetRpm = clamp(
+    Math.max(freeRev, wheelRpm) + engine.throttle * 200,
+    950,
+    6900,
+  )
+  engine.rpm +=
+    (targetRpm - engine.rpm) * (1 - Math.exp(-dt * (engine.shift > 0 ? 14 : 7)))
+  const lift = engine.wasThrottle && !input.throttle && engine.boost > 0.32
+  engine.wasThrottle = input.throttle
+  const targetBoost =
+    input.throttle && engine.shift === 0
+      ? clamp((engine.rpm - 2400) / 3500, 0, 1)
+      : 0
+  engine.boost +=
+    (targetBoost - engine.boost) *
+    (1 - Math.exp(-dt * (targetBoost > engine.boost ? 2 : 9)))
+  const slip = Math.abs(
+    -car.vx * Math.sin(car.angle) + car.vy * Math.cos(car.angle),
+  )
+  const rolling = clamp(speed / 220, 0, 1)
+  return {
+    // A whole engine cycle, with five exhaust pulses in the waveform below.
+    frequency: engine.rpm / 120,
+    engine: (0.11 + engine.throttle * 0.085) * (engine.shift > 0 ? 0.52 : 1),
+    cutoff: 420 + engine.rpm * (0.11 + engine.throttle * 0.19),
+    gravel: rolling * (car.offroad ? 0.15 : 0.055),
+    scrub: rolling * clamp(slip / 65 + (input.drift ? 0.3 : 0), 0, 1) * 0.1,
+    turbo: engine.boost * 0.045,
+    lift,
+  }
+}
+
+/** Construct only from a user gesture, or autoplay policy blocks the context. */
+export class RallyAudio {
+  private context = new AudioContext()
+  private master = this.context.createGain()
+  private engine = this.context.createOscillator()
+  private lowEngine = this.context.createOscillator()
+  private engineGain = this.context.createGain()
+  private engineFilter = this.context.createBiquadFilter()
+  private intakeGain = this.context.createGain()
+  private turboGain = this.context.createGain()
+  private turboFilter = this.context.createBiquadFilter()
+  private gravelGain = this.context.createGain()
+  private scrubGain = this.context.createGain()
+  private noise = this.context.createBufferSource()
+  private cues = new Set<OscillatorNode | AudioBufferSourceNode>()
+  private drive = startingEngine()
+  private muted = false
+  private active = false
+  private closed = false
+  private onUnavailable: () => void
+  private suspendTimer: ReturnType<typeof setTimeout> | undefined
+  private finishTimer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(onUnavailable: () => void) {
+    this.onUnavailable = onUnavailable
+    const ctx = this.context
+    this.master.gain.value = 0
+    const compressor = ctx.createDynamicsCompressor()
+    compressor.threshold.value = -16
+    compressor.knee.value = 12
+    compressor.ratio.value = 3
+    compressor.attack.value = 0.006
+    compressor.release.value = 0.18
+    this.master.connect(compressor).connect(ctx.destination)
+    this.engineGain.gain.value = 0
+    this.engineFilter.type = 'lowpass'
+    this.engineFilter.Q.value = 0.7
+    this.engineFilter.frequency.value = 800
+    const exhaust = ctx.createWaveShaper()
+    exhaust.curve = Float32Array.from(
+      { length: 1024 },
+      (_, i) => Math.tanh(((i / 1023) * 2 - 1) * 1.8) / Math.tanh(1.8),
+    )
+    exhaust.oversample = '2x'
+    this.engineFilter
+      .connect(exhaust)
+      .connect(this.engineGain)
+      .connect(this.master)
+
+    // Five slightly different pulses per cycle provide low, uneven exhaust
+    // harmonics instead of a clean musical note at the firing frequency.
+    const real = new Float32Array(64),
+      imaginary = new Float32Array(64)
+    const pulses = [1, 0.84, 0.96, 0.88, 0.93]
+    for (let harmonic = 1; harmonic < real.length; harmonic++) {
+      for (let pulse = 0; pulse < pulses.length; pulse++) {
+        const phase = (2 * Math.PI * harmonic * pulse) / pulses.length
+        const level = pulses[pulse] / (1 + (harmonic / 9) ** 2)
+        real[harmonic] += Math.cos(phase) * level
+        imaginary[harmonic] += Math.sin(phase) * level
+      }
+    }
+    this.engine.setPeriodicWave(ctx.createPeriodicWave(real, imaginary))
+    this.engine.frequency.value = 950 / 120
+    this.engine.connect(this.engineFilter)
+    this.lowEngine.type = 'triangle'
+    this.lowEngine.frequency.value = 950 / 60
+    const lowGain = ctx.createGain()
+    lowGain.gain.value = 0.32
+    this.lowEngine.connect(lowGain).connect(this.engineFilter)
+
+    const buffer = ctx.createBuffer(1, ctx.sampleRate * 2, ctx.sampleRate)
+    const samples = buffer.getChannelData(0)
+    let previous = 0
+    for (let i = 0; i < samples.length; i++) {
+      previous = (previous + (Math.random() * 2 - 1) * 0.12) / 1.12
+      samples[i] = previous * 3
+    }
+    // Blend the loop boundary so surface noise has no repeating click.
+    for (let i = 0; i < 512; i++) {
+      const at = samples.length - 512 + i,
+        fade = i / 511
+      samples[at] = samples[at] * (1 - fade) + samples[i] * fade
+    }
+    this.noise.buffer = buffer
+    this.noise.loop = true
+    this.noise.loopStart = 512 / ctx.sampleRate
+    const intakeFilter = ctx.createBiquadFilter()
+    intakeFilter.type = 'bandpass'
+    intakeFilter.frequency.value = 380
+    intakeFilter.Q.value = 0.6
+    this.intakeGain.gain.value = 0
+    this.noise
+      .connect(intakeFilter)
+      .connect(this.intakeGain)
+      .connect(this.engineFilter)
+    const flutter = ctx.createGain()
+    flutter.gain.value = 5
+    this.noise.connect(flutter)
+    flutter.connect(this.engine.detune)
+    this.turboFilter.type = 'bandpass'
+    this.turboFilter.frequency.value = 2600
+    this.turboFilter.Q.value = 1.2
+    this.turboGain.gain.value = 0
+    this.noise
+      .connect(this.turboFilter)
+      .connect(this.turboGain)
+      .connect(this.master)
+    const gravelFilter = ctx.createBiquadFilter()
+    gravelFilter.type = 'lowpass'
+    gravelFilter.frequency.value = 1400
+    this.gravelGain.gain.value = 0
+    this.noise
+      .connect(gravelFilter)
+      .connect(this.gravelGain)
+      .connect(this.master)
+    const scrubFilter = ctx.createBiquadFilter()
+    scrubFilter.type = 'bandpass'
+    scrubFilter.frequency.value = 1100
+    scrubFilter.Q.value = 0.65
+    this.scrubGain.gain.value = 0
+    this.noise.connect(scrubFilter).connect(this.scrubGain).connect(this.master)
+    this.engine.start()
+    this.lowEngine.start()
+    this.noise.start()
+  }
+
+  setMuted(muted: boolean) {
+    this.muted = muted
+    this.syncPlayback()
+  }
+
+  setActive(active: boolean) {
+    clearTimeout(this.finishTimer)
+    this.active = active
+    this.syncPlayback()
+  }
+
+  private syncPlayback() {
+    if (this.closed) return
+    clearTimeout(this.suspendTimer)
+    const ctx = this.context
+    this.master.gain.cancelScheduledValues(ctx.currentTime)
+    this.master.gain.setTargetAtTime(
+      this.active && !this.muted ? 0.65 : 0,
+      ctx.currentTime,
+      0.012,
+    )
+    if (this.active && !this.muted) {
+      void ctx.resume().catch(() => {
+        if (!this.closed) this.onUnavailable()
+      })
+    } else {
+      this.stopCues()
+      this.suspendTimer = setTimeout(() => {
+        if (!this.closed && (!this.active || this.muted))
+          void ctx.suspend().catch(() => {})
+      }, 70)
+    }
+  }
+
+  update(car: Car, input: Controls, dt: number) {
+    if (this.closed || !this.active) return
+    const time = this.context.currentTime
+    const voice = stepEngine(this.drive, car, input, dt)
+    if (this.muted) return
+    this.engine.frequency.setTargetAtTime(voice.frequency, time, 0.025)
+    this.lowEngine.frequency.setTargetAtTime(voice.frequency * 2, time, 0.04)
+    this.engineFilter.frequency.setTargetAtTime(voice.cutoff, time, 0.06)
+    this.engineGain.gain.setTargetAtTime(voice.engine, time, 0.06)
+    this.intakeGain.gain.setTargetAtTime(
+      0.08 + this.drive.throttle * 0.12,
+      time,
+      0.06,
+    )
+    this.turboGain.gain.setTargetAtTime(voice.turbo, time, 0.12)
+    this.turboFilter.frequency.setTargetAtTime(
+      1800 + this.drive.boost * 1800,
+      time,
+      0.1,
+    )
+    this.gravelGain.gain.setTargetAtTime(voice.gravel, time, 0.08)
+    this.scrubGain.gain.setTargetAtTime(voice.scrub, time, 0.05)
+    if (voice.lift) this.releaseTurbo()
+  }
+
+  reset() {
+    this.drive = startingEngine()
+    this.stopCues()
+  }
+
+  private releaseTurbo() {
+    const ctx = this.context,
+      start = ctx.currentTime
+    const source = ctx.createBufferSource(),
+      filter = ctx.createBiquadFilter(),
+      gain = ctx.createGain()
+    source.buffer = this.noise.buffer
+    filter.type = 'bandpass'
+    filter.Q.value = 0.7
+    filter.frequency.setValueAtTime(3200, start)
+    filter.frequency.exponentialRampToValueAtTime(900, start + 0.22)
+    gain.gain.setValueAtTime(0, start)
+    gain.gain.linearRampToValueAtTime(this.drive.boost * 0.16, start + 0.012)
+    gain.gain.exponentialRampToValueAtTime(0.001, start + 0.25)
+    source.connect(filter).connect(gain).connect(this.master)
+    this.cues.add(source)
+    source.onended = () => {
+      source.disconnect()
+      filter.disconnect()
+      gain.disconnect()
+      this.cues.delete(source)
+    }
+    source.start(start)
+    source.stop(start + 0.26)
+  }
+
+  countdown(number: number) {
+    if (number === 0) this.tone(880, 0.3)
+    else this.tone(440, 0.1)
+  }
+
+  finish() {
+    if (this.closed) return
+    const time = this.context.currentTime
+    for (const gain of [
+      this.engineGain,
+      this.gravelGain,
+      this.scrubGain,
+      this.turboGain,
+    ]) {
+      gain.gain.cancelScheduledValues(time)
+      gain.gain.setTargetAtTime(0, time, 0.06)
+    }
+    ;[523.25, 659.25, 783.99, 1046.5].forEach((frequency, i) =>
+      this.tone(frequency, 0.22, i * 0.13),
+    )
+    clearTimeout(this.finishTimer)
+    this.finishTimer = setTimeout(() => this.setActive(false), 1000)
+  }
+
+  private tone(frequency: number, duration: number, delay = 0) {
+    if (this.closed || this.muted || !this.active) return
+    const ctx = this.context,
+      start = ctx.currentTime + delay
+    const oscillator = ctx.createOscillator(),
+      gain = ctx.createGain()
+    oscillator.type = 'sine'
+    oscillator.frequency.value = frequency
+    gain.gain.setValueAtTime(0, start)
+    gain.gain.linearRampToValueAtTime(0.16, start + 0.008)
+    gain.gain.exponentialRampToValueAtTime(0.001, start + duration)
+    oscillator.connect(gain).connect(this.master)
+    this.cues.add(oscillator)
+    oscillator.onended = () => {
+      oscillator.disconnect()
+      gain.disconnect()
+      this.cues.delete(oscillator)
+    }
+    oscillator.start(start)
+    oscillator.stop(start + duration + 0.01)
+  }
+
+  private stopCues() {
+    for (const cue of this.cues) cue.stop()
+    this.cues.clear()
+  }
+
+  dispose() {
+    if (this.closed) return
+    this.closed = true
+    clearTimeout(this.suspendTimer)
+    clearTimeout(this.finishTimer)
+    this.stopCues()
+    this.engine.stop()
+    this.lowEngine.stop()
+    this.noise.stop()
+    this.master.disconnect()
+    void this.context.close().catch(() => {})
+  }
+}

--- a/src/lib/rally-engine.ts
+++ b/src/lib/rally-engine.ts
@@ -1,0 +1,283 @@
+import { RallyRenderer } from './rally-renderer.ts'
+import { RallyAudio, RALLY_MUTE_KEY, readRallyMuted } from './rally-audio.ts'
+import {
+  BEST_KEY,
+  FIXED_STEP,
+  recoverCar,
+  startingCar,
+  stepCar,
+} from './rally-stage.ts'
+
+export type Phase = 'ready' | 'countdown' | 'racing' | 'paused' | 'finished'
+export type View = {
+  phase: Phase
+  countdown: number
+  time: number
+  speed: number
+  progress: number
+  offroad: boolean
+  penalty: boolean
+  best: number | null
+  record: boolean
+  muted: boolean
+  audioAvailable: boolean
+}
+
+export const DRIVING_KEYS = new Set([
+  'arrowup',
+  'arrowdown',
+  'arrowleft',
+  'arrowright',
+  'w',
+  'a',
+  's',
+  'd',
+  ' ',
+])
+
+function readBest(): number | null {
+  try {
+    const n = Number(localStorage.getItem(BEST_KEY))
+    return Number.isFinite(n) && n > 0 ? n : null
+  } catch {
+    return null
+  }
+}
+
+/** Runs one rally on a canvas: clock, car, sound and picture. The React
+ * component around it only renders the view and forwards page events. */
+export class RallyEngine {
+  private renderer: RallyRenderer
+  private audio: RallyAudio | null = null
+  private resize: ResizeObserver
+  private reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+  private car = startingCar()
+  private phase: Phase = 'ready'
+  private resumePhase: Phase = 'racing'
+  private held = new Set<string>()
+  private countdown = 3
+  private accumulator = 0
+  private previous = 0
+  private lastPublish = 0
+  private frame = 0
+  private penaltyUntil = 0
+  private dirty = true
+  private best = readBest()
+  private record = false
+  private muted = readRallyMuted()
+  private audioAvailable = true
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    private listener: (view: View) => void,
+    private onError: (error: unknown) => void,
+  ) {
+    this.renderer = new RallyRenderer(canvas)
+    this.resize = new ResizeObserver(([entry]) => {
+      this.renderer.resize(entry.contentRect.width, entry.contentRect.height)
+      this.dirty = true
+    })
+    this.resize.observe(canvas)
+    this.frame = requestAnimationFrame(this.animate)
+  }
+
+  get view(): View {
+    return {
+      phase: this.phase,
+      countdown: Math.ceil(this.countdown),
+      time: this.car.elapsed,
+      speed: Math.round(Math.hypot(this.car.vx, this.car.vy) * 0.55),
+      progress: this.car.progress,
+      offroad: this.car.offroad,
+      penalty: this.car.elapsed < this.penaltyUntil,
+      best: this.best,
+      record: this.record,
+      muted: this.muted,
+      audioAvailable: this.audioAvailable,
+    }
+  }
+
+  start() {
+    this.held.clear()
+    this.car = startingCar()
+    this.renderer.reset()
+    this.phase = 'countdown'
+    this.countdown = 3
+    this.accumulator = 0
+    this.penaltyUntil = 0
+    this.record = false
+    this.wakeAudio()
+    this.audio?.reset()
+    this.audio?.countdown(3)
+    this.canvas.focus()
+    this.changed()
+  }
+
+  pause() {
+    if (this.phase !== 'racing' && this.phase !== 'countdown') return
+    this.resumePhase = this.phase
+    this.phase = 'paused'
+    this.audio?.setActive(false)
+    this.held.clear()
+    this.changed()
+  }
+
+  resume() {
+    if (this.phase !== 'paused') return
+    this.phase = this.resumePhase
+    this.held.clear()
+    this.wakeAudio()
+    this.canvas.focus()
+    this.changed()
+  }
+
+  /** The one obvious action for Enter or Space; false while driving. */
+  proceed() {
+    if (this.phase === 'paused') this.resume()
+    else if (this.phase === 'ready' || this.phase === 'finished') this.start()
+    else return false
+    return true
+  }
+
+  recover() {
+    if (this.phase !== 'racing') return
+    recoverCar(this.car)
+    this.penaltyUntil = this.car.elapsed + 2
+    this.changed()
+  }
+
+  toggleSound() {
+    this.muted = !this.muted
+    try {
+      localStorage.setItem(RALLY_MUTE_KEY, String(this.muted))
+    } catch {
+      /* Sound still works without storage. */
+    }
+    this.audio?.setMuted(this.muted)
+    if (!this.muted && this.driving) this.wakeAudio()
+    this.changed()
+  }
+
+  press(key: string) {
+    if (this.phase !== 'paused' && DRIVING_KEYS.has(key)) this.held.add(key)
+  }
+
+  release(key: string) {
+    this.held.delete(key)
+  }
+
+  releaseAll() {
+    this.held.clear()
+  }
+
+  refreshPalette() {
+    this.renderer.refreshPalette()
+    this.dirty = true
+  }
+
+  dispose() {
+    cancelAnimationFrame(this.frame)
+    this.resize.disconnect()
+    this.audio?.dispose()
+    this.held.clear()
+  }
+
+  private get driving() {
+    return this.phase === 'racing' || this.phase === 'countdown'
+  }
+
+  private changed() {
+    this.dirty = true
+    this.publish()
+  }
+
+  private publish() {
+    this.listener(this.view)
+  }
+
+  private wakeAudio() {
+    try {
+      this.audio ??= new RallyAudio(() => {
+        this.audioAvailable = false
+        this.publish()
+      })
+      this.audio.setMuted(this.muted)
+      this.audio.setActive(true)
+    } catch {
+      this.audioAvailable = false
+      this.publish()
+    }
+  }
+
+  private finish() {
+    this.phase = 'finished'
+    this.audio?.finish()
+    this.held.clear()
+    const old = readBest()
+    if (old === null || this.car.elapsed < old) {
+      try {
+        localStorage.setItem(BEST_KEY, String(this.car.elapsed))
+      } catch {
+        /* Still playable without storage. */
+      }
+      this.best = this.car.elapsed
+      this.record = true
+    }
+    this.publish()
+  }
+
+  private animate = (now: number) => {
+    const dt = this.previous ? Math.min((now - this.previous) / 1000, 0.08) : 0
+    this.previous = now
+    const active = this.driving
+    if (this.phase === 'countdown') {
+      const beat = Math.ceil(this.countdown)
+      this.countdown -= dt
+      if (this.countdown <= 0) {
+        this.phase = 'racing'
+        this.audio?.countdown(0)
+      } else if (Math.ceil(this.countdown) !== beat)
+        this.audio?.countdown(Math.ceil(this.countdown))
+    }
+    const keys = this.held
+    const input = {
+      throttle: keys.has('w') || keys.has('arrowup'),
+      brake: keys.has('s') || keys.has('arrowdown'),
+      steer:
+        Number(keys.has('d') || keys.has('arrowright')) -
+        Number(keys.has('a') || keys.has('arrowleft')),
+      drift: keys.has(' '),
+    }
+    if (this.phase === 'racing') {
+      this.accumulator += dt
+      while (this.accumulator >= FIXED_STEP) {
+        stepCar(this.car, input, FIXED_STEP)
+        this.accumulator -= FIXED_STEP
+      }
+      if (this.car.finished) this.finish()
+    }
+    if (this.driving) this.audio?.update(this.car, input, dt)
+    if (active || this.dirty) {
+      try {
+        this.renderer.draw(
+          this.car,
+          active ? dt : 0,
+          active,
+          input.drift,
+          this.reducedMotion.matches,
+        )
+      } catch (error) {
+        this.held.clear()
+        this.audio?.setActive(false)
+        this.onError(error)
+        return
+      }
+      this.dirty = false
+    }
+    if (active && now - this.lastPublish > 80) {
+      this.publish()
+      this.lastPublish = now
+    }
+    this.frame = requestAnimationFrame(this.animate)
+  }
+}

--- a/src/lib/rally-palette.test.ts
+++ b/src/lib/rally-palette.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import { createRallyPalette, FIELD_COLORS, luminance } from './rally-palette.ts'
+import type { RallyColors, RGB } from './rally-palette.ts'
+import { SITE_THEMES } from './site-themes.ts'
+
+const styles = readFileSync(new URL('../styles.css', import.meta.url), 'utf8')
+const blocks = new Map(
+  [...styles.matchAll(/\[data-theme='([^']+)'\]\s*\{([^}]+)\}/g)].map(
+    (match) => [match[1], match[2]],
+  ),
+)
+const rgb = (value: string): RGB => {
+  if (value.startsWith('#'))
+    return [1, 3, 5].map((at) =>
+      parseInt(value.slice(at, at + 2), 16),
+    ) as unknown as RGB
+  return value
+    .match(/[\d.]+/g)!
+    .slice(0, 3)
+    .map(Number) as unknown as RGB
+}
+
+// Iterates the registry, so a new theme is covered without touching this file.
+test('all shipped themes keep shadows dark and highlights light', () => {
+  for (const { id: name, light: isLight } of SITE_THEMES) {
+    const body = blocks.get(name)
+    assert.ok(body, `${name}: no [data-theme] block in styles.css`)
+    const token = (key: string) => {
+      const value = body.match(
+        new RegExp(`--t-${key}:\\s*(#[a-fA-F0-9]{6});`),
+      )?.[1]
+      assert.ok(value, `${name}: missing ${key}`)
+      return rgb(value)
+    }
+    const colors: RallyColors = {
+      ...(Object.fromEntries(
+        FIELD_COLORS.map((key) => [key, token(`field-${key}`)]),
+      ) as Record<(typeof FIELD_COLORS)[number], RGB>),
+      brand: token('brand'),
+      brandInk: token('brand-ink'),
+      paper: token('bg'),
+      ink: token('text'),
+    }
+    const palette = createRallyPalette(colors)
+    const light = (key: Exclude<keyof typeof palette, 'daylight'>) =>
+      luminance(rgb(palette[key]))
+    assert.equal(palette.daylight, Boolean(isLight), name)
+    assert.ok(
+      light('dark') < light('ground'),
+      `${name}: shadows must darken the ground`,
+    )
+    assert.ok(
+      light('dark') < light('road'),
+      `${name}: tyre marks must darken the road`,
+    )
+    assert.ok(
+      light('treeTop') > light('treeBase'),
+      `${name}: treetops must catch the light`,
+    )
+    assert.ok(
+      light('roadInner') > light('road'),
+      `${name}: worn gravel must be lighter`,
+    )
+    assert.ok(
+      light('road') > light('ground'),
+      `${name}: distinguish road from forest`,
+    )
+    assert.ok(
+      (light('text') + 0.05) / (light('dark') + 0.05) > 4.5,
+      `${name}: car markings must stay legible`,
+    )
+    assert.deepEqual(
+      rgb(palette.accent),
+      colors.brand,
+      `${name}: preserve the theme accent`,
+    )
+  }
+})

--- a/src/lib/rally-palette.ts
+++ b/src/lib/rally-palette.ts
@@ -1,0 +1,68 @@
+export type RGB = readonly [number, number, number]
+export const FIELD_COLORS = [
+  'bg',
+  'dim',
+  'mid',
+  'lit',
+  'hover',
+  'crest',
+] as const
+export type RallyColors = Record<
+  (typeof FIELD_COLORS)[number] | 'brand' | 'brandInk' | 'paper' | 'ink',
+  RGB
+>
+
+export function luminance(color: RGB) {
+  const linear = color.map((value) => {
+    const channel = value / 255
+    return channel <= 0.04045
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4
+  })
+  return linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722
+}
+
+const mix = (base: RGB, over: RGB, amount: number): RGB => [
+  Math.round(base[0] + (over[0] - base[0]) * amount),
+  Math.round(base[1] + (over[1] - base[1]) * amount),
+  Math.round(base[2] + (over[2] - base[2]) * amount),
+]
+const cssColor = (color: RGB, alpha = 1) => `rgb(${color.join(' ')} / ${alpha})`
+
+/** Theme contrast can reverse; illumination in the game world must not. */
+export function createRallyPalette(t: RallyColors) {
+  const { bg, dim, mid, lit, crest, paper, ink } = t
+  const daylight = luminance(bg) > luminance(crest)
+  const dark = daylight ? mix(crest, ink, 0.3) : bg
+  const colors = {
+    dark,
+    ground: daylight ? mix(mid, paper, 0.45) : mix(bg, dim, 0.6),
+    groundDetail: daylight ? mix(mid, paper, 0.38) : mix(bg, dim, 0.83),
+    road: daylight ? mix(ink, paper, 0.84) : mix(dim, crest, 0.62),
+    roadInner: daylight ? mix(ink, paper, 0.88) : mix(dim, crest, 0.68),
+    verge: daylight ? mix(mid, paper, 0.25) : mid,
+    text: daylight ? paper : crest,
+    accent: t.brand,
+    accentInk: t.brandInk,
+    gravel: daylight ? mix(ink, paper, 0.52) : mix(dim, crest, 0.35),
+    dust: daylight ? paper : mix(mid, crest, 0.6),
+    rock: daylight ? mix(mid, paper, 0.22) : mid,
+    treeBase: daylight ? mix(dark, mid, 0.3) : mix(bg, dim, 0.5),
+    treeMid: daylight ? mix(dark, mid, 0.65) : dim,
+    treeMidAlt: daylight ? mix(dark, mid, 0.8) : mix(dim, mid, 0.2),
+    treeTop: daylight ? mid : mix(dim, mid, 0.5),
+    treeTopAlt: daylight ? mix(mid, dim, 0.35) : mix(dim, mid, 0.7),
+    carSide: daylight ? mix(mid, paper, 0.68) : mix(mid, crest, 0.7),
+    glass: daylight ? dark : mix(bg, mid, 0.25),
+    glassShine: daylight ? mix(dark, mid, 0.6) : mid,
+    livery: lit,
+    headlight: daylight ? paper : t.hover,
+  }
+  return {
+    ...(Object.fromEntries(
+      Object.entries(colors).map(([key, value]) => [key, cssColor(value)]),
+    ) as Record<keyof typeof colors, string>),
+    shadow: cssColor(dark, daylight ? 0.28 : 0.65),
+    daylight,
+  }
+}

--- a/src/lib/rally-renderer.ts
+++ b/src/lib/rally-renderer.ts
@@ -1,0 +1,389 @@
+import { ROAD_WIDTH, STAGE, clamp, nearestRoad } from './rally-stage.ts'
+import type { Car, Point } from './rally-stage.ts'
+import { createRallyPalette } from './rally-palette.ts'
+import type { RGB } from './rally-palette.ts'
+
+type Decoration = Point & { size: number; kind: number; shade: number }
+type Dust = Point & { vx: number; vy: number; age: number; size: number }
+type Mark = { a: Point; b: Point; alpha: number }
+/** Resolve CSS colours in the browser; world lighting is mapped independently. */
+function readPalette() {
+  const css = getComputedStyle(document.documentElement)
+  const mixer = document
+    .createElement('canvas')
+    .getContext('2d', { willReadFrequently: true })!
+  const read = (name: string) => css.getPropertyValue(`--t-${name}`).trim()
+  // A theme missing a field token still gets a drivable, on-brand course.
+  const token = (name: string, fallback = name): RGB => {
+    mixer.clearRect(0, 0, 1, 1)
+    mixer.fillStyle = read(name) || read(fallback)
+    mixer.fillRect(0, 0, 1, 1)
+    const [r, g, b] = mixer.getImageData(0, 0, 1, 1).data
+    return [r, g, b]
+  }
+  return createRallyPalette({
+    bg: token('field-bg', 'bg'),
+    dim: token('field-dim', 'brand'),
+    mid: token('field-mid', 'brand'),
+    lit: token('field-lit', 'brand'),
+    hover: token('field-hover', 'brand'),
+    crest: token('field-crest', 'text'),
+    brand: token('brand', 'text'),
+    brandInk: token('brand-ink', 'bg'),
+    paper: token('bg'),
+    ink: token('text'),
+  })
+}
+
+export class RallyRenderer {
+  private palette = readPalette()
+  private ctx: CanvasRenderingContext2D
+  private road = new Path2D()
+  private decorations: Decoration[] = []
+  private gravel: Point[] = []
+  private dust: Dust[] = []
+  private marks: Mark[] = []
+  private camera = { x: STAGE[0].x - 180, y: STAGE[0].y - 150 }
+  private width = 1000
+  private height = 600
+  private ratio = 1
+  private lastTyres: Point[] | null = null
+  private zoom = 0.9
+  private particleTime = 0
+  private random: () => number
+
+  constructor(private canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext('2d', { alpha: false })
+    if (!ctx) throw new Error('Canvas is unavailable')
+    this.ctx = ctx
+    let seed = 404
+    this.random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      return seed / 4294967296
+    }
+    STAGE.forEach((p, i) =>
+      i ? this.road.lineTo(p.x, p.y) : this.road.moveTo(p.x, p.y),
+    )
+    for (let i = 0; i < 2300; i++) {
+      const p = {
+        x: this.random() * 2850 - 600,
+        y: this.random() * 5000 - 4300,
+      }
+      const distance = nearestRoad(p).distance
+      if (distance < ROAD_WIDTH / 2 + 33) continue
+      this.decorations.push({
+        ...p,
+        size: 12 + this.random() * 30,
+        kind: this.random(),
+        shade: this.random(),
+      })
+    }
+    this.decorations.sort((a, b) => a.y - b.y)
+    for (const p of STAGE) {
+      for (let i = 0; i < 9; i++) {
+        const side = (this.random() - 0.5) * (ROAD_WIDTH - 12)
+        this.gravel.push({
+          x: p.x + Math.cos(p.angle + Math.PI / 2) * side + this.random() * 8,
+          y: p.y + Math.sin(p.angle + Math.PI / 2) * side + this.random() * 8,
+        })
+      }
+    }
+  }
+
+  resize(width: number, height: number) {
+    this.width = width
+    this.height = height
+    this.ratio = Math.min(window.devicePixelRatio || 1, 2)
+    this.canvas.width = Math.round(width * this.ratio)
+    this.canvas.height = Math.round(height * this.ratio)
+  }
+
+  refreshPalette() {
+    this.palette = readPalette()
+  }
+
+  reset() {
+    this.dust = []
+    this.marks = []
+    this.lastTyres = null
+    this.camera = { x: STAGE[0].x - 180, y: STAGE[0].y - 150 }
+  }
+
+  draw(
+    car: Car,
+    dt: number,
+    active: boolean,
+    drifting: boolean,
+    reducedMotion: boolean,
+  ) {
+    const ctx = this.ctx,
+      w = this.width,
+      h = this.height
+    const speed = Math.hypot(car.vx, car.vy)
+    const follow = active ? 1 - Math.exp(-dt * 5) : 0
+    this.camera.x += (car.x + car.vx * 0.65 - this.camera.x) * follow
+    this.camera.y += (car.y + car.vy * 0.65 - this.camera.y) * follow
+    const desiredZoom = Math.min(w / 800, h / 530, 1.3) * (1 - speed / 1500)
+    this.zoom +=
+      (desiredZoom - this.zoom) * (active ? 1 - Math.exp(-dt * 3) : 1)
+    const z = this.zoom
+    ctx.setTransform(this.ratio, 0, 0, this.ratio, 0, 0)
+    ctx.fillStyle = this.palette.ground
+    ctx.fillRect(0, 0, w, h)
+    ctx.translate(w / 2, h / 2)
+    ctx.scale(z, z)
+    ctx.translate(-this.camera.x, -this.camera.y)
+    const visible = (p: Point, margin = 80) =>
+      Math.abs(p.x - this.camera.x) < w / z / 2 + margin &&
+      Math.abs(p.y - this.camera.y) < h / z / 2 + margin
+
+    // Sparse ground texture, with a contrasting edge beneath the gravel.
+    ctx.fillStyle = this.palette.groundDetail
+    for (const d of this.decorations) {
+      if (!visible(d)) continue
+      ctx.beginPath()
+      ctx.ellipse(d.x, d.y, d.size * 1.9, d.size * 1.2, 0.4, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    for (const [width, color] of [
+      [ROAD_WIDTH + 22, this.palette.dark],
+      [ROAD_WIDTH + 12, this.palette.verge],
+      [ROAD_WIDTH, this.palette.road],
+      [ROAD_WIDTH - 24, this.palette.roadInner],
+    ] as const) {
+      ctx.strokeStyle = color
+      ctx.lineWidth = width
+      ctx.stroke(this.road)
+    }
+    ctx.fillStyle = this.palette.gravel
+    for (const p of this.gravel)
+      if (visible(p, 0)) ctx.fillRect(p.x, p.y, 1.5, 2)
+
+    // Course stakes alternate with accent flags on the outside of bends.
+    STAGE.forEach((p, i) => {
+      if (i % 8 !== 0 || !visible(p)) return
+      for (const side of [-1, 1]) {
+        const x =
+          p.x + Math.cos(p.angle + Math.PI / 2) * side * (ROAD_WIDTH / 2 + 9)
+        const y =
+          p.y + Math.sin(p.angle + Math.PI / 2) * side * (ROAD_WIDTH / 2 + 9)
+        ctx.fillStyle = this.palette.dark
+        ctx.fillRect(x + 2, y + 2, 4, 8)
+        ctx.fillStyle = i % 24 === 0 ? this.palette.accent : this.palette.text
+        ctx.fillRect(x, y - 4, 3, 8)
+      }
+    })
+    this.gate(STAGE[2], 'START', false)
+    this.gate(STAGE.at(-3)!, 'FINISH', true)
+
+    if (active && dt > 0) {
+      const tyres = [-1, 1].map((side) => ({
+        x:
+          car.x -
+          Math.cos(car.angle) * 11 +
+          Math.cos(car.angle + Math.PI / 2) * side * 8,
+        y:
+          car.y -
+          Math.sin(car.angle) * 11 +
+          Math.sin(car.angle + Math.PI / 2) * side * 8,
+      }))
+      if (
+        this.lastTyres &&
+        speed > 45 &&
+        (drifting || Math.abs(car.yaw) > 0.75)
+      ) {
+        for (let i = 0; i < 2; i++) {
+          if (
+            Math.hypot(
+              tyres[i].x - this.lastTyres[i].x,
+              tyres[i].y - this.lastTyres[i].y,
+            ) < 35
+          )
+            this.marks.push({
+              a: this.lastTyres[i],
+              b: tyres[i],
+              alpha: drifting ? 0.3 : 0.13,
+            })
+        }
+      }
+      this.lastTyres = tyres
+      if (this.marks.length > 1800)
+        this.marks.splice(0, this.marks.length - 1800)
+      this.particleTime += dt
+      if (!reducedMotion && speed > 30 && this.particleTime > 0.035) {
+        this.particleTime = 0
+        for (const p of tyres)
+          this.dust.push({
+            ...p,
+            vx: -car.vx * 0.13 + (this.random() - 0.5) * 25,
+            vy: -car.vy * 0.13 + (this.random() - 0.5) * 25,
+            age: 0,
+            size: (car.offroad ? 6 : 3) + this.random() * 4,
+          })
+      }
+    }
+    ctx.strokeStyle = this.palette.dark
+    ctx.lineWidth = 3
+    for (const mark of this.marks) {
+      if (!visible(mark.a)) continue
+      ctx.globalAlpha = mark.alpha
+      ctx.beginPath()
+      ctx.moveTo(mark.a.x, mark.a.y)
+      ctx.lineTo(mark.b.x, mark.b.y)
+      ctx.stroke()
+    }
+    ctx.globalAlpha = 1
+    this.paintCar(car)
+    for (const puff of this.dust) {
+      puff.age += dt
+      puff.x += puff.vx * dt
+      puff.y += puff.vy * dt
+      ctx.globalAlpha = Math.max(0, 0.24 * (1 - puff.age / 1.1))
+      ctx.fillStyle = this.palette.dust
+      ctx.beginPath()
+      ctx.arc(puff.x, puff.y, puff.size + puff.age * 12, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    this.dust = this.dust.filter((p) => p.age < 1.1)
+    ctx.globalAlpha = 1
+
+    for (const d of this.decorations) {
+      if (!visible(d)) continue
+      ctx.save()
+      ctx.translate(d.x, d.y)
+      if (d.kind < 0.13) {
+        ctx.fillStyle = this.palette.shadow
+        ctx.fillRect(-d.size / 3 + 5, 0, d.size, d.size * 0.7)
+        ctx.fillStyle = this.palette.rock
+        ctx.beginPath()
+        ctx.moveTo(-d.size / 2, 0)
+        ctx.lineTo(-d.size / 3, -d.size / 2)
+        ctx.lineTo(d.size / 3, -d.size / 3)
+        ctx.lineTo(d.size / 2, d.size / 4)
+        ctx.lineTo(0, d.size / 2)
+        ctx.closePath()
+        ctx.fill()
+      } else {
+        ctx.fillStyle = this.palette.shadow
+        ctx.beginPath()
+        ctx.ellipse(12, 14, d.size, d.size * 0.8, 0.6, 0, Math.PI * 2)
+        ctx.fill()
+        for (let layer = 0; layer < 3; layer++) {
+          const radius = d.size * (1 - layer * 0.23)
+          ctx.fillStyle = [
+            this.palette.treeBase,
+            d.shade > 0.5 ? this.palette.treeMidAlt : this.palette.treeMid,
+            d.shade > 0.5 ? this.palette.treeTopAlt : this.palette.treeTop,
+          ][layer]
+          ctx.beginPath()
+          for (let i = 0; i < 16; i++) {
+            const angle = (i * Math.PI) / 8 + d.shade * 2
+            const r = radius * (i % 2 ? 0.72 : 1)
+            const x = Math.cos(angle) * r - layer * 2,
+              y = Math.sin(angle) * r - layer * 3
+            if (i === 0) ctx.moveTo(x, y)
+            else ctx.lineTo(x, y)
+          }
+          ctx.closePath()
+          ctx.fill()
+        }
+      }
+      ctx.restore()
+    }
+    ctx.setTransform(this.ratio, 0, 0, this.ratio, 0, 0)
+    // Gentle fixed vignette, independent of motion preferences.
+    const vignette = ctx.createRadialGradient(
+      w / 2,
+      h / 2,
+      h * 0.2,
+      w / 2,
+      h / 2,
+      Math.max(w, h) * 0.65,
+    )
+    vignette.addColorStop(0, 'transparent')
+    vignette.addColorStop(1, this.palette.dark)
+    ctx.fillStyle = vignette
+    ctx.globalAlpha = this.palette.daylight ? 0.1 : 0.4
+    ctx.fillRect(0, 0, w, h)
+    ctx.globalAlpha = 1
+  }
+
+  private gate(point: (typeof STAGE)[number], label: string, finish: boolean) {
+    const ctx = this.ctx
+    ctx.save()
+    ctx.translate(point.x, point.y)
+    ctx.rotate(point.angle + Math.PI / 2)
+    for (let i = 0; i < 12; i++)
+      for (let j = 0; j < 2; j++) {
+        ctx.fillStyle = (i + j) % 2 ? this.palette.dark : this.palette.text
+        ctx.fillRect(
+          -ROAD_WIDTH / 2 + (i * ROAD_WIDTH) / 12,
+          j * 7,
+          ROAD_WIDTH / 12,
+          7,
+        )
+      }
+    for (const side of [-1, 1]) {
+      ctx.fillStyle = finish ? this.palette.accent : this.palette.text
+      ctx.fillRect(side * (ROAD_WIDTH / 2 + 16) - 11, -22, 22, 36)
+      ctx.fillStyle = finish ? this.palette.accentInk : this.palette.dark
+      ctx.font = 'bold 9px monospace'
+      ctx.textAlign = 'center'
+      ctx.save()
+      ctx.translate(side * (ROAD_WIDTH / 2 + 16), -4)
+      ctx.rotate(-Math.PI / 2)
+      ctx.fillText(label, 0, 3)
+      ctx.restore()
+    }
+    ctx.restore()
+  }
+
+  private paintCar(car: Car) {
+    const ctx = this.ctx
+    ctx.save()
+    ctx.translate(car.x, car.y)
+    ctx.rotate(car.angle + Math.PI / 2)
+    ctx.fillStyle = this.palette.shadow
+    ctx.fillRect(-9, -16, 24, 40)
+    ctx.fillStyle = this.palette.dark
+    ctx.fillRect(-11, -21, 22, 42)
+    for (const side of [-1, 1]) {
+      ctx.save()
+      ctx.translate(side * 10, -9)
+      ctx.rotate(clamp(car.yaw * 0.2, -0.4, 0.4))
+      ctx.fillRect(-3, -5, 6, 10)
+      ctx.restore()
+      ctx.fillRect(side * 10 - 3, 9, 6, 10)
+    }
+    ctx.fillStyle = this.palette.text
+    ctx.fillRect(-10, -20, 20, 40)
+    ctx.fillRect(-8, -23, 16, 4)
+    ctx.fillStyle = this.palette.carSide
+    ctx.fillRect(-11, -7, 3, 20)
+    ctx.fillStyle = this.palette.glass
+    ctx.fillRect(-7, -8, 14, 8)
+    ctx.fillRect(-7, 10, 14, 6)
+    ctx.fillStyle = this.palette.glassShine
+    ctx.fillRect(-6, -7, 11, 2)
+    ctx.fillStyle = this.palette.accent
+    ctx.fillRect(3, -22, 4, 14)
+    ctx.fillRect(3, 16, 4, 5)
+    ctx.fillStyle = this.palette.livery
+    ctx.fillRect(-7, -22, 8, 10)
+    ctx.fillStyle = this.palette.dark
+    ctx.font = 'bold 8px monospace'
+    ctx.textAlign = 'center'
+    ctx.fillText('04', 0, 8)
+    ctx.fillStyle = this.palette.dark
+    ctx.fillRect(-13, 17, 26, 4)
+    ctx.fillStyle = this.palette.headlight
+    ctx.fillRect(-9, -23, 5, 3)
+    ctx.fillRect(4, -23, 5, 3)
+    ctx.fillStyle = this.palette.accent
+    ctx.fillRect(-9, 21, 5, 2)
+    ctx.fillRect(4, 21, 5, 2)
+    ctx.restore()
+  }
+}

--- a/src/lib/rally-stage.test.ts
+++ b/src/lib/rally-stage.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { advanceKonami } from './konami.ts'
+import {
+  FIXED_STEP,
+  ROAD_WIDTH,
+  STAGE,
+  STAGE_LENGTH,
+  angleDifference,
+  formatTime,
+  recoverCar,
+  startingCar,
+  stepCar,
+} from './rally-stage.ts'
+import type { Controls } from './rally-stage.ts'
+
+const coast: Controls = {
+  throttle: false,
+  brake: false,
+  steer: 0,
+  drift: false,
+}
+function drive(seconds: number, input: Controls, car = startingCar()) {
+  for (let i = 0; i < Math.round(seconds / FIXED_STEP); i++)
+    stepCar(car, input, FIXED_STEP)
+  return car
+}
+
+test('both secret codes accept uppercase and overlapping prefixes', () => {
+  for (const sequence of [
+    [
+      'ArrowUp',
+      'ArrowUp',
+      'ArrowUp',
+      'ArrowDown',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowLeft',
+      'ArrowRight',
+      'B',
+      'A',
+    ],
+    [...'xkkkjjhlhlBA'],
+  ]) {
+    let keys: string[] = [],
+      hit = false
+    for (const key of sequence) {
+      const result = advanceKonami(keys, key)
+      keys = result.keys
+      hit = result.hit
+    }
+    assert.equal(hit, true)
+    assert.deepEqual(keys, [])
+  }
+  let keys: string[] = []
+  for (const key of 'kkjjhXlhlba') {
+    const result = advanceKonami(keys, key)
+    assert.equal(result.hit, false)
+    keys = result.keys
+  }
+})
+
+test('course is continuous, ordered and long enough for a timed stage', () => {
+  assert.ok(STAGE_LENGTH > 6000)
+  for (let i = 1; i < STAGE.length; i++) {
+    assert.ok(STAGE[i].distance > STAGE[i - 1].distance)
+    assert.ok(
+      Math.hypot(STAGE[i].x - STAGE[i - 1].x, STAGE[i].y - STAGE[i - 1].y) <
+        ROAD_WIDTH / 4,
+    )
+  }
+})
+
+test('accelerates, coasts, brakes and reverses without steering at rest', () => {
+  const car = drive(1, { ...coast, throttle: true })
+  assert.ok(car.y < STAGE[0].y - 50)
+  assert.ok(Math.abs(car.x - STAGE[0].x) < 1)
+  const speed = Math.hypot(car.vx, car.vy)
+  drive(0.5, coast, car)
+  assert.ok(Math.hypot(car.vx, car.vy) < speed)
+  drive(2, { ...coast, brake: true }, car)
+  assert.ok(car.vy > 0)
+  assert.ok(Math.hypot(car.vx, car.vy) <= 55)
+  const stationary = drive(2, { ...coast, steer: 1 })
+  assert.equal(stationary.angle, STAGE[0].angle)
+})
+
+test('handbrake permits more sideways slip than normal cornering', () => {
+  const car = drive(1.4, { ...coast, throttle: true })
+  const grip = { ...car },
+    drift = { ...car }
+  drive(0.5, { ...coast, throttle: true, steer: 1 }, grip)
+  drive(0.5, { ...coast, throttle: true, steer: 1, drift: true }, drift)
+  const slip = (c: typeof car) =>
+    Math.abs(-c.vx * Math.sin(c.angle) + c.vy * Math.cos(c.angle))
+  assert.ok(slip(drift) > slip(grip) * 1.3)
+  assert.ok(drift.angle > grip.angle)
+})
+
+test('leaving the course reduces speed and recovery adds exactly three seconds', () => {
+  const car = startingCar()
+  car.x += ROAD_WIDTH * 3
+  car.vy = -250
+  car.progress = 12
+  car.elapsed = 10
+  stepCar(car, { ...coast, throttle: true }, FIXED_STEP)
+  assert.equal(car.offroad, true)
+  assert.ok(Math.hypot(car.vx, car.vy) <= 111)
+  const before = car.elapsed,
+    progress = car.progress
+  recoverCar(car)
+  assert.equal(car.elapsed, before + 3)
+  assert.equal(car.progress, progress)
+  assert.equal(car.x, STAGE[progress].x)
+  assert.equal(car.y, STAGE[progress].y)
+  assert.equal(car.vx, 0)
+  assert.equal(car.vy, 0)
+})
+
+test('finish requires ordered progress and the final clock is immutable', () => {
+  const car = startingCar(),
+    finish = STAGE.at(-2)!
+  car.x = finish.x
+  car.y = finish.y
+  stepCar(car, coast, FIXED_STEP)
+  assert.equal(car.finished, false)
+  car.progress = STAGE.length - 5
+  stepCar(car, coast, FIXED_STEP)
+  assert.equal(car.finished, true)
+  const final = { ...car }
+  stepCar(car, { ...coast, throttle: true }, FIXED_STEP)
+  recoverCar(car)
+  assert.deepEqual(car, final)
+})
+
+test('a steering controller can complete the entire course without recovery', () => {
+  const car = startingCar()
+  for (let i = 0; i < 120 * 180 && !car.finished; i++) {
+    const speed = Math.hypot(car.vx, car.vy)
+    const target =
+      STAGE[
+        Math.min(STAGE.length - 1, car.progress + Math.round(5 + speed / 22))
+      ]
+    const difference = angleDifference(
+      Math.atan2(target.y - car.y, target.x - car.x),
+      car.angle,
+    )
+    stepCar(
+      car,
+      {
+        throttle: Math.abs(difference) < 0.65 || speed < 85,
+        brake: Math.abs(difference) > 0.65 && speed > 110,
+        steer: Math.max(-1, Math.min(1, difference * 2)),
+        drift: false,
+      },
+      FIXED_STEP,
+    )
+  }
+  assert.equal(
+    car.finished,
+    true,
+    `stopped at ${((car.progress / STAGE.length) * 100).toFixed(0)}% after ${formatTime(car.elapsed)}`,
+  )
+  assert.ok(car.elapsed > 20)
+})
+
+test('clock formatting truncates consistently across minute boundaries', () => {
+  assert.equal(formatTime(0), '0:00.00')
+  assert.equal(formatTime(59.999), '0:59.99')
+  assert.equal(formatTime(60), '1:00.00')
+  assert.equal(formatTime(83.456), '1:23.45')
+})

--- a/src/lib/rally-stage.ts
+++ b/src/lib/rally-stage.ts
@@ -1,0 +1,197 @@
+export type Point = { x: number; y: number }
+export type RoadPoint = Point & { distance: number; angle: number }
+export type Controls = {
+  throttle: boolean
+  brake: boolean
+  steer: number
+  drift: boolean
+}
+export type Car = Point & {
+  vx: number
+  vy: number
+  angle: number
+  yaw: number
+  progress: number
+  elapsed: number
+  offroad: boolean
+  finished: boolean
+}
+
+export const ROAD_WIDTH = 138
+export const FIXED_STEP = 1 / 120
+export const BEST_KEY = 'omarchy-rally-best'
+const anchors = [
+  [0, 180],
+  [0, -220],
+  [100, -560],
+  [440, -780],
+  [810, -690],
+  [1020, -940],
+  [870, -1230],
+  [500, -1290],
+  [240, -1570],
+  [430, -1870],
+  [850, -1850],
+  [1250, -1650],
+  [1570, -1820],
+  [1620, -2180],
+  [1390, -2440],
+  [970, -2470],
+  [740, -2780],
+  [960, -3090],
+  [1360, -3170],
+  [1610, -3440],
+  [1590, -3800],
+]
+
+export function buildStage(): RoadPoint[] {
+  const points: RoadPoint[] = []
+  for (let i = 0; i < anchors.length - 1; i++) {
+    const a = anchors[Math.max(0, i - 1)]
+    const b = anchors[i],
+      c = anchors[i + 1],
+      d = anchors[Math.min(anchors.length - 1, i + 2)]
+    const steps = Math.ceil(Math.hypot(c[0] - b[0], c[1] - b[1]) / 12)
+    for (let j = 0; j < steps; j++) {
+      const t = j / steps
+      const coordinate = (axis: number) =>
+        0.5 *
+        (2 * b[axis] +
+          (-a[axis] + c[axis]) * t +
+          (2 * a[axis] - 5 * b[axis] + 4 * c[axis] - d[axis]) * t * t +
+          (-a[axis] + 3 * b[axis] - 3 * c[axis] + d[axis]) * t * t * t)
+      const x = coordinate(0),
+        y = coordinate(1),
+        previous = points.at(-1)
+      points.push({
+        x,
+        y,
+        distance: previous
+          ? previous.distance + Math.hypot(x - previous.x, y - previous.y)
+          : 0,
+        angle: 0,
+      })
+    }
+  }
+  const last = anchors.at(-1)!,
+    previous = points.at(-1)!
+  points.push({
+    x: last[0],
+    y: last[1],
+    distance:
+      previous.distance +
+      Math.hypot(last[0] - previous.x, last[1] - previous.y),
+    angle: 0,
+  })
+  for (let i = 0; i < points.length; i++) {
+    const a = points[Math.max(0, i - 1)],
+      b = points[Math.min(points.length - 1, i + 1)]
+    points[i].angle = Math.atan2(b.y - a.y, b.x - a.x)
+  }
+  return points
+}
+
+export const STAGE = buildStage()
+export const STAGE_LENGTH = STAGE.at(-1)!.distance
+export const stageKm = (STAGE_LENGTH / 3000).toFixed(1)
+export const clamp = (n: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, n))
+export const angleDifference = (a: number, b: number) =>
+  Math.atan2(Math.sin(a - b), Math.cos(a - b))
+
+export function startingCar(): Car {
+  return {
+    x: STAGE[0].x,
+    y: STAGE[0].y,
+    vx: 0,
+    vy: 0,
+    angle: STAGE[0].angle,
+    yaw: 0,
+    progress: 0,
+    elapsed: 0,
+    offroad: false,
+    finished: false,
+  }
+}
+
+/** Search locally, so a neighbouring stretch cannot skip part of the stage. */
+export function nearestRoad(point: Point, start = 0, end = STAGE.length - 1) {
+  let index = start,
+    distance = Infinity
+  for (let i = start; i <= end; i++) {
+    const d = Math.hypot(point.x - STAGE[i].x, point.y - STAGE[i].y)
+    if (d < distance) {
+      distance = d
+      index = i
+    }
+  }
+  return { index, distance }
+}
+
+/** Mutates only this run's car; call at FIXED_STEP for frame-independent handling. */
+export function stepCar(car: Car, input: Controls, dt: number) {
+  if (car.finished) return
+  car.elapsed += dt
+  const road = nearestRoad(
+    car,
+    Math.max(0, car.progress - 22),
+    Math.min(STAGE.length - 1, car.progress + 30),
+  )
+  car.offroad = road.distance > ROAD_WIDTH / 2 - 8
+  if (road.distance < ROAD_WIDTH * 0.8)
+    car.progress = Math.max(car.progress, road.index)
+  const forward = car.vx * Math.cos(car.angle) + car.vy * Math.sin(car.angle)
+  const steer = clamp(input.steer, -1, 1)
+  const targetYaw =
+    steer * clamp(forward / 85, -0.65, 1) * (input.drift ? 2.35 : 1.65)
+  car.yaw += (targetYaw - car.yaw) * Math.min(1, dt * 7)
+  car.angle += car.yaw * dt
+  let speed = car.vx * Math.cos(car.angle) + car.vy * Math.sin(car.angle)
+  const lateral = -car.vx * Math.sin(car.angle) + car.vy * Math.cos(car.angle)
+  if (input.throttle) speed += 150 * dt
+  if (input.brake) speed -= (speed > 0 ? 230 : 70) * dt
+  speed *= Math.exp(-(car.offroad ? 1.9 : input.drift ? 0.9 : 0.45) * dt)
+  speed = clamp(speed, -55, car.offroad ? 110 : 290)
+  // The rear steps out under handbraking, then grips progressively on release.
+  const slip =
+    lateral * Math.exp(-(input.drift ? 1.35 : car.offroad ? 3.5 : 7.5) * dt)
+  car.vx = Math.cos(car.angle) * speed - Math.sin(car.angle) * slip
+  car.vy = Math.sin(car.angle) * speed + Math.cos(car.angle) * slip
+  car.x += car.vx * dt
+  car.y += car.vy * dt
+  if (car.progress >= STAGE.length - 3 && road.distance < ROAD_WIDTH / 2)
+    car.finished = true
+}
+
+export function recoverCar(car: Car) {
+  if (car.finished) return
+  const road = STAGE[car.progress]
+  Object.assign(car, {
+    x: road.x,
+    y: road.y,
+    angle: road.angle,
+    vx: 0,
+    vy: 0,
+    yaw: 0,
+    offroad: false,
+    elapsed: car.elapsed + 3,
+  })
+}
+
+export function formatTime(seconds: number) {
+  const centiseconds = Math.floor(Math.max(0, seconds) * 100)
+  return `${Math.floor(centiseconds / 6000)}:${String(Math.floor(centiseconds / 100) % 60).padStart(2, '0')}.${String(centiseconds % 100).padStart(2, '0')}`
+}
+
+export function paceNote(progress: number) {
+  const here = STAGE[Math.min(progress + 8, STAGE.length - 1)]
+  const ahead = STAGE[Math.min(progress + 27, STAGE.length - 1)]
+  if (STAGE_LENGTH - STAGE[progress].distance < 330)
+    return { arrow: '↑', text: 'Finish ahead' }
+  const bend = angleDifference(ahead.angle, here.angle)
+  if (Math.abs(bend) < 0.2) return { arrow: '↑', text: 'Flat out' }
+  return {
+    arrow: bend > 0 ? '↱' : '↰',
+    text: `${Math.abs(bend) > 0.85 ? 'Tight' : 'Easy'} ${bend > 0 ? 'right' : 'left'}`,
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -141,6 +141,7 @@
   /* z-index scale: no arbitrary values anywhere else */
   --z-nav: 100;
   --z-dropdown: 200;
+  --z-rally: 250;
   --z-modal: 300;
   --z-tooltip: 400;
 }


### PR DESCRIPTION
Enter the Konami code, or its vim-keys twin, anywhere on the site to unlock
a timed gravel rally drawn on a canvas. The course, car, scenery and engine
audio are all generated in the browser from theme tokens; there are no
downloaded assets. Regular visitors pay for a 1.7 KB keystroke listener that
hydrates on idle. The game itself, including its stylesheet, only loads after
the code is entered.

The rally follows the current theme and repaints when it changes, pauses when
the theme picker or another tab takes over, and is fully keyboard-driven with
Enter and Space acting on whichever card is showing. Interface copy goes
through the site catalogue so the background translation workflow covers all
languages; brand marks and key names stay English. A test iterates the theme
registry so a new theme must ship the tokens the rally reads, and the renderer
falls back to base colours if one is missing.


https://github.com/user-attachments/assets/058a364d-03ae-4fc0-897b-62f7a398506f

