### PR TITLE
Add Russian site locale

### DIFF
--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -232,6 +232,14 @@
     "ogLocale": "nb_NO",
     "manual": false
   },
+  "ru": {
+    "name": "Русский",
+    "domain": "https://ru.omarchy.org",
+    "formatLocale": "ru-RU",
+    "ogLocale": "ru_RU",
+    "manual": false,
+    "flag": "RU"
+  },
   "en-NZ": {
     "name": "English (NZ)",
     "domain": "https://omarchy.nz",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -1,0 +1,6 @@
+{
+  "Workstation photo viewer": "Просмотр фото",
+  "Close photo viewer": "Закрыть просмотр",
+  "Previous photo": "Предыдущее фото",
+  "Next photo": "Следующее фото"
+}


### PR DESCRIPTION
First Russian locale for the site: registers `ru` in `src/i18n/locales.json` (proposed domain https://ru.omarchy.org, following the subdomain pattern of the other recent locales — happy to change it to whatever the maintainers prefer) and adds `src/i18n/messages/ru.json` with the translated UI strings.

Related system-localization work (shell menu, shell/CLI catalogs, Russian pack): omacom/omarchy#8765.