### PR TITLE
Mirror directional arrow icons for RTL locales

### DIFF
--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -207,7 +207,7 @@ function HeroCallout({ href, html }: { href: string; html: string }) {
         className="min-w-0 [&_s]:text-current/60"
         dangerouslySetInnerHTML={{ __html: t(html) }}
       />
-      <ArrowRightIcon className="size-4 shrink-0 transition-transform duration-150 ease-out group-hover:translate-x-0.5" />
+      <ArrowRightIcon className="size-4 shrink-0 transition-transform duration-150 ease-out group-hover:translate-x-0.5 rtl:-scale-x-100 rtl:group-hover:-translate-x-0.5" />
     </>
   )
   const news = NEWS_PATH.exec(href)
@@ -265,19 +265,19 @@ export function HomePage({ data }: { data: HomeData }) {
   const allPlugins = (
     <a href="https://plugins.omarchy.org" className={sectionLink}>
       {t('All plugins')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </a>
   )
   const extraThemes = (
     <Link to="/themes/" className={sectionLink}>
       {t('More community themes')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
   const allNews = (
     <Link to="/news/" className={sectionLink}>
       {t('All news')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
   const installGuide = (
@@ -287,7 +287,7 @@ export function HomePage({ data }: { data: HomeData }) {
       className={sectionLink}
     >
       {t('Full installation guide')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
   const moreOnX = (
@@ -304,19 +304,19 @@ export function HomePage({ data }: { data: HomeData }) {
   const allTeams = (
     <Link to="/teams/" className={sectionLink}>
       {t('All teams')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
   const allPatrons = (
     <Link to="/$/" params={{ _splat: 'patrons' }} className={sectionLink}>
       {t('All patrons')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
   const allMeetups = (
     <Link to="/meetups/" className={sectionLink}>
       {t('All meetups')}
-      <ArrowRightIcon />
+      <ArrowRightIcon className="rtl:-scale-x-100" />
     </Link>
   )
 
@@ -870,7 +870,7 @@ export function HomePage({ data }: { data: HomeData }) {
                   </p>
                   <span className="mt-auto flex items-center gap-1 pt-4 text-[13px] font-medium text-brand">
                     {card.cta}
-                    <ArrowRightIcon className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5" />
+                    <ArrowRightIcon className="size-4 transition-transform duration-150 ease-out group-hover:translate-x-0.5 rtl:-scale-x-100 rtl:group-hover:-translate-x-0.5" />
                   </span>
                 </>
               )

--- a/src/astro/pages/MeetupsPage.tsx
+++ b/src/astro/pages/MeetupsPage.tsx
@@ -205,7 +205,7 @@ export function MeetupsPage({ rules }: { rules: string }) {
       className="inline-flex min-h-10 shrink-0 items-center justify-center gap-2 py-2 text-sm font-medium whitespace-nowrap text-text underline decoration-current underline-offset-4 transition-colors duration-150 hover:text-brand hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&_svg]:size-5 [&_svg]:shrink-0"
     >
       {t('The calendar on Luma')}
-      <ArrowRightIcon aria-hidden="true" />
+      <ArrowRightIcon className="rtl:-scale-x-100" aria-hidden="true" />
     </a>
   )
 

--- a/src/astro/pages/NewsPages.tsx
+++ b/src/astro/pages/NewsPages.tsx
@@ -26,7 +26,7 @@ export function NewsIndexPage({ news }: { news: Array<NewsSummary> }) {
                 </time>
                 <span className="flex items-baseline gap-1.5 font-sans text-lg font-medium text-text transition-colors duration-150 ease-out group-hover:text-brand">
                   {post.title}
-                  <ArrowRightIcon className="size-5 shrink-0 self-center text-text-muted transition-[color,translate] duration-150 ease-out group-hover:translate-x-0.5 group-hover:text-brand" />
+                  <ArrowRightIcon className="size-5 shrink-0 self-center text-text-muted transition-[color,translate] duration-150 ease-out group-hover:translate-x-0.5 group-hover:text-brand rtl:-scale-x-100 rtl:group-hover:-translate-x-0.5" />
                 </span>
                 {post.excerpt ? (
                   <span className="text-sm leading-relaxed text-text-secondary [text-wrap:pretty]">
@@ -73,7 +73,7 @@ export function NewsPostPage({ post }: { post: NewsPost }) {
         to="/news/"
         className="mt-10 inline-flex items-center gap-1.5 text-sm text-text-secondary transition-colors duration-150 ease-out hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >
-        <ArrowLeftIcon className="size-5" />
+        <ArrowLeftIcon className="size-5 rtl:-scale-x-100" />
         {t('All news')}
       </Link>
     </main>

--- a/src/components/AgentShowcase.tsx
+++ b/src/components/AgentShowcase.tsx
@@ -72,7 +72,7 @@ export function AgentShowcase() {
       className="inline-flex min-h-10 shrink-0 items-center justify-center gap-2 py-2 text-sm font-medium whitespace-nowrap text-text underline decoration-current underline-offset-4 transition-colors duration-150 hover:text-brand hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&_svg]:size-5 [&_svg]:shrink-0"
     >
       {t('Meet your new agent')}
-      <ArrowRightIcon aria-hidden="true" />
+      <ArrowRightIcon className="rtl:-scale-x-100" aria-hidden="true" />
     </a>
   )
   return (

--- a/src/components/DeveloperShowcase.tsx
+++ b/src/components/DeveloperShowcase.tsx
@@ -56,7 +56,7 @@ export function DeveloperShowcase() {
               className="mt-auto inline-flex min-h-10 items-center gap-2 self-start pt-4 text-sm font-medium text-text underline-offset-4 hover:text-brand focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&:hover_span]:decoration-current"
             >
               <span className="underline decoration-current">{tool.link}</span>
-              <ArrowRightIcon className="size-5 shrink-0" aria-hidden="true" />
+              <ArrowRightIcon className="size-5 shrink-0 rtl:-scale-x-100" aria-hidden="true" />
             </a>
           </div>
         ))}

--- a/src/components/GamingShowcase.tsx
+++ b/src/components/GamingShowcase.tsx
@@ -39,7 +39,7 @@ export function GamingShowcase() {
       className="inline-flex min-h-10 shrink-0 items-center justify-center gap-2 py-2 text-sm font-medium whitespace-nowrap text-text underline decoration-current underline-offset-4 transition-colors duration-150 hover:text-brand hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&_svg]:size-5 [&_svg]:shrink-0"
     >
       {t('Get your game on')}
-      <ArrowRightIcon aria-hidden="true" />
+      <ArrowRightIcon className="rtl:-scale-x-100" aria-hidden="true" />
     </a>
   )
   return (

--- a/src/components/HardwareShowcase.tsx
+++ b/src/components/HardwareShowcase.tsx
@@ -62,7 +62,7 @@ export function HardwareShowcase() {
               className="mt-auto inline-flex min-h-10 items-center gap-2 self-start pt-4 text-sm font-medium text-text underline-offset-4 hover:text-brand focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&:hover_span]:decoration-current"
             >
               <span className="underline decoration-current">{link}</span>
-              <ArrowRightIcon className="size-5 shrink-0" aria-hidden="true" />
+              <ArrowRightIcon className="size-5 shrink-0 rtl:-scale-x-100" aria-hidden="true" />
             </a>
           </div>
         ))}

--- a/src/components/NotFoundHero.tsx
+++ b/src/components/NotFoundHero.tsx
@@ -93,7 +93,7 @@ export function NotFoundHero() {
                 onClick={home}
                 render={<Link to="/" />}
               >
-                <ArrowLeftIcon data-icon="inline-start" />
+                <ArrowLeftIcon data-icon="inline-start" className="rtl:-scale-x-100" />
                 {t('Back to Omarchy')}
               </Button>
             </div>

--- a/src/components/WindowsShowcase.tsx
+++ b/src/components/WindowsShowcase.tsx
@@ -9,7 +9,7 @@ export function WindowsShowcase() {
       className="inline-flex min-h-10 shrink-0 items-center justify-center gap-2 py-2 text-sm font-medium whitespace-nowrap text-text underline decoration-current underline-offset-4 transition-colors duration-150 hover:text-brand hover:decoration-current focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring [&_svg]:size-5 [&_svg]:shrink-0"
     >
       {t('Set up Windows')}
-      <ArrowRightIcon aria-hidden="true" />
+      <ArrowRightIcon className="rtl:-scale-x-100" aria-hidden="true" />
     </a>
   )
   return (


### PR DESCRIPTION
ArrowRightIcon/ArrowLeftIcon are used as "onward"/"back" reading-flow indicators (CTA links, back links, hover-nudge arrows), but always pointed the LTR direction regardless of dir, so in RTL they pointed backward into the text instead of leading it. 

Adds rtl:-scale-x-100 (and rtl:group-hover:-translate-x-0.5 where there's a hover nudge) to mirror them. ArrowUpRightIcon (external-link indicator) is left as is, matching common RTL convention.