### PR TITLE
Translate the sound control, the menu button and Open GitHub

### DIFF
--- a/src/astro/pages/TeamsPage.tsx
+++ b/src/astro/pages/TeamsPage.tsx
@@ -154,7 +154,7 @@ export function TeamsPage() {
               render={<a href="https://github.com/omacom/omarchy" />}
             >
               <GithubIcon data-icon="inline-start" />
-              Open GitHub
+              {t('Open GitHub')}
             </Button>
           </div>
         </div>

--- a/src/components/MusicControl.tsx
+++ b/src/components/MusicControl.tsx
@@ -94,10 +94,10 @@ export function MusicMenuControl({
           }
         >
           {state === 'failed'
-            ? 'Sound unavailable'
+            ? t('Sound unavailable')
             : on
-              ? 'Sound on'
-              : 'Sound off'}
+              ? t('Sound on')
+              : t('Sound off')}
         </span>
         <span
           aria-hidden={!on}
@@ -206,8 +206,8 @@ export function MusicControl({ path = '/' }: { path?: string }) {
         type="button"
         onClick={() => music.toggle()}
         aria-pressed={on}
-        aria-label={on ? 'Turn the sound off' : 'Turn the sound on'}
-        title={on ? 'Sound off' : 'Sound on'}
+        aria-label={on ? t('Turn the sound off') : t('Turn the sound on')}
+        title={on ? t('Sound off') : t('Sound on')}
         className="relative size-11 shrink-0 self-center border-r border-border-subtle bg-cover bg-center text-white touch-manipulation focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
         style={{ backgroundImage: `url(${TRACK.art})` }}
       >
@@ -234,7 +234,7 @@ export function MusicControl({ path = '/' }: { path?: string }) {
       </button>
       <span className="flex flex-col justify-center pr-4 pl-3 leading-tight">
         <span className="font-sans text-[12px] font-medium text-text">
-          {state === 'failed' ? 'The sound could not start' : title}
+          {state === 'failed' ? t('The sound could not start') : title}
         </span>
         <span className="relative mt-0.5 font-mono text-[12px] text-text-secondary">
           <span className="transition-opacity duration-150 ease-out group-has-[input:hover]/card:opacity-0 group-has-[input:focus-visible]/card:opacity-0 group-has-[input:active]/card:opacity-0">

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -586,7 +586,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
               className="relative size-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 sm:hidden"
               aria-expanded={menuOpen}
               aria-controls="site-menu"
-              aria-label={menuOpen ? 'Close menu' : 'Menu'}
+              aria-label={menuOpen ? t('Close menu') : t('Menu')}
               onClick={() => setMenuOpen((open) => !open)}
             >
               <MenuBarsIcon open={menuOpen} className="size-[22px]" />


### PR DESCRIPTION
Nine strings render in English on all 29 translated sites, because they were never wrapped in `t()`:

| | |
|---|---|
| `MusicControl.tsx` | Sound unavailable, Sound on, Sound off, Turn the sound on/off, The sound could not start |
| `SiteHeader.tsx` | Close menu, Menu |
| `TeamsPage.tsx` | Open GitHub |

These look like oversights rather than choices. `MusicControl` and `SiteHeader` already import `t` and translate everything around these lines, and `Open GitHub` sits in the same button group as `{t("Join the Discord")}`. The menu button is the widest of them, since its `aria-label` is on every page.

I noticed this while adding zh-TW in #252, but it is not a zh-TW problem — every language shows the English.

**Why the checks did not catch it.** `collectSources()` gathers messages by walking the AST for `t()` calls, so a string that was never wrapped is not a source string, and `check-translations` reports every language complete without it. The check measures how much of the catalogue is translated, not how much of the page is. Before this change it counted 327 messages; after, 336.

**Nothing changes for readers yet.** `t()` falls back to the English source (`catalogue[english] ?? english`), so every language renders exactly what it renders today until the translation pipeline fills the new keys in. English output is byte-identical.

Left alone: `Install → Style → Themes` on the themes page. That is a literal menu path in Omarchy, set in mono, and `Install` and `Themes` are unwrapped for the same reason.

`lint`, `typecheck`, `test`, `build` and `parity` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPQgSiXv51pEhwVusPQPNH