### PR TITLE
Add machine-translation notice to non-English footers

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -194,6 +194,16 @@ export function SiteFooter({ path }: { path: string }) {
               </a>
             ))}
         </nav>
+        {language !== 'en' && (
+          <p
+            data-quiet
+            className="mt-8 text-xs text-text-muted [text-wrap:pretty]"
+          >
+            {t(
+              'This page contains machine-translated content, which may differ from the meaning of the original English text.',
+            )}
+          </p>
+        )}
         <div className="mt-12 flex flex-col gap-2 border-t border-border-subtle pt-6 text-[13px] text-text-muted sm:flex-row sm:items-center sm:justify-between">
           <p data-quiet>
             <Link to="/$/" params={{ _splat: 'brand' }} className={footerLink}>

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "تحتوي هذه الصفحة على محتوى مترجم آليًا، وقد يختلف عن معنى النص الإنجليزي الأصلي.",
   "News": "الأخبار",
   "Manual": "الدليل (بالإنجليزية)",
   "Themes": "السمات",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "এই পৃষ্ঠায় যন্ত্রে অনূদিত বিষয়বস্তু রয়েছে, যা মূল ইংরেজি লেখার অর্থ থেকে ভিন্ন হতে পারে।",
   "News": "সংবাদ",
   "Manual": "নির্দেশিকা (ইংরেজি)",
   "Themes": "থিম",

--- a/src/i18n/messages/ca.json
+++ b/src/i18n/messages/ca.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Aquesta pàgina conté contingut traduït automàticament, que pot diferir del significat del text original en anglès.",
   "News": "Notícies",
   "Manual": "Manual (en anglès)",
   "Themes": "Temes",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Denne side indeholder maskinoversat indhold, som kan afvige fra betydningen af den oprindelige engelske tekst.",
   "News": "Nyheder",
   "Manual": "Håndbog (engelsk)",
   "Themes": "Temaer",

--- a/src/i18n/messages/el.json
+++ b/src/i18n/messages/el.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Αυτή η σελίδα περιέχει περιεχόμενο που έχει μεταφραστεί αυτόματα, το οποίο ενδέχεται να διαφέρει από το νόημα του πρωτότυπου αγγλικού κειμένου.",
   "News": "Νέα",
   "Manual": "Εγχειρίδιο (αγγλικά)",
   "Themes": "Θέματα",

--- a/src/i18n/messages/es-MX.json
+++ b/src/i18n/messages/es-MX.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Esta página contiene contenido traducido automáticamente, que puede diferir del significado del texto original en inglés.",
   "News": "Noticias",
   "Manual": "Manual (en inglés)",
   "Themes": "Temas",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Tämä sivu sisältää konekäännettyä sisältöä, joka saattaa poiketa alkuperäisen englanninkielisen tekstin merkityksestä.",
   "News": "Uutiset",
   "Manual": "Ohjekirja (englanniksi)",
   "Plugins": "Lisäosat",

--- a/src/i18n/messages/fil.json
+++ b/src/i18n/messages/fil.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Naglalaman ang pahinang ito ng nilalamang isinalin ng makina, na maaaring magkaiba sa kahulugan ng orihinal na tekstong Ingles.",
   "News": "Balita",
   "Manual": "Manwal (Ingles)",
   "Themes": "Mga tema",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Cette page contient du contenu traduit automatiquement, qui peut différer du sens du texte original en anglais.",
   "News": "Actualités",
   "Manual": "Manuel (en anglais)",
   "Themes": "Thèmes",

--- a/src/i18n/messages/ga.json
+++ b/src/i18n/messages/ga.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Tá ábhar aistrithe ag meaisín ar an leathanach seo, a d'fhéadfadh a bheith difriúil ó bhrí an téacs Béarla bunaidh.",
   "News": "Nuacht",
   "Manual": "Lámhleabhar (i mBéarla)",
   "Themes": "Téamaí",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "इस पृष्ठ में मशीन-अनूदित सामग्री शामिल है, जो मूल अंग्रेज़ी पाठ के अर्थ से भिन्न हो सकती है।",
   "News": "समाचार",
   "Manual": "मैनुअल (अंग्रेज़ी)",
   "Themes": "थीम",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Ez az oldal gépi fordítású tartalmat tartalmaz, amely eltérhet az eredeti angol szöveg jelentésétől.",
   "News": "Hírek",
   "Manual": "Kézikönyv (angolul)",
   "Themes": "Témák",

--- a/src/i18n/messages/is.json
+++ b/src/i18n/messages/is.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Þessi síða inniheldur vélþýtt efni sem getur verið frábrugðið merkingu upprunalega enska textans.",
   "News": "Fréttir",
   "Manual": "Handbók (á ensku)",
   "Themes": "Þemu",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Questa pagina contiene contenuti tradotti automaticamente, che potrebbero differire dal significato del testo originale in inglese.",
   "News": "Notizie",
   "Manual": "Manuale (in inglese)",
   "Themes": "Temi",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "このページには機械翻訳されたコンテンツが含まれており、元の英語テキストの意味と異なる場合があります。",
   "News": "ニュース",
   "Manual": "マニュアル（英語）",
   "Themes": "テーマ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "기계로 번역된 내용이 포함되어 있으며 영어 원본의 의미와 다를 수도 있습니다.",
   "News": "소식",
   "Manual": "매뉴얼(영어)",
   "Themes": "테마",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1,5 +1,5 @@
 {
-  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "기계로 번역된 내용이 포함되어 있으며 영어 원본의 의미와 다를 수도 있습니다.",
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "이 페이지는 기계로 번역된 내용이 포함되어 있으며 영어 원문의 의미와 다른 부분이 있을 수 있습니다.",
   "News": "소식",
   "Manual": "매뉴얼(영어)",
   "Themes": "테마",

--- a/src/i18n/messages/lt.json
+++ b/src/i18n/messages/lt.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Šiame puslapyje pateikiamas mašininiu būdu išverstas turinys, kuris gali skirtis nuo originalaus teksto anglų kalba reikšmės.",
   "News": "Naujienos",
   "Manual": "Vadovas (anglų kalba)",
   "Themes": "Temos",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Deze pagina bevat machinaal vertaalde inhoud, die kan afwijken van de betekenis van de oorspronkelijke Engelse tekst.",
   "News": "Nieuws",
   "Manual": "Handleiding",
   "Themes": "Thema's",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Denne siden inneholder maskinoversatt innhold, som kan avvike fra betydningen av den opprinnelige engelske teksten.",
   " detailed guides.": " detaljerte veiledninger.",
   " incompatibility.": " enhver inkompatibilitet.",
   " missing app.": " enhver manglende app.",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Ta strona zawiera treści przetłumaczone maszynowo, które mogą różnić się znaczeniem od oryginalnego tekstu w języku angielskim.",
   "News": "Aktualności",
   "Manual": "Podręcznik (po angielsku)",
   "Themes": "Motywy",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Esta página contém conteúdo traduzido automaticamente, que pode diferir do significado do texto original em inglês.",
   "News": "Notícias",
   "Manual": "Manual (em inglês)",
   "Themes": "Temas",

--- a/src/i18n/messages/si.json
+++ b/src/i18n/messages/si.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "මෙම පිටුවේ යන්ත්‍ර පරිවර්තිත අන්තර්ගතය ඇතුළත් වන අතර, එය මුල් ඉංග්‍රීසි පෙළේ අර්ථයට වඩා වෙනස් විය හැක.",
   "News": "පුවත්",
   "Manual": "අත්පොත (ඉංග්‍රීසියෙන්)",
   "Themes": "තේමා",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Den här sidan innehåller maskinöversatt innehåll, som kan skilja sig från betydelsen i den ursprungliga engelska texten.",
   "News": "Nyheter",
   "Manual": "Handbok (engelska)",
   "Themes": "Teman",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "இந்தப் பக்கத்தில் இயந்திர மொழிபெயர்ப்புச் செய்யப்பட்ட உள்ளடக்கம் உள்ளது, இது அசல் ஆங்கில உரையின் பொருளிலிருந்து வேறுபடலாம்.",
   "News": "செய்திகள்",
   "Manual": "கையேடு (ஆங்கிலம்)",
   "Themes": "தோற்றக்கருக்கள்",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "หน้านี้มีเนื้อหาที่แปลด้วยเครื่อง ซึ่งอาจแตกต่างจากความหมายของข้อความภาษาอังกฤษต้นฉบับ",
   "News": "ข่าว",
   "Manual": "คู่มือ (ภาษาอังกฤษ)",
   "Themes": "ธีม",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Bu sayfa makine tarafından çevrilmiş içerik barındırır ve orijinal İngilizce metnin anlamından farklı olabilir.",
   "News": "Haberler",
   "Manual": "Kılavuz (İngilizce)",
   "Themes": "Temalar",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "اس صفحے میں مشینی ترجمہ شدہ مواد شامل ہے، جو اصل انگریزی متن کے مفہوم سے مختلف ہو سکتا ہے۔",
   "News": "خبریں",
   "Manual": "رہنما (انگریزی)",
   "Themes": "تھیمز",

--- a/src/i18n/messages/uz.json
+++ b/src/i18n/messages/uz.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Ushbu sahifada mashina tarjimasi bilan tarjima qilingan matn mavjud bo‘lib, u asl inglizcha matn maʼnosidan farq qilishi mumkin.",
   "News": "Yangiliklar",
   "Manual": "Qo‘llanma (inglizcha)",
   "Themes": "Mavzular",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "Trang này chứa nội dung được dịch máy, có thể khác với ý nghĩa của văn bản gốc bằng tiếng Anh.",
   "News": "Tin tức",
   "Manual": "Hướng dẫn (tiếng Anh)",
   "Themes": "Giao diện",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1,4 +1,5 @@
 {
+  "This page contains machine-translated content, which may differ from the meaning of the original English text.": "此页面包含机器翻译的内容，可能与英文原文的含义有所不同。",
   "News": "新闻",
   "Manual": "用户手册",
   "Themes": "主题",


### PR DESCRIPTION
Non-English site footers now show a short notice that the page content is machine-translated and may differ from the meaning of the original English text, shown only when the site language isn't English (src/components/SiteFooter.tsx).

Adds the English source string plus a translation for every one of the 30 non-English locales in src/i18n/messages/*.json, following each language's own sentence-final punctuation convention: no trailing punctuation in Thai, 。 in Japanese and Chinese, । in Hindi and Bengali, ۔ in Urdu, and a period everywhere else.

Validation: npm run lint, npm run typecheck, npm test, and npm run check:translations all passed. Verified rendering locally with PUBLIC_SITE_LOCALE=ko astro dev and a screenshot of the Korean footer.

<img width="1280" height="555" alt="image" src="https://github.com/user-attachments/assets/a29841e6-5a41-46d0-8888-bf7df4781fb3" />

---
_Generated by [Claude Code](https://claude.ai/code)_
