### PR TITLE
Docs: theme submissions go in src/data/themes.json, not themes/index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,22 @@ Put the result in `assets/themes/`. Name the file after the theme, lowercase
 and hyphenated — `your-theme.webp`. Aim for 1200x675; keep it under about
 100KB so the page stays quick to load.
 
-**2. An entry.** Add a figure block to `themes/index.html`, in alphabetical
+**2. An entry.** Add an object to `src/data/themes.json`, in alphabetical
 order among the others:
 
-```html
-<figure class="themes__theme">
-  <a href="https://github.com/you/your-theme"
-    ><img
-      src="/assets/themes/your-theme.webp"
-      alt="Your Theme theme"
-      loading="lazy"
-      decoding="async"
-  /></a>
-  <figcaption>
-    <a href="https://github.com/you/your-theme">Your Theme</a>
-  </figcaption>
-</figure>
+```json
+{
+ "repo": "https://github.com/you/your-theme",
+ "image": "/assets/themes/your-theme.webp",
+ "name": "Your Theme"
+}
 ```
 
-Both links point at the theme's own repository, which is where people
-install it from and where it needs to keep living.
+`repo` points at the theme's own repository, which is where people install it
+from and where it needs to keep living. The `/themes` page is rendered from
+`src/data/themes.json` (via `src/astro/pages/ThemesPage.tsx`), so an entry here
+is what makes a theme show up — the older `themes/index.html` is no longer the
+source of truth.
 
 ### The screenshot matters
 


### PR DESCRIPTION
## What & why

Since the site moved to Astro, the extra-themes page (`/themes`) renders from **`src/data/themes.json`** — `src/astro/pages/ThemesPage.tsx` does `import themes from '@/data/themes.json'` and maps over it.

But the README's "Adding your theme" section still tells contributors to add a `<figure>` block to **`themes/index.html`**, which is now legacy. A theme added only there won't show up on the live page.

This corrects **step 2** to point at `src/data/themes.json` with the actual entry shape (`repo` / `image` / `name`), and notes that `themes/index.html` is no longer the source of truth. Step 1 (the screenshot) is unchanged.

Found while preparing a theme-listing PR (#300): the current entries all live in `themes.json`, so following the README as written would produce a PR that doesn't render.