### PR TITLE
Add DigitalOcean's $3 million to the foundation counter

### DIFF
--- a/src/data/momentum.json
+++ b/src/data/momentum.json
@@ -12,7 +12,7 @@
     ]
   },
   "foundation": {
-    "total": 15.5,
+    "total": 18.5,
     "steps": [
       {
         "date": "2026-08-21",
@@ -48,6 +48,11 @@
         "date": "2026-09-07",
         "amount": 15.5,
         "post": "/news/2026/09/omacom-foundation-raises-another-half-a-million-dollars/"
+      },
+      {
+        "date": "2026-09-09",
+        "amount": 18.5,
+        "post": "/news/2026/09/digitalocean-joins-as-founding-corporate-patron/"
       }
     ]
   },


### PR DESCRIPTION
The homepage "pledged to the Omacom Foundation" figure and its step chart stopped at $15.5M (Sep 7). DigitalOcean's Founding Corporate Patron pledge announced Sep 9 takes it to $18.5M, with a new chart row linking to the announcement.

Typecheck and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
