### PR TITLE
Support theme selection through URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ The screensaver and the Discord redirect are still served
 directly. Their styles, fonts, and scripts remain under `assets/`, alongside
 shared images and public downloads.
 
+## Opening a page in a theme
+
+Add a supported site theme ID to any site page, for example:
+<https://omarchy.org/doctrine/?theme=catppuccin#beauty-is-truth>.
+This lets the Omarchy CLI open documentation in the desktop's current theme.
+URL themes do not overwrite the saved preference. Empty or unsupported values
+behave like a missing parameter.
+
+The palette stays active during client-side navigation, including back/forward.
+A destination with a valid `theme` replaces it; destinations without one keep
+it. Choosing a theme in the picker saves that preference and removes `theme`
+from the current URL, preserving other parameters and the section anchor—even
+when choosing the already active theme. Older history entries with an explicit
+valid theme can activate it again. A fresh load without `theme` uses the saved
+preference or the site's existing system-color-scheme fallback.
+
 ## Adding your theme
 
 Community themes are listed on [omarchy.org/themes](https://omarchy.org/themes/).

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -13,6 +13,7 @@ import {
   PICKER_STATE_EVENT,
   SITE_THEMES,
   switchTheme,
+  applyTheme,
   paintFavicon,
   watchChrome,
   readTheme,
@@ -97,6 +98,7 @@ export function ThemePicker() {
   const choose = useCallback(() => {
     const next = SITE_THEMES[indexRef.current]
     if (next.id === readTheme()) {
+      applyTheme(next.id)
       close()
       return
     }
@@ -142,7 +144,7 @@ export function ThemePicker() {
     }
   }, [open, openPicker, close])
 
-  // The stored theme is stamped before first paint by a script in <head>,
+  // The active theme is stamped before first paint by a script in <head>,
   // which never goes through applyTheme, so the tab icon needs painting
   // once on arrival as well as on every later change.
   useEffect(() => {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -92,7 +92,7 @@ const ogImage = socialImage(path)
     <PixelSnap client:load />
     <script>
       import type { TransitionBeforeSwapEvent } from 'astro:transitions/client'
-      import { readTheme } from '@/lib/theme'
+      import { readTheme, themeForNavigation, paintFavicon, paintChrome, THEME_EVENT } from '@/lib/theme'
       import { watchOutbound } from '@/lib/outbound'
       import { watchBrandDownloads } from '@/lib/brand-downloads'
 
@@ -101,11 +101,15 @@ const ogImage = socialImage(path)
       // Navigation should paint live text, not briefly rasterize it through
       // the snapshot animation used for palette changes.
       document.addEventListener('astro:before-swap', (event) => {
-        (event as TransitionBeforeSwapEvent).viewTransition.skipTransition()
+        const navigation = event as TransitionBeforeSwapEvent
+        navigation.viewTransition.skipTransition()
+        navigation.newDocument.documentElement.dataset.theme = themeForNavigation(navigation.to)
       })
-      // Restore the selected palette before the incoming page is painted.
+      // Refresh browser chrome and persistent listeners after the palette lands.
       document.addEventListener('astro:after-swap', () => {
-        document.documentElement.dataset.theme = readTheme()
+        paintFavicon()
+        paintChrome()
+        window.dispatchEvent(new CustomEvent(THEME_EVENT, { detail: readTheme() }))
       })
     </script>
   </body>

--- a/src/lib/theme-state.test.ts
+++ b/src/lib/theme-state.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { runInNewContext } from 'node:vm'
+import {
+  DEFAULT_THEME,
+  THEME_KEY,
+  readTheme,
+  saveTheme,
+  themeForNavigation,
+  themeInitScript,
+} from './theme-state.ts'
+import { SITE_THEMES } from './site-themes.ts'
+
+function visit(
+  search = '',
+  stored: string | null = 'nord',
+  blocked = false,
+  light = false,
+) {
+  const writes: string[] = []
+  const document = {
+    documentElement: { dataset: {} as Record<string, string> },
+    querySelector: () => ({}),
+  }
+  const location = new URL(`https://omarchy.org/doctrine/${search}`)
+  const state = { index: 7, scrollY: 350 }
+  const history = {
+    state,
+    replaceState(next: typeof state, _: string, url: URL) {
+      assert.equal(next, state, 'preserve Astro history state')
+      location.href = url.href
+    },
+  }
+  const localStorage = {
+    getItem(key: string) {
+      assert.equal(key, THEME_KEY)
+      if (blocked) throw new Error('storage unavailable')
+      return stored
+    },
+    setItem(key: string, value: string) {
+      assert.equal(key, THEME_KEY)
+      if (blocked) throw new Error('storage unavailable')
+      writes.push(value)
+      stored = value
+    },
+  }
+  const matchMedia = () => ({ matches: light })
+  const context = {
+    document,
+    location,
+    history,
+    localStorage,
+    URLSearchParams,
+    window: { matchMedia },
+    matchMedia,
+  }
+  const initialize = () => runInNewContext(themeInitScript, context)
+  const run = (fn: () => void) => {
+    const originals = Object.getOwnPropertyDescriptors(globalThis)
+    try {
+      for (const [key, value] of Object.entries(context)) {
+        Object.defineProperty(globalThis, key, { value, configurable: true })
+      }
+      fn()
+    } finally {
+      for (const key of Object.keys(context)) {
+        if (originals[key])
+          Object.defineProperty(globalThis, key, originals[key])
+        else Reflect.deleteProperty(globalThis, key)
+      }
+    }
+  }
+  return { document, location, writes, initialize, run }
+}
+
+test('every supported URL theme wins before paint without saving', () => {
+  for (const { id } of SITE_THEMES) {
+    const page = visit(`?theme=${id}&source=cli#beauty-is-truth`)
+    page.initialize()
+    assert.equal(page.document.documentElement.dataset.theme, id)
+    assert.deepEqual(page.writes, [])
+    page.run(() => assert.equal(readTheme(), id))
+    assert.equal(page.location.search, `?theme=${id}&source=cli`)
+    assert.equal(page.location.hash, '#beauty-is-truth')
+  }
+})
+
+test('missing, empty and unsupported values preserve saved preference', () => {
+  for (const query of ['', '?theme=', '?theme=unknown', '?theme=CATPPUCCIN']) {
+    const page = visit(query)
+    page.initialize()
+    page.run(() => assert.equal(readTheme(), 'nord'))
+    assert.deepEqual(page.writes, [])
+  }
+})
+
+test('a fresh visit retains random system palette selection and persistence', () => {
+  for (const stored of [null, 'unsupported']) {
+    const page = visit('', stored)
+    page.initialize()
+    const selected = page.document.documentElement.dataset.theme
+    assert.ok(SITE_THEMES.some((t) => t.id === selected && !t.light))
+    assert.deepEqual(page.writes, [selected])
+  }
+})
+
+test('unavailable storage does not block a URL theme or the existing fallback', () => {
+  for (const query of ['?theme=catppuccin', '', '?theme=', '?theme=invalid']) {
+    const page = visit(query, null, true)
+    page.initialize()
+    page.run(() =>
+      assert.equal(
+        readTheme(),
+        query === '?theme=catppuccin' ? 'catppuccin' : DEFAULT_THEME,
+      ),
+    )
+    assert.deepEqual(page.writes, [])
+  }
+})
+
+test('explicit choices, including the URL theme, save and preserve other URL and history state', () => {
+  for (const chosen of ['catppuccin', 'nord']) {
+    const page = visit(
+      '?source=cli&theme=catppuccin&tag=a&tag=b#beauty-is-truth',
+    )
+    page.initialize()
+    page.run(() => saveTheme(chosen))
+    assert.deepEqual(page.writes, [chosen])
+    assert.equal(page.location.search, '?source=cli&tag=a&tag=b')
+    assert.equal(page.location.hash, '#beauty-is-truth')
+  }
+})
+
+test('choices still clear the URL when storage is blocked; plain URLs stay intact', () => {
+  for (const query of [
+    '?theme=catppuccin&source=cli#beauty-is-truth',
+    '?source=cli#beauty-is-truth',
+  ]) {
+    const page = visit(query, null, true)
+    page.initialize()
+    page.run(() => saveTheme('catppuccin'))
+    assert.equal(page.location.search, '?source=cli')
+    assert.equal(page.location.hash, '#beauty-is-truth')
+  }
+})
+
+test('Astro carries the active palette, accepts explicit destinations, and revisits URL themes', () => {
+  const page = visit('?theme=catppuccin')
+  page.initialize()
+  page.run(() => {
+    for (const [path, expected] of [
+      ['/manual/', 'catppuccin'],
+      ['/manual/?theme=', 'catppuccin'],
+      ['/manual/?theme=unknown', 'catppuccin'],
+      ['/doctrine/?theme=white#beauty-is-truth', 'white'],
+      ['/manual/', 'white'],
+      ['/doctrine/?theme=catppuccin', 'catppuccin'],
+    ]) {
+      const destination = new URL(path, page.location)
+      const incoming = themeForNavigation(destination)
+      assert.equal(incoming, expected)
+      page.document.documentElement.dataset.theme = incoming
+      page.location.href = destination.href
+      page.initialize() // Astro reruns the head script after swapping.
+      assert.equal(readTheme(), expected)
+    }
+    saveTheme('nord')
+    page.document.documentElement.dataset.theme = 'nord'
+    assert.equal(themeForNavigation(new URL('/manual/', page.location)), 'nord')
+  })
+  assert.deepEqual(page.writes, ['nord'])
+  const fresh = visit('', 'nord')
+  fresh.initialize()
+  fresh.run(() => assert.equal(readTheme(), 'nord'))
+})
+
+test('the fresh fallback still follows a light system color scheme', () => {
+  const page = visit('', null, false, true)
+  page.initialize()
+  const selected = page.document.documentElement.dataset.theme
+  assert.ok(SITE_THEMES.some((theme) => theme.id === selected && theme.light))
+  assert.deepEqual(page.writes, [selected])
+})

--- a/src/lib/theme-state.ts
+++ b/src/lib/theme-state.ts
@@ -1,0 +1,54 @@
+import { inlineJson } from './inline-json.ts'
+import { SITE_THEMES } from './site-themes.ts'
+
+export const DEFAULT_THEME = 'tokyo-night'
+export const THEME_KEY = 'omarchy-site-theme'
+
+export function isTheme(id: unknown): id is string {
+  return SITE_THEMES.some((theme) => theme.id === id)
+}
+
+/** An explicit valid destination replaces the palette carried by Astro. */
+export function themeForNavigation(url: URL): string {
+  const requested = url.searchParams.get('theme')
+  return isTheme(requested) ? requested : readTheme()
+}
+
+/** Only an explicit choice persists a URL palette, including choosing it again. */
+export function saveTheme(id: string) {
+  const url = new URL(location.href)
+  if (url.searchParams.has('theme')) {
+    url.searchParams.delete('theme')
+    history.replaceState(history.state, '', url)
+  }
+  try {
+    localStorage.setItem(THEME_KEY, id)
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/** Resolve URL → carried Astro palette → saved preference before first paint.
+ * Fresh documents have no carried palette; retain the system-scheme fallback.
+ * The favicon is owned outside React so replacing it cannot break reconciliation. */
+export const themeInitScript = `(function(){try{var ok=${inlineJson(
+  SITE_THEMES.map((t) => t.id),
+)};var light=${inlineJson(
+  SITE_THEMES.filter((t) => t.light).map((t) => t.id),
+)};var dark=${inlineJson(
+  SITE_THEMES.filter((t) => !t.light).map((t) => t.id),
+)};var t=new URLSearchParams(location.search).get("theme");if(ok.indexOf(t)<0)t=document.documentElement.dataset.theme;if(ok.indexOf(t)<0)t=localStorage.getItem(${inlineJson(THEME_KEY)});if(ok.indexOf(t)<0){var pool=window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches?light:dark;t=pool[Math.floor(Math.random()*pool.length)];localStorage.setItem(${inlineJson(THEME_KEY)},t)}document.documentElement.dataset.theme=t}catch(e){document.documentElement.dataset.theme=${inlineJson(DEFAULT_THEME)}}if(!document.querySelector('link[rel="icon"][data-theme-icon]')){var l=document.createElement('link');l.rel='icon';l.type='image/svg+xml';l.href='/brand/omarchy-logo.svg';l.setAttribute('data-theme-icon','');document.head.appendChild(l)}})()`
+
+export function readTheme(): string {
+  if (typeof document !== 'undefined') {
+    const active = document.documentElement.dataset.theme
+    if (isTheme(active)) return active
+  }
+  try {
+    const stored = localStorage.getItem(THEME_KEY)
+    if (isTheme(stored)) return stored
+  } catch {
+    /* storage unavailable */
+  }
+  return DEFAULT_THEME
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,13 +1,17 @@
-import { inlineJson } from './inline-json'
+import { saveTheme } from './theme-state.ts'
+export {
+  DEFAULT_THEME,
+  THEME_KEY,
+  themeInitScript,
+  readTheme,
+  themeForNavigation,
+} from './theme-state.ts'
 
 import { OMARCHY_MARK_PATH } from '@/components/Brand'
 import { runThemeViewTransition } from '@/lib/theme-transition'
 
-import { SITE_THEMES } from './site-themes.ts'
 export { SITE_THEMES, type SiteTheme } from './site-themes.ts'
 
-export const DEFAULT_THEME = 'tokyo-night'
-export const THEME_KEY = 'omarchy-site-theme'
 /** Fired on <window> after a theme lands, for canvas renderers to re-read. */
 export const THEME_EVENT = 'omarchy-theme'
 /** Ask the mounted ThemePicker to open (footer link, welcome notice). */
@@ -16,26 +20,6 @@ export const OPEN_PICKER_EVENT = 'omarchy-open-picker'
 export const PICKER_STATE_EVENT = 'omarchy-picker-state'
 /** Set once the user has seen the picker or dismissed the welcome notice. */
 export const HINT_KEY = 'omarchy-theme-hint-seen'
-
-/** Apply the saved palette before paint, or select one matching the system color scheme.
- * The favicon is owned outside React so replacing it cannot break reconciliation. */
-export const themeInitScript = `(function(){try{var t=localStorage.getItem(${inlineJson(THEME_KEY)});var ok=${inlineJson(
-  SITE_THEMES.map((t) => t.id),
-)};var light=${inlineJson(
-  SITE_THEMES.filter((t) => t.light).map((t) => t.id),
-)};var dark=${inlineJson(
-  SITE_THEMES.filter((t) => !t.light).map((t) => t.id),
-)};if(ok.indexOf(t)<0){var pool=window.matchMedia&&matchMedia('(prefers-color-scheme: light)').matches?light:dark;t=pool[Math.floor(Math.random()*pool.length)];localStorage.setItem(${inlineJson(THEME_KEY)},t)}document.documentElement.dataset.theme=t}catch(e){document.documentElement.dataset.theme=${inlineJson(DEFAULT_THEME)}}if(!document.querySelector('link[rel="icon"][data-theme-icon]')){var l=document.createElement('link');l.rel='icon';l.type='image/svg+xml';l.href='/brand/omarchy-logo.svg';l.setAttribute('data-theme-icon','');document.head.appendChild(l)}})()`
-
-export function readTheme(): string {
-  try {
-    const stored = localStorage.getItem(THEME_KEY)
-    if (SITE_THEMES.some((t) => t.id === stored)) return stored as string
-  } catch {
-    /* storage unavailable */
-  }
-  return DEFAULT_THEME
-}
 
 /** Replace the favicon link to invalidate browsers that cache it by element. */
 export function paintFavicon() {
@@ -206,11 +190,7 @@ export function applyTheme(id: string) {
   const root = document.documentElement
   root.classList.add('no-transitions')
   root.dataset.theme = id
-  try {
-    localStorage.setItem(THEME_KEY, id)
-  } catch {
-    /* storage unavailable */
-  }
+  saveTheme(id)
   paintFavicon()
   paintChrome()
   window.dispatchEvent(new CustomEvent(THEME_EVENT, { detail: id }))


### PR DESCRIPTION
Opening Omarchy documentation from the CLI should let the website match the desktop's current theme using an ordinary URL:

https://omarchy.org/doctrine/?theme=catppuccin#beauty-is-truth

Resolve a supported `theme` before first paint using the existing `SITE_THEMES` list. The URL palette overrides the saved preference without writing it to local storage, including when storage is unavailable. Missing, empty, and unsupported values retain the saved-preference/system-scheme fallback.

Astro carries the active palette into the incoming document before swapping. Client-side navigation (including back/forward) keeps it unless the destination specifies another valid theme. An explicit picker choice saves the preference and removes `theme` with `replaceState`, preserving Astro's history state, other query parameters, and the anchor. Choosing the already active URL theme also commits that preference. Older history entries containing a valid theme can activate it again; a fresh load without the parameter uses the saved preference/fallback.

`readTheme()` reads the active palette so hydrated UI agrees with the pre-paint script. Swaps refresh the favicon, browser theme color, and theme-event listeners. The existing picker controls and animated transitions are retained. The storage/initialization code is extracted into a small testable module, with the existing theme module retaining its exports. README documents the public URL behavior. No new dependencies, persistent override storage, global API, internal-link rewriting, or CLI changes.

Validation:

- `npm ci`, `npm run lint`, `npm run typecheck`, `npm test`: pass (44 JS/TS tests, including 8 new theme-state tests; 33 Python tests).
- `bin/build-news`, `npm run build`, `npm run parity`: pass; all 4,937 addresses answer and all 1,922 passthrough files are byte-identical.
- Changed-file formatting and `git diff --check`: pass.
- Built static site tested with temporary Playwright/headless Chromium at 1440×1000 and 390×844. Checked first-frame palette, different saved preference remaining unchanged, favicon/theme color, picker selection and keyboard controls (including choosing the URL theme), unavailable storage, invalid/empty/missing values, query/anchor preservation, manual navigation, explicit destination themes, back/forward, reload, and animated narrow-screen selection. Visually inspected desktop/narrow doctrine and picker screenshots. The doctrine section anchor lands below the fixed header.
- Environment: Node 26.7.0 and Python 3.13.13. No Firefox/Safari or physical-mobile verification.

Pre-existing browser limitations reproduced against a separately built, unchanged `master` (`4771127`): at 390px the picker preview card intercepts the Next arrow's click; keyboard stepping and clicking the selected theme work. Chromium also reports “Transition was skipped” during the existing navigation transition cancellation. Both remain outside this URL-theme change. An initial dev-server module-fetch error led to verification against the production build instead.
