### PR TITLE
Let a spelled-out number become a numeral in translation

### DIFF
--- a/scripts/test_translate_site.py
+++ b/scripts/test_translate_site.py
@@ -49,6 +49,13 @@ class ValidationTests(unittest.TestCase):
         worker.validate_value('Over 1,000 downloads', 'Plus de 1 000 téléchargements')
         with self.assertRaises(worker.TranslationError):
             worker.validate_value('29 languages', '28 sprog')
+        with self.assertRaises(worker.TranslationError):
+            worker.validate_value('29 languages', 'sprog')
+
+    def test_spelled_out_numbers_may_become_numerals(self):
+        worker.validate_value('ten principles', '10の原則')
+        worker.validate_value('more than twenty years', '20年以上')
+        worker.validate_value('29 languages and ten themes', '29言語と10テーマ')
 
     def test_code_and_empty_paragraphs_rejected(self):
         with self.assertRaises(worker.TranslationError):

--- a/scripts/translate-site.py
+++ b/scripts/translate-site.py
@@ -54,7 +54,8 @@ def validate_value(source, value):
         raise TranslationError('placeholders changed')
     if Counter(LITERALS.findall(source_text)) != Counter(LITERALS.findall(target_text)):
         raise TranslationError('commands or literal references changed')
-    if numbers(source_text) != numbers(target_text):
+    # A number the source spells out may come back as a numeral, so only the source's digits are held to.
+    if numbers(source_text) - numbers(target_text):
         raise TranslationError('numeric values changed')
     return value
 


### PR DESCRIPTION
The translation validator in `scripts/translate-site.py` compared every digit token in the English source and the translation and rejected any difference. English prose that spells its numbers out has no digits at all, while Japanese, Korean, Chinese, Sinhala, and Vietnamese correctly render "ten principles" and "more than twenty years" as numerals. Those translations were rejected as "numeric values changed" on every hourly retry and never landed: the doctrine description has been stuck in English on the Japanese edition, and Emir's staff bio is stuck in English on all five since #333 re-keyed it.

The check now holds the translation only to the source's own digits. A number that is missing or altered in the target still fails, with the same count as before, and a numeral the target adds for a spelled-out word passes. The existing tests for localized formatting and changed values still hold, and new ones cover the spelled-out cases and a dropped number. Once merged, the next scheduled run clears the six pending items without any change to the English copy.

Codex XHigh reviewed the diff and found nothing to change, confirming the multiset subtraction keeps catching missing and altered numbers and that the docs stay consistent.

🤖 Generated by Fable 5.1 in Claude Code. Reviewed by Codex XHigh.
