### PR TITLE
Wrap open patron clusters instead of pushing into the next column

### DIFF
--- a/src/components/PatronHighlights.tsx
+++ b/src/components/PatronHighlights.tsx
@@ -40,7 +40,7 @@ export function PatronHighlights() {
       <TeamClusters
         groups={groups}
         maxFaces={12}
-        className="sm:grid-cols-1 lg:grid-cols-2 lg:gap-y-2 lg:[&_.team-cluster>p]:h-8"
+        className="team-clusters-wrap sm:grid-cols-1 lg:grid-cols-2 lg:gap-y-2 lg:[&_.team-cluster>p]:h-8"
       />
       <p className="mt-4 font-mono text-xs text-text-muted">
         <a

--- a/src/styles.css
+++ b/src/styles.css
@@ -2262,6 +2262,11 @@ h6 {
 .team-cluster[data-open] .team-faces {
   margin-right: 0;
 }
+.team-clusters-wrap .team-cluster[data-open] .team-faces {
+  flex-wrap: wrap;
+  row-gap: var(--team-gap);
+  transition: none;
+}
 .team-cluster[data-open] .team-face {
   transform: none;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2267,6 +2267,13 @@ h6 {
   row-gap: var(--team-gap);
   transition: none;
 }
+@media (max-width: 1023px) {
+  .team-cluster[data-open] .team-faces {
+    flex-wrap: wrap;
+    row-gap: var(--team-gap);
+    transition: none;
+  }
+}
 .team-cluster[data-open] .team-face {
   transform: none;
 }


### PR DESCRIPTION
On the homepage patron grid, opening the 12-face Founding Patrons row spread wider than its column and ran into Founding Corporate Patrons. An open row in that grid now wraps onto a second line.

Below desktop width the same applies to every cluster, including the teams grid, so a row that outgrows its column wraps instead of being clipped at the viewport edge. On desktop the teams grid is untouched and keeps its sliding columns.

**Before:**
<img width="1338" height="664" alt="image" src="https://github.com/user-attachments/assets/f27ee4ae-6e8b-4f61-9e6e-2ea3e97670ce" />


**After:**
<img width="1371" height="717" alt="image" src="https://github.com/user-attachments/assets/b7ac007e-32b5-433b-998e-e891a193d2d5" />
