### PR TITLE
Turn the navigation bar into the desktop's menu bar

### DIFF
--- a/src/astro/pages/HomePage.tsx
+++ b/src/astro/pages/HomePage.tsx
@@ -17,7 +17,6 @@ import {
   WindowsIcon,
 } from '@/components/icons'
 import { OmarchyWordmark, WORDMARK_BANDS } from '@/components/Brand'
-import { HeroNavGhost } from '@/components/SiteHeader'
 import { HeroShader } from '@/components/HeroShader'
 import { EtchPicker } from '@/components/EtchPicker'
 import { CardRail } from '@/components/CardRail'
@@ -333,11 +332,6 @@ export function HomePage({ data }: { data: HomeData }) {
       >
         <HeroShader onPainted={() => setPainted(true)} />
         {etchAsked ? <EtchPicker /> : null}
-
-        {/* The bar's labels, blended against the canvas. They have to live in
-            here to reach it: the real header is sticky, and a sticky element
-            isolates everything inside it from the page behind. */}
-        <HeroNavGhost />
 
         <div className="pointer-events-none relative flex flex-1 flex-col items-center px-6">
           <div className="flex-1" />

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { Popover } from '@base-ui/react/popover'
 import { useState } from 'react'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { hasTranslation, language, locale, sortedLocales, t } from '@/i18n/site'
 
@@ -14,7 +15,13 @@ function flag(domain: string, countryCode?: string) {
     : '🌐'
 }
 
-export function LanguageSwitcher({ path }: { path: string }) {
+export function LanguageSwitcher({
+  path,
+  triggerClassName,
+}: {
+  path: string
+  triggerClassName?: string
+}) {
   const [suffix, setSuffix] = useState('')
 
   return (
@@ -31,8 +38,10 @@ export function LanguageSwitcher({ path }: { path: string }) {
             variant="ghost"
             size="icon"
             aria-label={`${t('Language')}: ${locale.name}`}
-            data-nav-glyph
-            className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
+            className={cn(
+              'relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]',
+              triggerClassName,
+            )}
           />
         }
       >

--- a/src/components/NotFoundHero.tsx
+++ b/src/components/NotFoundHero.tsx
@@ -2,7 +2,6 @@ import { t } from '@/i18n/site'
 import { useState } from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { HeroShader } from '@/components/HeroShader'
-import { HeroNavGhost } from '@/components/SiteHeader'
 import { NotFoundWordmark } from '@/components/Brand'
 import { ArrowLeftIcon } from '@/components/icons'
 import {
@@ -26,7 +25,6 @@ export function NotFoundHero() {
   const home = useTopLink()
 
   return (
-    // The header watches this hero sentinel and paints its blended labels here.
     <main>
       <section
         data-hero-sentinel
@@ -38,8 +36,6 @@ export function NotFoundHero() {
           onPainted={() => setPainted(true)}
           onGlyphPress={() => void navigate({ to: '/' })}
         />
-
-        <HeroNavGhost />
 
         <div className="pointer-events-none relative flex flex-1 flex-col items-center px-6">
           <div className="flex-[0.5]" />

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,18 +1,16 @@
-import { t } from '@/i18n/site'
+import { locale, t } from '@/i18n/site'
 import { Link, useLocation } from '@tanstack/react-router'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import type { ReactElement, RefObject } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
 import {
   DownloadIcon,
   GithubIcon,
-  MENU_BARS_FOLD_MS,
   MenuBarsIcon,
   PaletteIcon,
   RssIcon,
   SearchIcon,
 } from '@/components/icons'
-import { OmarchyMarkDrawn, OmarchyWordmark } from '@/components/Brand'
-import { GlobeIcon } from '@/components/icons/GlobeIcon'
+import { OmarchyMarkDrawn } from '@/components/Brand'
 import { LanguageSwitcher } from '@/components/LanguageSwitcher'
 import { MusicMenuControl } from '@/components/MusicControl'
 import { Button } from '@/components/ui/button'
@@ -23,9 +21,8 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useHashLink, useTopLink } from '@/lib/hash-scroll'
-import { OPEN_PICKER_EVENT, THEME_EVENT, groundOf } from '@/lib/theme'
+import { OPEN_PICKER_EVENT } from '@/lib/theme'
 import { OPEN_SEARCH_EVENT } from '@/lib/search'
-import { cn } from '@/lib/utils'
 
 function NavTooltip({
   children,
@@ -42,12 +39,51 @@ function NavTooltip({
       <TooltipContent side="bottom" sideOffset={10}>
         {label}
         {shortcut && (
-          <kbd className="ml-1 rounded border border-current/25 px-1 font-mono text-[11px] opacity-75">
+          <kbd className="ml-1 border border-current/25 px-1 font-mono text-[11px] opacity-75">
             {shortcut}
           </kbd>
         )}
       </TooltipContent>
     </Tooltip>
+  )
+}
+
+/**
+ * The desktop's clock: the weekday and the hour in the visitor's own time,
+ * written the way the site's language writes them, which is what Waybar
+ * shows with `{:L%A %H:%M}`. Rendered empty on the server and filled on the
+ * client, since the server does not know the visitor's zone.
+ */
+function BarClock() {
+  const [now, setNow] = useState<Date | null>(null)
+  useEffect(() => {
+    let timer = 0
+    const tick = () => {
+      const date = new Date()
+      setNow(date)
+      // Wake on the next whole minute rather than every second.
+      timer = window.setTimeout(
+        tick,
+        60_000 - (date.getSeconds() * 1000 + date.getMilliseconds()),
+      )
+    }
+    tick()
+    return () => window.clearTimeout(timer)
+  }, [])
+  if (!now) return <span className="site-bar__clock" aria-hidden="true" />
+  const day = new Intl.DateTimeFormat(locale.formatLocale, {
+    weekday: 'long',
+  }).format(now)
+  // 24 hours whatever the language, as the desktop's clock has it.
+  const time = new Intl.DateTimeFormat(locale.formatLocale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(now)
+  return (
+    <time className="site-bar__clock" dateTime={now.toISOString()}>
+      {day} {time}
+    </time>
   )
 }
 
@@ -59,370 +95,46 @@ const navLinks = [
   { to: '/themes/', label: t('Themes') },
 ] as const
 
-/** Observe the live hero sentinel; the header and blended labels share this state. */
-/** Choose the visible label layer before paint to prevent a navigation flash. */
-const useBeforePaint =
-  typeof document === 'undefined' ? useEffect : useLayoutEffect
-
-function useHeroInView(seed: boolean) {
-  const [heroInView, setHeroInView] = useState(seed)
-
-  useBeforePaint(() => {
-    let observer: IntersectionObserver | null = null
-    let sizeWatcher: ResizeObserver | null = null
-    let settling = 0
-    /** The sentinel currently being observed - the element, not the route.
-     *  On a client-side navigation the pathname changes before the DOM does:
-     *  the outgoing page is still mounted, so an effect keyed on the route
-     *  attaches to the outgoing page's sentinel, and when that node is
-     *  removed a moment later its observer fires one last time with
-     *  isIntersecting false. That false was permanent - the route never
-     *  changes again, so nothing re-attached, and the bar arrived at every
-     *  hero page unblended. Tracking the element makes the swap visible:
-     *  the live sentinel is no longer the watched one, so watch it instead.
-     */
-    let watched: Element | null | undefined
-
-    // The same question the observer answers, asked directly: is the hero's
-    // bottom edge still below the bar's? Asking it at once matters because
-    // the answer is needed on the first frame, and an observer's first
-    // callback is not guaranteed to have arrived by then - or at all, while
-    // the tab is not being rendered. The observer then keeps it current.
-    //
-    // null where nothing has been laid out: an unrendered tab measures every
-    // box at zero, and zero is not "the hero has scrolled away", it is "no
-    // one has asked yet". Answering it would put the bar in the wrong state
-    // with no second measurement coming to correct it.
-    const covers = (hero: Element, bar: Element) => {
-      const barBox = bar.getBoundingClientRect()
-      if (barBox.height === 0) return null
-      return hero.getBoundingClientRect().bottom > barBox.height
-    }
-
-    /**
-     * Take the measurement, and if there is nothing to measure yet, come back
-     * for it. Bounded, because a tab that is never rendered never lays
-     * anything out and would otherwise be asked forever; the observer is
-     * still watching either way, and answers as soon as it is shown.
-     */
-    const settle = (hero: Element, bar: Element, tries = 3) => {
-      const covered = covers(hero, bar)
-      if (covered !== null) {
-        setHeroInView(covered)
-        return
-      }
-      if (tries > 0)
-        settling = requestAnimationFrame(() => settle(hero, bar, tries - 1))
-    }
-
-    const watch = (hero: Element, bar: Element) => {
-      observer?.disconnect()
-      // The moment to swap is when the bar's bottom edge meets the hero's,
-      // which is the one border the hero and the section under it share.
-      // Inset the root by the bar's measured height so the two edges are
-      // compared directly: hardcoding it went off by the bar's border, and
-      // by a whole row on the narrow layout where the nav wraps under.
-      const height = bar.getBoundingClientRect().height
-      observer = new IntersectionObserver(
-        ([entry]) => setHeroInView(entry.isIntersecting),
-        { rootMargin: `-${height}px 0px 0px 0px` },
-      )
-      observer.observe(hero)
-    }
-
-    /**
-     * Point everything at whatever sentinel the page has right now. A no-op
-     * while the watched one is still the live one; a teardown-and-reattach
-     * the moment it is not, whether the page swapped its hero for another or
-     * for nothing. Disconnecting the old observer first also discards any
-     * report it has queued about the node that just left.
-     */
-    const sync = () => {
-      const hero = document.querySelector('[data-hero-sentinel]')
-      if (hero === watched) return
-      observer?.disconnect()
-      sizeWatcher?.disconnect()
-      cancelAnimationFrame(settling)
-      watched = hero
-      const bar = document.querySelector('header')
-      if (!hero || !bar) {
-        // Nothing over the bar right now - which is the right answer both on
-        // a page with no hero and on one whose chunk is still loading, since
-        // the arrivals watcher below re-runs this when a hero does mount.
-        setHeroInView(false)
-        return
-      }
-      settle(hero, bar)
-      watch(hero, bar)
-      // The bar grows a second row of links on narrow screens, so the edge
-      // it is measured against moves with the layout.
-      sizeWatcher = new ResizeObserver(() => watch(hero, bar))
-      sizeWatcher.observe(bar)
-    }
-
-    // Every arrival and departure funnels through sync, which is what lets
-    // this run once for the life of the header instead of once per route:
-    // the DOM says when the hero changes, and the DOM is what is being
-    // watched, so there is nothing for the route to add.
-    const arrivals = new MutationObserver(sync)
-    arrivals.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    })
-    sync()
-
-    return () => {
-      cancelAnimationFrame(settling)
-      observer?.disconnect()
-      sizeWatcher?.disconnect()
-      arrivals.disconnect()
-    }
-  }, [])
-
-  return heroInView
-}
-
-/** Write surface opacity to CSS while scrolling; measure section geometry once per layout. */
-function useNavSurface(
-  sheetOpen: boolean,
-  /** The blended ghost is up behind the bar, so the real labels stand aside. */
-  blended: boolean,
-  bar: RefObject<HTMLElement | null>,
-  /** Re-surveyed on arrival at a new page, whose sections are its own. */
-  pathname: string,
-) {
-  const wasOpen = useRef(sheetOpen)
-  useEffect(() => {
-    const el = bar.current
-    if (!el) return
-    const justClosed = wasOpen.current && !sheetOpen
-    wasOpen.current = sheetOpen
-    // Keep real labels visible until the menu toggle finishes its closing animation.
-    let holding = blended && justClosed
-
-    const solid = (on: boolean) => {
-      // Render the label state as an attribute so it also applies before hydration.
-      if (!on && holding) return
-      if (on) el.removeAttribute('data-nav-blend')
-      else el.setAttribute('data-nav-blend', '')
-      const ghost = document.querySelector<HTMLElement>('[data-nav-ghost]')
-      if (ghost) ghost.style.opacity = on ? '0' : '1'
-    }
-
-    type Ground = { top: number; bottom: number; colour: string }
-    let grounds: Ground[] = []
-    let height = 0
-    /** The hero bottom in page coordinates. */
-    let heroBottom = 0
-    /** The <main> the last survey read. The route changes before the DOM
-     *  does, so the one mounted when this effect runs may be the outgoing
-     *  page's; comparing identities is how the swap is noticed. */
-    let surveyed: Element | null = null
-    let heroUp = false
-    // Read hover state immediately on navigation; only mouse pointers have persistent hover.
-    let hovering =
-      window.matchMedia('(hover: hover)').matches && el.matches(':hover')
-
-    const survey = () => {
-      // Keep the size watcher pointed at whichever <main> is actually
-      // mounted; the one this effect started with may already be gone.
-      const main = document.querySelector('main')
-      if (main !== surveyed) {
-        surveyed = main
-        sizes.disconnect()
-        if (main) sizes.observe(main)
-      }
-      const hero = document.querySelector('[data-hero-sentinel]')
-      heroUp = hero !== null
-      heroBottom = hero
-        ? hero.getBoundingClientRect().bottom + window.scrollY
-        : 0
-      height = el.getBoundingClientRect().height
-      const sections = document.querySelectorAll<HTMLElement>(
-        'main > section, main [data-ground]',
-      )
-      const nodes = sections.length
-        ? [...sections]
-        : [...document.querySelectorAll<HTMLElement>('main')]
-
-      const footer = document.querySelector<HTMLElement>('footer')
-      if (footer) nodes.push(footer)
-
-      grounds = nodes
-        .filter((node) => !node.hasAttribute('data-hero-sentinel'))
-        .map((node) => {
-          const box = node.getBoundingClientRect()
-          return {
-            top: box.top + window.scrollY,
-            bottom: box.bottom + window.scrollY,
-            colour: groundOf(node) ?? 'var(--color-bg)',
-          }
-        })
-      return grounds.length > 0
-    }
-
-    /**
-     * The bar carries a section's colour only while it is wholly inside that
-     * section: from the moment its own top edge meets the section's top, to
-     * the moment its bottom edge meets the section's bottom. Outside that -
-     * which is exactly while a boundary is crossing it - it carries nothing.
-     *
-     * Both switches happen at the instant the fill and the thing behind it are
-     * the same colour, so neither is visible. What you see instead is a bar
-     * that hides the page sliding under it, and lets a section edge pass
-     * through in the open.
-     *
-     * Cheap enough to run straight from the scroll event: it reads scrollY,
-     * which costs no layout, and compares it against numbers taken once.
-     */
-    /** The innermost ground at a point down the page, or none. */
-    const groundAt = (y: number) => {
-      let found: Ground | null = null
-      for (const g of grounds) if (y >= g.top && y < g.bottom) found = g
-      return found
-    }
-
-    // On a phone the bar is never bare past the hero. Going bare lets
-    // whatever is scrolling under the bar show straight through it for the
-    // moment a section edge is crossing, which behind the wordmark read as
-    // a leak. The edge still passes through pixel by pixel: while it is
-    // inside the bar, the bar paints the upper section's colour down to the
-    // edge and the lower section's below it, both at the usual 90% over the
-    // blur, and the split moves with the scroll.
-    const phone = window.matchMedia('(max-width: 639.98px)')
-    const wash = (colour: string) =>
-      `color-mix(in srgb, ${colour} 90%, transparent)`
-
-    const paint = () => {
-      const y = window.scrollY
-      const top = groundAt(y)
-      const bottom = groundAt(y + height)
-      const whole = top && top === bottom ? top : null
-      const here = phone.matches ? (top ?? bottom) : whole
-      let image = ''
-      let fill = '1'
-      if (phone.matches && !sheetOpen && top !== bottom) {
-        const edge =
-          top && bottom
-            ? Math.min(top.bottom, bottom.top > y ? bottom.top : Infinity)
-            : top
-              ? top.bottom
-              : bottom!.top
-        const split = Math.round(edge - y)
-        const above = top ? wash(top.colour) : 'transparent'
-        const below = bottom ? wash(bottom.colour) : 'transparent'
-        image = `linear-gradient(to bottom, ${above} ${split}px, ${below} ${split}px)`
-        fill = '0'
-      }
-      el.style.backgroundImage = image
-      el.style.setProperty('--nav-fill', fill)
-      if (here) el.style.setProperty('--nav-ground', here.colour)
-      else if (!heroUp) el.style.setProperty('--nav-ground', 'var(--color-bg)')
-      el.style.setProperty('--nav-surface', here || !heroUp ? '1' : '0')
-      el.toggleAttribute(
-        'data-nav-past-hero',
-        !heroUp || (phone.matches ? y + height : y) >= heroBottom,
-      )
-      // The ghost holds the labels for as long as it is up, and hovering hands
-      // them over early: it sits under the bar and cannot answer a pointer.
-      solid(sheetOpen || !blended || hovering)
-    }
-
-    const hold = holding
-      ? window.setTimeout(() => {
-          holding = false
-          paint()
-        }, MENU_BARS_FOLD_MS)
-      : 0
-
-    const onEnter = (event: PointerEvent) => {
-      if (event.pointerType !== 'mouse') return
-      hovering = true
-      paint()
-    }
-    const onLeave = (event: PointerEvent) => {
-      if (event.pointerType !== 'mouse') return
-      hovering = false
-      paint()
-    }
-
-    const relayout = () => {
-      survey()
-      paint()
-    }
-
-    // Arriving at /#install, the page is moved to the anchor by whatever
-    // handles the hash, which may be before this attaches - and a scroll that
-    // has already happened sends no event to catch up on. One more pass once
-    // the current task is done reads wherever the page actually ended up.
-    const settle = window.setTimeout(relayout, 0)
-
-    // Sections grow as images and fonts land, which moves every edge below.
-    // survey() points this at the mounted <main>, and re-points it when the
-    // page under the bar is swapped for another.
-    const sizes = new ResizeObserver(relayout)
-
-    // The page mounts async on a client-side navigation, so wait for it.
-    let probe = 0
-    const wait = () => {
-      if (survey()) {
-        paint()
-        return
-      }
-      probe = requestAnimationFrame(wait)
-    }
-    wait()
-
-    // Observe DOM swaps because route updates can precede the incoming page mounting.
-    const arrivals = new MutationObserver(() => {
-      if (document.querySelector('main') !== surveyed) relayout()
-    })
-    arrivals.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    })
-
-    el.addEventListener('pointerenter', onEnter)
-    el.addEventListener('pointerleave', onLeave)
-    phone.addEventListener('change', paint)
-    window.addEventListener('scroll', paint, { passive: true })
-    window.addEventListener('resize', relayout)
-    // Each ground's colour is read once and held, so a theme has to say when
-    // it has changed or the bar keeps the last one until the next scroll.
-    window.addEventListener(THEME_EVENT, relayout)
-    return () => {
-      cancelAnimationFrame(probe)
-      window.clearTimeout(settle)
-      window.clearTimeout(hold)
-      arrivals.disconnect()
-      sizes.disconnect()
-      el.removeEventListener('pointerenter', onEnter)
-      el.removeEventListener('pointerleave', onLeave)
-      phone.removeEventListener('change', paint)
-      el.style.backgroundImage = ''
-      el.style.removeProperty('--nav-fill')
-      window.removeEventListener('scroll', paint)
-      window.removeEventListener('resize', relayout)
-      window.removeEventListener(THEME_EVENT, relayout)
-    }
-  }, [sheetOpen, blended, bar, pathname])
-}
-
+/**
+ * The desktop's bar, brought to the web: the mark and the page links on the
+ * left like workspaces, a tray of actions on the right. One opaque surface
+ * in the theme's own colours at every scroll position, over the hero too.
+ */
 export function SiteHeader({ path = '/' }: { path?: string }) {
   const { pathname } = useLocation({ serverPath: path })
-  const heroInView = useHeroInView(pathname === '/')
   const [menuOpen, setMenuOpen] = useState(false)
+  const toggle = useRef<HTMLButtonElement>(null)
   const installLink = useHashLink('install')
   const homeLink = useTopLink()
-  const transparent = heroInView
+
+  const currentPage = (to: string) => {
+    const current = pathname.replace(/\/+$/, '') || '/'
+    const target = to.replace(/\/+$/, '') || '/'
+    if (current === target) return 'page' as const
+    if (current.startsWith(`${target}/`)) return 'location' as const
+    return undefined
+  }
 
   useEffect(() => setMenuOpen(false), [pathname])
   useEffect(() => {
     if (!menuOpen) return
-    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setMenuOpen(false)
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      setMenuOpen(false)
+      toggle.current?.focus()
+    }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [menuOpen])
+  // The sheet only exists on a phone; widening past it leaves it closed.
+  useEffect(() => {
+    const wide = window.matchMedia('(min-width: 640px)')
+    const sync = () => {
+      if (wide.matches) setMenuOpen(false)
+    }
+    wide.addEventListener('change', sync)
+    return () => wide.removeEventListener('change', sync)
+  }, [])
   useEffect(() => {
     const root = document.documentElement
     if (menuOpen) root.dataset.navMenu = 'open'
@@ -431,32 +143,16 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
       delete root.dataset.navMenu
     }
   }, [menuOpen])
-  const bar = useRef<HTMLDivElement>(null)
-  // Continue tracking section colors after the hero leaves the viewport.
-  useNavSurface(menuOpen, transparent, bar, pathname)
-
-  const glyph = (
-    <Link
-      to="/"
-      aria-label={t('Omarchy home')}
-      onClick={homeLink}
-      className="mark-draw-trigger relative flex items-center"
-    >
-      <OmarchyMarkDrawn className="size-[22px] shrink-0 transition-opacity duration-150 ease-out max-sm:group-data-[nav-past-hero]/bar:opacity-0 lg:size-[calc(var(--pxc)*2)]" />
-      <OmarchyWordmark className="absolute top-1/2 left-0 w-28 -translate-y-1/2 text-brand opacity-0 transition-opacity duration-150 ease-out group-data-[nav-past-hero]/bar:opacity-100 sm:hidden" />
-    </Link>
-  )
 
   const search = (
     <Button
       variant="ghost"
       size="icon"
       aria-label={t('Search Omarchy')}
-      data-nav-glyph
-      className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
+      className="site-bar__icon"
       onClick={() => window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))}
     >
-      <SearchIcon className="size-5" />
+      <SearchIcon />
     </Button>
   )
 
@@ -465,158 +161,135 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
       variant="ghost"
       size="icon"
       aria-label={t('Change website theme')}
-      data-nav-glyph
-      className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
+      className="site-bar__icon"
       onClick={() => window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))}
     >
-      <PaletteIcon className="size-5" />
-    </Button>
-  )
-
-  const install = (
-    <Button
-      className="relative h-8 px-4 before:absolute before:-inset-y-1.5 lg:h-[calc(var(--pxr)*3)]"
-      nativeButton={false}
-      onClick={installLink}
-      render={<Link to="/" hash="install" />}
-    >
-      {t('Install')}
+      <PaletteIcon />
     </Button>
   )
 
   return (
-    <header dir="ltr" className="pixel-container sticky top-0 z-(--z-nav)">
-      <div
-        ref={bar}
-        data-nav-blend={transparent ? '' : undefined}
-        // With the sheet down, the bar is the top of the sheet and wears its
-        // ground rather than the section's: taking a colour from the page
-        // behind it would put a seam across the one surface being looked at.
-        className={cn('group/bar', menuOpen && 'bg-bg/95 backdrop-blur-lg')}
-        style={{
-          // On the bar rather than the header, so both the surface it paints
-          // and the height the hooks measure include the strip above it.
-          paddingTop: 'env(safe-area-inset-top)',
-          backgroundColor: menuOpen
-            ? undefined
-            : 'color-mix(in srgb, var(--nav-ground, var(--color-bg)) calc(var(--nav-surface, 0) * var(--nav-fill, 1) * 90%), transparent)',
-          // Keep blur off over the hero so its pixels stay sharp.
-          backdropFilter: menuOpen
-            ? undefined
-            : 'blur(calc(var(--nav-surface, 0) * 12px))',
-        }}
-      >
-        <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
-          {glyph}
+    <header dir="ltr" className="site-bar sticky top-0 z-(--z-nav)">
+      <div className="site-bar__row">
+        <Link
+          to="/"
+          aria-label={t('Omarchy home')}
+          onClick={(event) => {
+            setMenuOpen(false)
+            homeLink(event)
+          }}
+          className="site-bar__home mark-draw-trigger"
+        >
+          <OmarchyMarkDrawn className="site-bar__mark" />
+        </Link>
 
-          <nav
-            data-nav-links
-            aria-label={t('Main')}
-            className="hidden items-center sm:flex"
-          >
-            {navLinks.map((link) =>
-              'href' in link ? (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  className="px-3 py-1.5 text-sm whitespace-nowrap text-text-secondary transition-[background-color] duration-150 ease-out hover:bg-surface-2 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                >
-                  {link.label}
-                </a>
-              ) : (
-                <Link
-                  key={link.label}
-                  to={link.to}
-                  className="px-3 py-1.5 text-sm whitespace-nowrap text-text-secondary transition-[background-color] duration-150 ease-out hover:bg-surface-2 hover:text-text focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                  activeProps={{ className: 'text-text bg-surface-2' }}
-                >
-                  {link.label}
-                </Link>
-              ),
-            )}
-          </nav>
+        <nav aria-label={t('Main')} className="site-bar__pages hidden sm:flex">
+          {navLinks.map((link) =>
+            'href' in link ? (
+              <a key={link.label} href={link.href} className="site-bar__page">
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.label}
+                to={link.to}
+                className="site-bar__page"
+                aria-current={currentPage(link.to)}
+              >
+                {link.label}
+              </Link>
+            ),
+          )}
+        </nav>
 
-          <div className="ml-auto flex items-center gap-2.5">
-            <div className="hidden items-center gap-1 sm:flex">
-              <TooltipProvider delay={300}>
-                <NavTooltip label={t('Search Omarchy')} shortcut="⌘K / Ctrl+K">
-                  {search}
-                </NavTooltip>
-                <NavTooltip label={t('Change website theme')} shortcut="T">
-                  {theme}
-                </NavTooltip>
-                <LanguageSwitcher path={pathname} />
-                <NavTooltip label={t('Subscribe via RSS')}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t('Omarchy RSS feed')}
-                    data-nav-glyph
-                    className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-                    nativeButton={false}
-                    render={<a href="/news/rss.xml" />}
-                  >
-                    <RssIcon className="size-5" />
-                  </Button>
-                </NavTooltip>
-                <NavTooltip label={t('View Omarchy on GitHub')}>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={t('Omarchy on GitHub')}
-                    data-nav-glyph
-                    className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-                    nativeButton={false}
-                    render={<a href="https://github.com/omacom/omarchy" />}
-                  >
-                    <GithubIcon className="size-5" />
-                  </Button>
-                </NavTooltip>
-              </TooltipProvider>
-              <span className="ml-2 flex">{install}</span>
-            </div>
-            <div className="flex items-center gap-1 sm:hidden">
+        <div className="site-bar__center" aria-hidden="true">
+          <BarClock />
+        </div>
+
+        <div className="site-bar__tray ml-auto hidden sm:flex">
+          <TooltipProvider delay={300}>
+            <NavTooltip label={t('Search Omarchy')} shortcut="⌘K / Ctrl+K">
+              {search}
+            </NavTooltip>
+            <NavTooltip label={t('Change website theme')} shortcut="T">
               {theme}
-              <LanguageSwitcher path={pathname} />
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              data-nav-toggle
-              className="relative size-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 sm:hidden"
-              aria-expanded={menuOpen}
-              aria-controls="site-menu"
-              aria-label={menuOpen ? 'Close menu' : 'Menu'}
-              onClick={() => setMenuOpen((open) => !open)}
-            >
-              <MenuBarsIcon open={menuOpen} className="size-[22px]" />
-            </Button>
-          </div>
+            </NavTooltip>
+            <LanguageSwitcher
+              path={pathname}
+              triggerClassName="site-bar__icon"
+            />
+            <NavTooltip label={t('Subscribe via RSS')}>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Omarchy RSS feed')}
+                className="site-bar__icon"
+                nativeButton={false}
+                render={<a href="/news/rss.xml" />}
+              >
+                <RssIcon />
+              </Button>
+            </NavTooltip>
+            <NavTooltip label={t('View Omarchy on GitHub')}>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t('Omarchy on GitHub')}
+                className="site-bar__icon"
+                nativeButton={false}
+                render={<a href="https://github.com/omacom/omarchy" />}
+              >
+                <GithubIcon />
+              </Button>
+            </NavTooltip>
+          </TooltipProvider>
+          <span className="site-bar__separator" aria-hidden="true" />
+          <Button
+            variant="ghost"
+            className="site-bar__install"
+            nativeButton={false}
+            onClick={installLink}
+            render={<Link to="/" hash="install" />}
+          >
+            <DownloadIcon aria-hidden="true" />
+            {t('Install')}
+          </Button>
+        </div>
+
+        <div className="ml-auto flex items-center sm:hidden">
+          {theme}
+          <LanguageSwitcher path={pathname} triggerClassName="site-bar__icon" />
+          <Button
+            ref={toggle}
+            variant="ghost"
+            size="icon"
+            className="site-bar__toggle"
+            aria-expanded={menuOpen}
+            aria-controls="site-menu"
+            aria-label={menuOpen ? 'Close menu' : 'Menu'}
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            <MenuBarsIcon open={menuOpen} className="size-5" />
+          </Button>
         </div>
       </div>
-      {/* Tapping the page behind the sheet closes it. The header is an
-          inline-size container, so it is the containing block for fixed
-          children as well - bottom-0 would resolve to the bar's own 56px, and
-          the scrim is sized explicitly instead. Dimmed and blurred the way
-          the search and the theme picker dim the page, so the three open
-          alike; a wash of the page's own colour barely showed on a dark
-          theme. */}
+
+      {/* Tapping the page behind the sheet closes it. */}
       {menuOpen ? (
         <div
           data-menu-scrim
           aria-hidden="true"
           onClick={() => setMenuOpen(false)}
-          className="absolute inset-x-0 top-(--nav-h) h-svh bg-black/55 supports-backdrop-filter:backdrop-blur-xs sm:hidden"
+          className="fixed inset-x-0 top-(--nav-h) bottom-0 bg-black/55 supports-backdrop-filter:backdrop-blur-xs sm:hidden"
         />
       ) : null}
 
       {/* Overlaid, not stacked: pushing the page down would change the bar's
           height and with it the hero's offsets. */}
-
       <div
         id="site-menu"
         hidden={!menuOpen}
-        className="absolute inset-x-0 top-(--nav-h) border-b border-border-subtle bg-bg/95 backdrop-blur-lg sm:hidden"
+        className="site-bar__menu absolute inset-x-0 top-full border-b border-border-subtle bg-bg sm:hidden"
       >
         <nav
           aria-label={t('Main pages')}
@@ -628,7 +301,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
                 key={link.label}
                 href={link.href}
                 onClick={() => setMenuOpen(false)}
-                className="py-3 text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                className="site-bar__menu-link"
               >
                 {link.label}
               </a>
@@ -637,8 +310,8 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
                 key={link.label}
                 to={link.to}
                 onClick={() => setMenuOpen(false)}
-                className="py-3 text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                activeProps={{ className: 'text-text font-medium' }}
+                className="site-bar__menu-link"
+                aria-current={currentPage(link.to)}
               >
                 {link.label}
               </Link>
@@ -650,7 +323,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
               setMenuOpen(false)
               window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))
             }}
-            className="mt-2 flex items-center gap-2.5 border-t border-border-subtle py-3 pt-4 text-left text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            className="site-bar__menu-link mt-2 flex items-center gap-2.5 border-t border-border-subtle"
           >
             <SearchIcon className="size-5" />
             {t('Search Omarchy')}
@@ -661,7 +334,7 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
               setMenuOpen(false)
               window.dispatchEvent(new CustomEvent(OPEN_PICKER_EVENT))
             }}
-            className="flex items-center gap-2.5 py-3 text-left text-[15px] text-text-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            className="site-bar__menu-link flex items-center gap-2.5"
           >
             <PaletteIcon className="size-5" />
             {t('Change the theme')}
@@ -702,89 +375,5 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
         </nav>
       </div>
     </header>
-  )
-}
-
-/** Render inside the hero stacking context so labels can blend with its canvas. */
-export function HeroNavGhost() {
-  // Use the header's shared hero state to keep both label layers synchronized.
-  return (
-    <div
-      aria-hidden="true"
-      dir="ltr"
-      data-nav-ghost
-      className="pointer-events-none fixed inset-x-0 top-0 z-(--z-nav) mix-blend-difference"
-      // The header hydrates before the hero does, and its effect writes this
-      // node's opacity in between - 1 with the hero up, 0 with the page
-      // reloaded further down, or the pointer already resting on the bar, or
-      // on a phone. React then hydrates this node against whichever value it
-      // found. Declaring the property keeps React from reporting an inline
-      // style it never rendered; suppressing the warning covers the loads
-      // where the effect's answer was 0. React does not patch attributes on
-      // a mismatch, so the effect's value, the right one, is what stays.
-      style={{ paddingTop: 'env(safe-area-inset-top)', opacity: 1 }}
-      suppressHydrationWarning
-    >
-      <div className="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:px-6">
-        <span className="flex items-center">
-          <span className="block size-[22px] shrink-0 lg:size-[calc(var(--pxc)*2)]" />
-        </span>
-
-        <span className="hidden items-center sm:flex">
-          {navLinks.map((link) => (
-            <span
-              key={link.label}
-              className="px-3 py-1.5 text-sm whitespace-nowrap"
-              style={{ color: 'var(--t-hdr-text-2)' }}
-            >
-              {link.label}
-            </span>
-          ))}
-        </span>
-
-        <span className="ml-auto flex items-center gap-2.5">
-          <span
-            className="hidden items-center gap-1 sm:flex"
-            style={{ color: 'var(--t-hdr-text-2)' }}
-          >
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <SearchIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <PaletteIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <GlobeIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <RssIcon className="size-5" />
-            </span>
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <GithubIcon className="size-5" />
-            </span>
-            {/* Install holds its own colours, so the ghost only holds its
-                place - same box, same type metrics, nothing painted. The
-                border is part of the box: the real button wears a 1px
-                transparent one, and without it here the ghost's icons sat
-                2px to the right of the real ones, so every swap between
-                the two layers read as a wiggle. */}
-            <span
-              aria-hidden="true"
-              className="ml-2 inline-flex h-8 items-center border border-transparent px-4 text-sm font-medium lg:h-[calc(var(--pxr)*3)]"
-              style={{ color: 'transparent' }}
-            >
-              {t('Install')}
-            </span>
-          </span>
-
-          <span
-            className="flex size-8 items-center justify-center sm:hidden"
-            style={{ color: 'var(--t-hdr-text-2)' }}
-          >
-            <MenuBarsIcon className="size-[22px]" />
-          </span>
-        </span>
-      </div>
-    </div>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -964,9 +964,16 @@ body,
   font-family: var(--font-mono);
 }
 
-/* Shared height for the sticky bar, hero offset, and mobile menu. */
+/* Shared height for the sticky bar, hero offset, and mobile menu. The row
+   is a touch taller than the desktop's 26px; fingers get 44px. */
 :root {
-  --nav-h: calc(3.5rem + env(safe-area-inset-top, 0px));
+  --nav-row-h: 2rem;
+  --nav-h: calc(var(--nav-row-h) + 1px + env(safe-area-inset-top, 0px));
+}
+@media (width < 40rem), (any-pointer: coarse) {
+  :root {
+    --nav-row-h: 2.75rem;
+  }
 }
 
 body {
@@ -982,13 +989,10 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-/* Sticky stacking contexts prevent blending with the hero; labels blend inside the hero instead. */
 /* The hero field's cell size, derived in pure CSS: the wordmark slot is
    88% of the padded container capped at 896px, split into 81 columns,
    which is exactly the lattice the canvas draws. Elements sized with
-   --pxc multiples fit the grid with no runtime measurement at all. The
-   header and the hero section are both containers of the same width, so
-   the value agrees across them. */
+   --pxc multiples fit the grid with no runtime measurement at all. */
 .pixel-container {
   container-type: inline-size;
 }
@@ -1127,24 +1131,189 @@ h6 {
   }
 }
 
-/* Hide real labels while the blended copy is visible to avoid double painting. */
-[data-nav-blend] [data-nav-links] a,
-[data-nav-blend] [data-nav-glyph],
-[data-nav-blend] [data-nav-toggle] {
-  color: transparent;
+/* Omarchy's bar: one opaque theme surface, monospace labels, the current
+   page marked like a workspace, a tray of actions on the right. */
+.site-bar {
+  padding-top: env(safe-area-inset-top, 0px);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: 400 12px/1 var(--font-mono);
 }
 
-/* No active or hover chip while labels are blended. The ghost's colour is compensated
-   against the field behind the bar; a chip is not the field, so a label
-   painted through one comes out near enough black. Hovering hands the labels
-   back to the real layer anyway - this is only here so that the two can never
-   be seen in the same frame. */
-[data-nav-blend] [data-nav-links] a,
-[data-nav-blend] [data-nav-glyph]:hover,
-[data-nav-blend] [data-nav-glyph][aria-expanded='true'],
-[data-nav-blend] [data-nav-toggle]:hover {
-  background-color: transparent;
-  transition: none;
+.site-bar__row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: var(--nav-row-h);
+  padding-inline: 8px;
+}
+
+/* Centred on the bar like Waybar's middle modules, not on the space the
+   sides leave over. A phone's bar has no such room, so it goes without. */
+.site-bar__center {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  z-index: -1;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  height: var(--nav-row-h);
+  pointer-events: none;
+}
+
+@media (width >= 40rem) {
+  .site-bar__center {
+    display: flex;
+  }
+}
+
+.site-bar__clock {
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.site-bar__home,
+.site-bar__page,
+.site-bar__icon,
+.site-bar__install,
+.site-bar__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: var(--nav-row-h);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  white-space: nowrap;
+  transition:
+    background-color 120ms ease-out,
+    color 120ms ease-out;
+}
+
+.site-bar__home,
+.site-bar__icon,
+.site-bar__toggle {
+  width: var(--nav-row-h);
+  padding: 0;
+}
+
+.site-bar__home {
+  color: var(--color-brand);
+}
+
+.site-bar__mark {
+  width: 22px;
+  height: 22px;
+}
+
+.site-bar__pages {
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+}
+
+.site-bar__page {
+  position: relative;
+  padding-inline: 11px;
+}
+
+.site-bar__home:hover,
+.site-bar__page:hover,
+.site-bar__icon:hover,
+.site-bar__install:hover,
+.site-bar__toggle:hover,
+.site-bar__menu-link:hover {
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
+  color: var(--color-text);
+}
+
+.site-bar__page[aria-current],
+.site-bar__menu-link[aria-current] {
+  background: color-mix(in srgb, var(--color-text) 18%, transparent);
+  color: var(--color-text);
+}
+
+.site-bar__page[aria-current]::after {
+  position: absolute;
+  right: 11px;
+  bottom: 3px;
+  left: 11px;
+  height: 1px;
+  background: var(--color-brand);
+  content: '';
+}
+
+/* Inset, because the bar's controls are no taller than its row. */
+.site-bar
+  :is(
+    .site-bar__home,
+    .site-bar__page,
+    .site-bar__icon,
+    .site-bar__install,
+    .site-bar__toggle,
+    .site-bar__menu-link
+  ):focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: -2px;
+}
+
+/* The text ink contrasts with the current-page fill in every theme; the
+   accent does not. */
+.site-bar
+  :is(.site-bar__page, .site-bar__menu-link)[aria-current]:focus-visible {
+  outline-color: var(--color-text);
+}
+
+.site-bar__tray {
+  align-items: center;
+  gap: 2px;
+}
+
+.site-bar__icon svg,
+.site-bar__install svg {
+  width: 15px;
+  height: 15px;
+}
+
+.site-bar__separator {
+  width: 1px;
+  height: 14px;
+  margin-inline: 7px;
+  background: var(--color-border-strong);
+}
+
+.site-bar__install {
+  gap: 7px;
+  padding-inline: 8px;
+  color: var(--color-text);
+}
+
+.site-bar__menu {
+  max-height: calc(100dvh - var(--nav-h));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.site-bar__menu-link {
+  min-height: 44px;
+  padding: 12px;
+  color: var(--color-text-secondary);
+  text-align: left;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-bar :is(a, button) {
+    transition: none;
+  }
 }
 
 /* A full-bleed rail's own scrollbar would run the whole window width. These
@@ -2116,12 +2285,6 @@ h6 {
 @media (prefers-reduced-motion: reduce) {
   .hero-canvas-in {
     animation: none;
-  }
-}
-
-@media (max-width: 639.98px) {
-  html:not([data-nav-menu='open']) [data-nav-past-hero] {
-    box-shadow: inset 0 -1px 0 var(--color-border-subtle);
   }
 }
 


### PR DESCRIPTION
The navigation bar becomes the desktop's bar: one opaque surface in the theme's own colors at every scroll position, monospace labels, the mark and the page links on the left like workspaces, the current page marked with a fill and a brand underline, a tray of actions on the right with Install as a text action, and the clock in the middle on desktop in the visitor's own time, weekday and hour the way Waybar writes them in the site's language. 8px to the edges like the desktop's bar; 32 px tall with a mouse, 44px on a phone or with touch.

This is the menu bar from #203 by @HANCORE-linux, rebuilt on master without the hero announcement. The blended label layer over the hero goes with it: no ghost copy in the hero, no section color tracking, no surface fade. The hero keeps its sentinel and offsets, the mobile sheet keeps its items.

Supersedes #321 if merged, since the bar always has its surface now.