### PR TITLE
Blur the page behind the search palette like behind the theme picker

### DIFF
--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -163,7 +163,7 @@ export function SearchPalette() {
       <div
         aria-hidden="true"
         onClick={close}
-        className="absolute inset-0 bg-black/55"
+        className="absolute inset-0 bg-black/55 supports-backdrop-filter:backdrop-blur-xs"
       />
 
       <div className="ring-elevation relative flex max-h-[70vh] w-full max-w-2xl flex-col bg-surface">


### PR DESCRIPTION
The theme picker dims and blurs the page behind it; the search palette only dimmed it. Now both open the same way, the same 4 px blur where the browser supports it.

<img width="1715" height="925" alt="image" src="https://github.com/user-attachments/assets/12be2ab1-76bb-454f-8f42-c6d200f4382a" />
