### PR TITLE
Add the Omarchy Doctrine and refine homepage and footer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ layout, navigation, and styling in `src/`; preview through the dev server.
 After editing content inputs, run `npm run port` to refresh the dev data.
 
 - Edit standalone page content in its existing `index.html`.
+- Edit the doctrine in `content/doctrine.md`; `/doctrine/` renders its principles using the shared page heading and prose styles.
 - Edit the homepage announcement in `src/data/banner.json` (`null` hides it).
 - Run `bin/build-news` after editing Markdown in `content/news/`; it updates
   article inputs, images, and the RSS feed.

--- a/content/doctrine.md
+++ b/content/doctrine.md
@@ -1,0 +1,39 @@
+## 1. Unite the nerds.
+
+There are amazing nerds everywhere. Cracked teenagers. Wise neckbeards. Obsessive people with jagged opinions and incredible talent. But we're spread across a thousand little fiefdoms, accomplishing a fraction of what we could together. Omarchy is a rallying cry to unite that talent behind a common goal: Make Linux win the desktop, as the prophecy foretold.
+
+## 2. Hold the line.
+
+The original hacker cred was all about the code. It didn't care who you were, what your background was, or even if you were legally old enough to operate a [three-node elite BBS out of your bedroom](https://x.com/dhh/status/2096542976683970838). It just cared about the work, the art, the dare. Omarchy is bringing that ethos back, and dropping the Code-of-Conduct struggle sessions and identity-overload nonsense that has plagued open source for far too long. We're done with all of it. Just be nice and sincere.
+
+## 3. Have some fun.
+
+We're serious people, doing serious work, but if we can't laugh at ourselves and the delusional mission, it gets stuffy and stale real quick. We need fun, we need whimsy, we need cool for its own sake. The computer needs easter eggs, it needs silly games, it needs [funny pun songs](https://radio.omarchy.org). Serious people have serious fun.
+
+## 4. Beauty is truth.
+
+Great tools are beautiful because they're right. The best curve of the blade is also the elegant one, so let's nail the sharp lines of that TUI, get those corner radii right, and polish the CLIs. The colors should be coordinated. The padding should be just so. There's enough desaturated brutalism in this world already. Make it shine, make it wow, make it art.
+
+## 5. Heritage is duty.
+
+The modern history of computers is barely a lifetime old, but its heritage is rich and deserves our respect. It's our duty to honor those who forged the path before us. From [shipping basic vi](https://github.com/omacom/omarchy/pull/10307) fifty years after Bill Joy wrote the first version to dedicating a [theme to von Neumann](https://github.com/dhh/omarchy-giants-theme). We should be proud of how we got here and make our ancestors smile from retirement or above.
+
+## 6. Command is service.
+
+Excellence is not born out of committee, and Omarchy is not a democracy. It's a benevolent dictatorship in the grand tradition of Linux, Ruby, and Rails. The dictator's job is to listen to everyone, but make the call according to their intuition, vision, and experience. Some calls will be wrong, and then they'll be reverted. Others will be delegated. But the buck will always have a place to stop.
+
+## 7. Welcome the agents.
+
+The age of agents is the most important paradigm shift in computing since the microprocessor, and Omarchy is going to take full advantage. Agents are welcome everywhere. In the code, in the issues, in the pull requests, and in the infrastructure. We're going to lean all the way in, put the new intelligence to work all over, and together [We Can Fix Everything](https://wecanfixeverything.com)!
+
+## 8. Perfect the computer.
+
+There's no paper cut too small, no incompatibility too difficult, and no partnership that's out of reach. Omarchy's mission is nothing less than _The Perfect Computer_. That means [the pursuit of excellence without justification](https://x.com/mitchellh/status/2074225453217505494). Everything should be faster, better, prettier. We can do all of it, at the same time, and be done before ASI.
+
+## 9. Own the machine.
+
+The Perfect Computer may start as omakase, but it's ultimately yours. Fully and completely. No tollbooths, no gatekeepers, no platforms that can change the terms on you. Just free and open code that you can turn into whatever you desire. The malleable machine of the future is here today and it's yours to own.
+
+## 10. You're somebody now.
+
+Omarchy is for everyone willing to learn and participate. From [billionaires](https://oligarchy.fyi) to anons on X. From [staff engineers](/staff) to script kiddies. From [China](https://omarchy.cn) to Malibu. Show up, fix something, or just spread the enthusiasm. [You're somebody now](https://x.com/dhh/status/2097747649625497874).

--- a/scripts/parity.py
+++ b/scripts/parity.py
@@ -51,7 +51,7 @@ def addresses():
                         file.relative_to(SITE).as_posix(), 'file'))
     data = SITE / 'src' / 'data'
     read = lambda name: json.loads((data / f'{name}.json').read_text())
-    pages = {'/', '/404.html', '/manual/', '/manual/toc/', '/news/', '/themes/',
+    pages = {'/', '/404.html', '/doctrine/', '/manual/', '/manual/toc/', '/news/', '/themes/',
              '/teams/', '/plugins/', '/plugins/explore/', '/plugins/develop/',
              '/plugins/publish/'}
     pages.update(f'/{slug}/' for slug in read('pages'))

--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -491,11 +491,20 @@ export function HomePage({ data }: { data: HomeData }) {
                 className={`mt-5 max-w-[35.5rem] text-[15px] leading-relaxed text-text-secondary [text-wrap:pretty] ${language === 'zh-CN' ? 'whitespace-pre-line' : ''}`}
               >
                 {t(
-                  "Oma is for omakase, chef's choice: the chef picks the courses, but you are always free to send anything back. Omarchy lets you take an exquisite baseline and then make it your own.",
+                  "Oma is for omakase, chef's choice: we pick the tools and tune the details, so you can get straight to work. But this is your computer. You're free to change everything.",
                 )}
               </p>
               <p className="mt-5 max-w-[35.5rem] text-[15px] leading-relaxed text-text-secondary [text-wrap:pretty]">
-                {t("It's not perfect... yet. But")}
+                {t('Behind it all is the')}{' '}
+                <Link
+                  to="/doctrine/"
+                  className="underline decoration-border-strong underline-offset-4 hover:decoration-current"
+                >
+                  {t('Omarchy Doctrine')}
+                </Link>
+                {t(
+                  ": ten principles for uniting the nerds, welcoming the agents, and building the perfect computer. We're not there yet, but",
+                )}
                 {language === 'zh-CN' ? '' : ' '}
                 <a
                   href="https://wecanfixeverything.com/"

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -26,6 +26,7 @@ const columns = [
       { label: t('Meetups'), to: '/meetups/' },
       { label: t('Teams'), to: '/teams/' },
       { label: t('Workstations'), splat: 'workstations' },
+      { label: t('Doctrine'), to: '/doctrine/' },
     ],
   },
   {
@@ -35,7 +36,7 @@ const columns = [
       { label: t('Staff'), splat: 'staff' },
       { label: t('Patrons'), splat: 'patrons' },
       { label: t('Sponsorships'), splat: 'sponsorships' },
-      { label: t('Artists in Residence'), splat: 'air' },
+      { label: 'AIR', splat: 'air' },
     ],
   },
   {
@@ -55,9 +56,7 @@ const columns = [
 const focusRing =
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring'
 
-const footerLink = `text-text-secondary transition-colors duration-150 ease-out hover:text-text ${focusRing}`
-
-const creditLink = `text-text-secondary transition-colors duration-150 ease-out hover:text-text ${focusRing}`
+const footerLink = `text-text-secondary underline decoration-transparent underline-offset-4 transition-colors duration-150 ease-out hover:text-brand hover:decoration-current ${focusRing}`
 
 export function SiteFooter({ path }: { path: string }) {
   const homeLink = useTopLink()
@@ -119,21 +118,21 @@ export function SiteFooter({ path }: { path: string }) {
               <p data-quiet>
                 {t('Incubated at')}{' '}
                 {/* Keep the link inline to preserve the paragraph baseline. */}
-                <a href="https://37signals.com" className={creditLink}>
+                <a href="https://37signals.com" className={footerLink}>
                   <ThirtySevenSignalsMark className="mr-[3px] inline-block size-4 shrink-0 align-[-0.28em]" />
                   37signals
                 </a>
               </p>
               <p data-quiet>
                 {t('Hosting by')}{' '}
-                <a href="https://cloudflare.com" className={creditLink}>
+                <a href="https://cloudflare.com" className={footerLink}>
                   <CloudflareMark className="mr-[5px] inline-block h-3 w-auto shrink-0 align-[-0.15em]" />
                   Cloudflare
                 </a>
               </p>
               <p data-quiet>
                 {t('Compute by')}{' '}
-                <a href="https://www.digitalocean.com" className={creditLink}>
+                <a href="https://www.digitalocean.com" className={footerLink}>
                   <DigitalOceanMark className="mr-[5px] inline-block size-4 shrink-0 align-[-0.2em]" />
                   DigitalOcean
                 </a>
@@ -177,7 +176,7 @@ export function SiteFooter({ path }: { path: string }) {
 
         <nav
           aria-label={t('Language')}
-          className="mt-8 flex flex-wrap gap-x-4 gap-y-2 text-sm"
+          className="mt-12 flex flex-wrap gap-x-4 gap-y-2 text-sm"
         >
           {sortedLocales
             .filter(([code]) => hasTranslation(code, currentPath))

--- a/src/pages/doctrine.astro
+++ b/src/pages/doctrine.astro
@@ -1,0 +1,44 @@
+---
+import Base from '../layouts/Base.astro'
+import { PageHeading } from '../components/PageHeading'
+import { compiledContent } from '../../content/doctrine.md'
+
+// Present clean, linked titles while keeping the numbered Markdown as the source.
+const html = (await compiledContent()).replace(
+  /<h2 id="\d+-([^"]+)">\d+\. ([\s\S]*?)\.?<\/h2>/g,
+  '<h2 id="$1"><a href="#$1">$2</a></h2>',
+)
+---
+
+<Base
+  title="The Omarchy Doctrine"
+  description="Ten principles behind Omarchy. Unite the nerds. Hold the line. Have some fun. Build the perfect computer."
+  path="/doctrine/"
+>
+  <main class="mx-auto max-w-3xl px-4 py-8 sm:px-6" lang="en">
+    <PageHeading title="Doctrine by DHH" />
+    <article class="prose ported doctrine" aria-label="The Omarchy Doctrine" set:html={html} />
+  </main>
+</Base>
+
+<style>
+  .doctrine :global(h2) {
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.75rem;
+    letter-spacing: normal;
+    margin-bottom: 0.5em;
+  }
+
+  .doctrine :global(h2:not(:first-child)) {
+    margin-top: 2.75em;
+  }
+
+  .doctrine :global(h2 a),
+  .doctrine :global(h2 a:hover) {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: var(--color-border-strong);
+    transition: none;
+  }
+</style>


### PR DESCRIPTION
Add `/doctrine/` to present the ten Omarchy principles using the shared wordmark, narrow reading column, and news-sized headings. Each heading has a stable anchor and permanent underline, and the closing sentence links to DHH's tweet. The copy lives in `content/doctrine.md`.

Introduce the doctrine in the homepage's opening copy and link it from the footer's Community column. Shorten the Foundation link to AIR, balance the spacing around the languages, and give footer text links matching theme-accent text and underlines on hover.

Validation: lint, typecheck, tests, production build, and route parity. Verified all ten principles, heading anchors, the tweet link, and homepage/footer links in the rendered HTML.
