### PR TITLE
Make the rails and their arrows work right to left

### DIFF
--- a/src/components/MeetupShowcase.tsx
+++ b/src/components/MeetupShowcase.tsx
@@ -5,7 +5,10 @@ import { SectionActions, SectionHeading } from '@/components/SectionHeading'
 import { MeetupCover } from '@/components/MeetupCover'
 import { RailBar, useRail } from '@/components/Rail'
 import { Button } from '@/components/ui/button'
-import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
+import {
+  ChevronEndIcon,
+  ChevronStartIcon,
+} from '@/components/icons/ReadingChevrons'
 import meetups from '@/data/meetups.json'
 import { cn } from '@/lib/utils'
 
@@ -39,7 +42,7 @@ export function MeetupShowcase({ action }: { action?: ReactNode }) {
         disabled={rail.atStart}
         onClick={() => turn(-1)}
       >
-        <ChevronLeftIcon className="size-5" />
+        <ChevronStartIcon className="size-5" />
       </Button>
       <Button
         variant="outline"
@@ -48,7 +51,7 @@ export function MeetupShowcase({ action }: { action?: ReactNode }) {
         disabled={rail.atEnd}
         onClick={() => turn(1)}
       >
-        <ChevronRightIcon className="size-5" />
+        <ChevronEndIcon className="size-5" />
       </Button>
     </div>
   )

--- a/src/components/Rail.tsx
+++ b/src/components/Rail.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PointerEvent as ReactPointerEvent, MouseEvent } from 'react'
+import { locale } from '@/i18n/site'
+import { edgesAt, slideSpan, slideTarget, startPad } from '@/lib/rail-geometry'
+import type { RailAlign } from '@/lib/rail-geometry'
+
+/** The site builds one language at a time, and the page's `dir` comes from
+ *  this same value, so the rails cannot disagree with the document. */
+const RTL = locale.direction === 'rtl'
 
 const GLIDE_MS = 420
 const EASE_OUT = (t: number) => 1 - Math.pow(1 - t, 3)
@@ -22,7 +29,7 @@ const capture = (el: Element, pointerId: number) => {
   }
 }
 
-export type RailAlign = 'center' | 'start'
+export type { RailAlign }
 
 export function useRail<T extends HTMLElement = HTMLDivElement>({
   count,
@@ -66,11 +73,15 @@ export function useRail<T extends HTMLElement = HTMLDivElement>({
   const targetFor = useCallback(
     (el: HTMLElement, slide: HTMLElement) => {
       const first = el.children[0] as HTMLElement | undefined
-      const raw =
-        align === 'center'
-          ? slide.offsetLeft - (el.clientWidth - slide.clientWidth) / 2
-          : slide.offsetLeft - (first?.offsetLeft ?? 0)
-      return Math.max(0, Math.min(el.scrollWidth - el.clientWidth, raw))
+      return slideTarget({
+        align,
+        slideOffset: slide.offsetLeft,
+        slideWidth: slide.clientWidth,
+        firstOffset: first?.offsetLeft ?? 0,
+        clientWidth: el.clientWidth,
+        reach: el.scrollWidth - el.clientWidth,
+        rtl: RTL,
+      })
     },
     [align],
   )
@@ -104,11 +115,19 @@ export function useRail<T extends HTMLElement = HTMLDivElement>({
     const first = el?.children[0] as HTMLElement | undefined
     const second = el?.children[1] as HTMLElement | undefined
     if (!el || !first) return 1
-    const step = second
-      ? second.offsetLeft - first.offsetLeft
-      : first.clientWidth
+    const step = slideSpan(
+      first.offsetLeft,
+      second?.offsetLeft,
+      first.clientWidth,
+    )
     const gap = Math.max(0, step - first.clientWidth)
-    const room = el.clientWidth - first.offsetLeft * 2 + gap
+    const pad = startPad({
+      clientWidth: el.clientWidth,
+      firstOffset: first.offsetLeft,
+      firstWidth: first.clientWidth,
+      rtl: RTL,
+    })
+    const room = el.clientWidth - pad * 2 + gap
     // A hair of tolerance, so four cards sized to fill the column exactly
     // never round down to three.
     return Math.max(1, Math.floor(room / Math.max(1, step) + 0.05))
@@ -126,7 +145,12 @@ export function useRail<T extends HTMLElement = HTMLDivElement>({
    */
   const columnAt = (el: HTMLElement, scrollLeft: number) => {
     const first = el.children[0] as HTMLElement | undefined
-    const pad = first?.offsetLeft ?? 0
+    const pad = startPad({
+      clientWidth: el.clientWidth,
+      firstOffset: first?.offsetLeft ?? 0,
+      firstWidth: first?.clientWidth ?? 0,
+      rtl: RTL,
+    })
     const left = scrollLeft + pad - 1
     const right = scrollLeft + el.clientWidth - pad + 1
     const inside = new Set<number>()
@@ -165,8 +189,7 @@ export function useRail<T extends HTMLElement = HTMLDivElement>({
     // Percentages here are of the thumb's own width, so the travel is
     // expressed relative to it rather than to the track.
     bar.style.transform = `translateX(${(progress * (1 - ratio) * 100) / ratio}%)`
-    const start = el.scrollLeft <= 1
-    const end = el.scrollLeft >= reach - 1
+    const { start, end } = edgesAt(el.scrollLeft, reach, RTL)
     setEdges((was) =>
       was.start === start && was.end === end ? was : { start, end },
     )

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,12 +1,11 @@
 import { t } from '@/i18n/site'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
+import { BrushIcon, CrossIcon } from '@/components/icons'
 import {
-  BrushIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  CrossIcon,
-} from '@/components/icons'
+  ChevronEndIcon,
+  ChevronStartIcon,
+} from '@/components/icons/ReadingChevrons'
 import {
   HINT_KEY,
   OPEN_PICKER_EVENT,
@@ -442,10 +441,10 @@ export function ThemePicker() {
             step(-1)
           }}
           className={cn(
-            'absolute left-3 top-1/2 flex size-11 cursor-pointer -translate-y-1/2 items-center justify-center border border-border-subtle bg-bg text-text transition-colors duration-150 ease-out hover:bg-surface-2 sm:left-6',
+            'absolute start-3 top-1/2 flex size-11 cursor-pointer -translate-y-1/2 items-center justify-center border border-border-subtle bg-bg text-text transition-colors duration-150 ease-out hover:bg-surface-2 sm:start-6',
           )}
         >
-          <ChevronLeftIcon className="size-5" />
+          <ChevronStartIcon className="size-5" />
         </button>
         <button
           type="button"
@@ -455,10 +454,10 @@ export function ThemePicker() {
             step(1)
           }}
           className={cn(
-            'absolute right-3 top-1/2 flex size-11 cursor-pointer -translate-y-1/2 items-center justify-center border border-border-subtle bg-bg text-text transition-colors duration-150 ease-out hover:bg-surface-2 sm:right-6',
+            'absolute end-3 top-1/2 flex size-11 cursor-pointer -translate-y-1/2 items-center justify-center border border-border-subtle bg-bg text-text transition-colors duration-150 ease-out hover:bg-surface-2 sm:end-6',
           )}
         >
-          <ChevronRightIcon className="size-5" />
+          <ChevronEndIcon className="size-5" />
         </button>
       </div>
     </>

--- a/src/components/VideoCarousel.tsx
+++ b/src/components/VideoCarousel.tsx
@@ -1,6 +1,10 @@
 import { t } from '@/i18n/site'
 import { useEffect, useState } from 'react'
-import { ChevronLeftIcon, ChevronRightIcon, PlayIcon } from '@/components/icons'
+import { PlayIcon } from '@/components/icons'
+import {
+  ChevronEndIcon,
+  ChevronStartIcon,
+} from '@/components/icons/ReadingChevrons'
 import { OmarchyMark } from '@/components/Brand'
 import { Button } from '@/components/ui/button'
 import { RailBar, useRail } from '@/components/Rail'
@@ -51,7 +55,7 @@ export function VideoCarousel({
         aria-label={t('Previous video')}
         onClick={() => goTo(index - 1)}
       >
-        <ChevronLeftIcon className="size-5" />
+        <ChevronStartIcon className="size-5" />
       </Button>
       <Button
         variant="outline"
@@ -59,7 +63,7 @@ export function VideoCarousel({
         aria-label={t('Next video')}
         onClick={() => goTo(index + 1)}
       >
-        <ChevronRightIcon className="size-5" />
+        <ChevronEndIcon className="size-5" />
       </Button>
     </div>
   )

--- a/src/components/icons/ReadingChevrons.tsx
+++ b/src/components/icons/ReadingChevrons.tsx
@@ -1,0 +1,13 @@
+import { locale } from '@/i18n/site'
+import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
+
+/**
+ * Chevrons that follow the reading direction instead of the screen's edges.
+ * `Start` points back towards where a line begins and `End` on towards where
+ * it finishes, so a right-to-left page gets the mirror of a left-to-right
+ * one and "previous" never points the way the reader is going.
+ */
+const rtl = locale.direction === 'rtl'
+
+export const ChevronStartIcon = rtl ? ChevronRightIcon : ChevronLeftIcon
+export const ChevronEndIcon = rtl ? ChevronLeftIcon : ChevronRightIcon

--- a/src/lib/rail-geometry.test.ts
+++ b/src/lib/rail-geometry.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  edgesAt,
+  slideSpan,
+  slideTarget,
+  startPad,
+  travelFrom,
+} from './rail-geometry.ts'
+
+// Measured from the running site at a 1440px viewport. The right-to-left
+// figures are the Arabic build's; the left-to-right ones are the same rails
+// mirrored, so the pairs below describe one layout read from either end.
+const video = {
+  ltr: {
+    clientWidth: 1425,
+    reach: 6720,
+    width: 1104,
+    offsets: [161, 1281, 2401],
+  },
+  rtl: {
+    clientWidth: 1425,
+    reach: 6720,
+    width: 1104,
+    offsets: [161, -959, -2079],
+  },
+}
+const meetups = {
+  ltr: { clientWidth: 1425, reach: 3102, width: 258, offsets: [160, 442, 724] },
+  rtl: {
+    clientWidth: 1425,
+    reach: 3102,
+    width: 258,
+    offsets: [1007, 725, 443],
+  },
+}
+
+test('a centred slide is targeted the same distance along either direction', () => {
+  const centre = (rail: typeof video.ltr, i: number, rtl: boolean) =>
+    slideTarget({
+      align: 'center',
+      slideOffset: rail.offsets[i],
+      slideWidth: rail.width,
+      firstOffset: rail.offsets[0],
+      clientWidth: rail.clientWidth,
+      reach: rail.reach,
+      rtl,
+    })
+
+  // Left to right the rail counts up from its starting edge; right to left it
+  // counts down from it. Either way the second slide is one span along.
+  assert.equal(centre(video.ltr, 1, false), 1120.5)
+  assert.equal(centre(video.rtl, 1, true), -1119.5)
+  assert.equal(centre(video.rtl, 2, true), -2239.5)
+})
+
+test('every slide of a right-to-left rail gets its own target', () => {
+  // The bug this guards: clamping to a left-to-right range collapsed every
+  // right-to-left target onto zero, so the rail sprang back to the first
+  // slide however it was dragged or paged.
+  const targets = video.rtl.offsets.map((slideOffset) =>
+    slideTarget({
+      align: 'center',
+      slideOffset,
+      slideWidth: video.rtl.width,
+      firstOffset: video.rtl.offsets[0],
+      clientWidth: video.rtl.clientWidth,
+      reach: video.rtl.reach,
+      rtl: true,
+    }),
+  )
+  assert.equal(new Set(targets).size, targets.length)
+  assert.ok(targets.slice(1).every((to) => to < 0))
+})
+
+test('a target never asks for travel the rail does not have', () => {
+  const far = (rtl: boolean, slideOffset: number) =>
+    slideTarget({
+      align: 'center',
+      slideOffset,
+      slideWidth: 1104,
+      firstOffset: 161,
+      clientWidth: 1425,
+      reach: 6720,
+      rtl,
+    })
+  assert.equal(far(false, 99999), 6720)
+  assert.equal(far(false, -99999), 0)
+  assert.equal(far(true, -99999), -6720)
+  assert.equal(far(true, 99999), 0)
+})
+
+test('a rail aligned to the start lines slides up with its leading edge', () => {
+  const start = (rail: typeof meetups.ltr, i: number, rtl: boolean) =>
+    slideTarget({
+      align: 'start',
+      slideOffset: rail.offsets[i],
+      slideWidth: rail.width,
+      firstOffset: rail.offsets[0],
+      clientWidth: rail.clientWidth,
+      reach: rail.reach,
+      rtl,
+    })
+  assert.equal(start(meetups.ltr, 0, false), 0)
+  assert.equal(start(meetups.ltr, 2, false), 564)
+  assert.equal(start(meetups.rtl, 0, true), 0)
+  assert.equal(start(meetups.rtl, 2, true), -564)
+})
+
+test('the padding in front of the first slide is measured from the near edge', () => {
+  // Right to left the first slide sits against the far end of the axis, so
+  // its own offset is the room behind it rather than in front.
+  assert.equal(
+    startPad({
+      clientWidth: 1425,
+      firstOffset: 160,
+      firstWidth: 258,
+      rtl: false,
+    }),
+    160,
+  )
+  assert.equal(
+    startPad({
+      clientWidth: 1425,
+      firstOffset: 1007,
+      firstWidth: 258,
+      rtl: true,
+    }),
+    160,
+  )
+})
+
+test('the span between slides is a distance, not a direction', () => {
+  assert.equal(slideSpan(161, 1281, 1104), 1120)
+  assert.equal(slideSpan(161, -959, 1104), 1120)
+  // A rail of one slide steps by its own width.
+  assert.equal(slideSpan(161, undefined, 1104), 1104)
+})
+
+test('travel is counted up from the starting edge in either direction', () => {
+  assert.equal(travelFrom(0, false), 0)
+  assert.equal(travelFrom(3360, false), 3360)
+  assert.equal(travelFrom(0, true), 0)
+  assert.equal(travelFrom(-3360, true), 3360)
+})
+
+test('both ends of the travel are reported in either direction', () => {
+  assert.deepEqual(edgesAt(0, 6720, false), { start: true, end: false })
+  assert.deepEqual(edgesAt(6720, 6720, false), { start: false, end: true })
+  // The bug this guards: right to left the rail read as parked at its start
+  // forever, so paging back stayed disabled and paging on never stopped.
+  assert.deepEqual(edgesAt(0, 6720, true), { start: true, end: false })
+  assert.deepEqual(edgesAt(-6720, 6720, true), { start: false, end: true })
+})
+
+test('a rail with nothing to scroll sits against both of its ends', () => {
+  assert.deepEqual(edgesAt(0, 0, false), { start: true, end: true })
+  assert.deepEqual(edgesAt(0, 0, true), { start: true, end: true })
+})

--- a/src/lib/rail-geometry.ts
+++ b/src/lib/rail-geometry.ts
@@ -1,0 +1,96 @@
+/**
+ * Rail geometry that reads the same in both writing directions.
+ *
+ * A right-to-left scroller counts `scrollLeft` down from zero at its starting
+ * edge to `-(scrollWidth - clientWidth)` at its far one, and lays its slides
+ * out with falling `offsetLeft`. Both are measured against the same signed
+ * axis, so most of a rail's arithmetic carries over untouched. What does not
+ * are the places that assume travel runs upward from zero, that a step
+ * between slides is a positive number, or that the first slide's offset is
+ * the padding in front of it rather than the room left behind.
+ */
+
+export type RailAlign = 'center' | 'start'
+
+/** How far the rail has come from its starting edge, counted up from zero. */
+export function travelFrom(scrollLeft: number, rtl: boolean): number {
+  // Subtracted rather than negated so a rail parked at the start reads as
+  // zero rather than as negative zero.
+  return rtl ? 0 - scrollLeft : scrollLeft
+}
+
+/** Keep a target inside the travel the scroller actually has. */
+export function clampScroll(
+  target: number,
+  reach: number,
+  rtl: boolean,
+): number {
+  return rtl
+    ? Math.min(0, Math.max(-reach, target))
+    : Math.max(0, Math.min(reach, target))
+}
+
+/** Which ends of its travel the rail is resting against. */
+export function edgesAt(
+  scrollLeft: number,
+  reach: number,
+  rtl: boolean,
+): { start: boolean; end: boolean } {
+  const from = travelFrom(scrollLeft, rtl)
+  return { start: from <= 1, end: from >= reach - 1 }
+}
+
+/**
+ * The room between the scroller's starting edge and its first slide. Right to
+ * left the first slide sits against the far end of the axis, so its own
+ * offset measures the space behind it instead.
+ */
+export function startPad({
+  clientWidth,
+  firstOffset,
+  firstWidth,
+  rtl,
+}: {
+  clientWidth: number
+  firstOffset: number
+  firstWidth: number
+  rtl: boolean
+}): number {
+  return rtl ? clientWidth - (firstOffset + firstWidth) : firstOffset
+}
+
+/** The distance from one slide's leading edge to the next, never negative. */
+export function slideSpan(
+  firstOffset: number,
+  secondOffset: number | undefined,
+  firstWidth: number,
+): number {
+  return secondOffset === undefined
+    ? firstWidth
+    : Math.abs(secondOffset - firstOffset)
+}
+
+/** The scroll position that shows a slide where the rail aligns it. */
+export function slideTarget({
+  align,
+  slideOffset,
+  slideWidth,
+  firstOffset,
+  clientWidth,
+  reach,
+  rtl,
+}: {
+  align: RailAlign
+  slideOffset: number
+  slideWidth: number
+  firstOffset: number
+  clientWidth: number
+  reach: number
+  rtl: boolean
+}): number {
+  const raw =
+    align === 'center'
+      ? slideOffset - (clientWidth - slideWidth) / 2
+      : slideOffset - firstOffset
+  return clampScroll(raw, reach, rtl)
+}


### PR DESCRIPTION
On the Arabic site the video carousel could not be moved: dragging it or
pressing either arrow sprang it straight back to the first video.

## Why

A right-to-left scroller counts `scrollLeft` **down** from `0` at its starting
edge to `-(scrollWidth - clientWidth)` at its far one, and lays its slides out
with falling `offsetLeft`. Measured on the running Arabic site, the video rail
rests at `scrollLeft: 0` with a range of `[-6720, 0]`, and its slides sit at
`161, -959, -2079, …`.

`useRail` assumed the left-to-right convention throughout, so:

- **`targetFor`** clamped with `Math.max(0, Math.min(reach, raw))`. Every
  right-to-left target is negative, so every slide collapsed onto `0` — the rail
  had one destination, the first slide. This is the reported bug, and it took
  both the drag release and the arrows through the same path.
- **`columnAt`** took the first slide's `offsetLeft` as the padding in front of
  it. Right to left that is the room *behind* it, which inverted the range
  (`left: 1006` past `right: 419`), so nothing was ever in the content column
  and all 15 meetup cards stayed dimmed.
- **`perView`** divided by a signed step, so `Math.max(1, -1120)` made it return
  `1103` instead of `1`.
- **The edge flags** read `start` as `scrollLeft <= 1` — always true — and `end`
  as `scrollLeft >= reach - 1` — never true. The meetup rail's back arrow was
  permanently disabled and its forward arrow never disabled.
- **The chevrons** followed the screen's edges rather than the reading
  direction, so "previous" pointed the way an Arabic reader is already going.

## What changed

The direction-sensitive arithmetic moves into `src/lib/rail-geometry.ts` as
pure functions, so it can be tested without a DOM, and `useRail` calls into it.
`src/components/icons/ReadingChevrons.tsx` exposes `ChevronStartIcon` and
`ChevronEndIcon`, which resolve against `locale.direction` — the same value
`Base.astro` puts in `<html dir>`, so a page and its rails cannot disagree.

The parts that were already direction-neutral are left alone: `nearest`, the
drag's `scrollLeft` tracking, the page arithmetic in `endDrag` (its negative
step cancels the flip), the thumb transform, and the thumb drag all measure
against the same signed axis and were verified correct in both directions.

Left-to-right behaviour is unchanged: `startPad`, `slideSpan` and `clampScroll`
all reduce to the previous expressions when `rtl` is false.

## Verified

`src/lib/rail-geometry.test.ts` covers each rail read from both ends, including
a regression test per reported bug. Driving the running Arabic site, the video
rail now steps `0 → -1120 → -2240 → … → -6720` and back, where every one of
those positions read `0` before; a real mouse drag moves the strip and settles
on a slide; the meetup rail shows 4 cards in column instead of 0; "previous"
points right and "next" points left.

`npm run lint`, `npm run typecheck`, `npm test` (35 node + 26 python), a full
`npm run build`, and `npm run parity` (4027/4027 addresses, 1252/1252 files
byte-identical) all pass.
