### PR TITLE
Map Urdu locale to omarchy.pk

### DIFF
--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -240,9 +240,7 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "NZ",
-    "aliases": [
-      "www.omarchy.nz"
-    ]
+    "aliases": ["www.omarchy.nz"]
   },
   "en-US": {
     "name": "English (US)",
@@ -252,9 +250,7 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "US",
-    "aliases": [
-      "www.omarchy.us"
-    ]
+    "aliases": ["www.omarchy.us"]
   },
   "en-SG": {
     "name": "English (SG)",
@@ -264,9 +260,7 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "SG",
-    "aliases": [
-      "www.omarchy.sg"
-    ]
+    "aliases": ["www.omarchy.sg"]
   },
   "en-AU": {
     "name": "English (AU)",

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -122,7 +122,7 @@
   },
   "ur": {
     "name": "اردو",
-    "domain": "https://ur.omarchy.org",
+    "domain": "https://omarchy.pk",
     "formatLocale": "ur-PK",
     "ogLocale": "ur_PK",
     "manual": false,
@@ -240,7 +240,9 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "NZ",
-    "aliases": ["www.omarchy.nz"]
+    "aliases": [
+      "www.omarchy.nz"
+    ]
   },
   "en-US": {
     "name": "English (US)",
@@ -250,7 +252,9 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "US",
-    "aliases": ["www.omarchy.us"]
+    "aliases": [
+      "www.omarchy.us"
+    ]
   },
   "en-SG": {
     "name": "English (SG)",
@@ -260,7 +264,9 @@
     "manual": false,
     "contentLocale": "en",
     "flag": "SG",
-    "aliases": ["www.omarchy.sg"]
+    "aliases": [
+      "www.omarchy.sg"
+    ]
   },
   "en-AU": {
     "name": "English (AU)",


### PR DESCRIPTION
## Summary
Points the Urdu (`ur`) locale at `https://omarchy.pk`.

Opened after DHH asked for a PR so Pakistan’s `.pk` domain can serve the Urdu site. Today Urdu is on `ur.omarchy.org`; `omarchy.pk` exists but doesn’t serve Urdu yet.

## Change
- `src/i18n/locales.json`: set `ur.domain` to `https://omarchy.pk`

## DNS note
- `ur.omarchy.org` → 200 (Urdu)
- `omarchy.pk` → 302 to English `omarchy.org`
- Both are on Cloudflare, but `omarchy.pk` uses a **different nameserver pair** (`lloyd` / `molly`) than the main Omarchy zone (`eva` / `mario`)

Please confirm Cloudflare/DNS ownership for `.pk` before attaching it as the Urdu primary.

## Test plan
- [ ] Diff only touches `locales.json`
- [ ] After deploy, `omarchy.pk` serves Urdu (not the English redirect)