### PR TITLE
Restore Plausible tracking after the redesign

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -40,6 +40,7 @@ const ogImage = socialImage(path)
 <html lang={language} dir={locale.direction ?? 'ltr'} transition:name="root" transition:animate="none">
   <head>
     <ClientRouter fallback="swap" />
+    <script is:inline defer data-domain="omarchy.org" src="https://plausible.io/js/script.js" transition:persist="plausible" />
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>{title}</title>


### PR DESCRIPTION
The redesign dropped the Plausible script from the shared layout, so production pages stopped recording visits. Restore the existing `omarchy.org` tracker across all editions and persist its script through Astro client navigation.

Validation: production build and typecheck passed; all 97 rendered pages contain exactly one tracker. A Chromium test using the actual Plausible script verified one pageview per initial load, client navigation, back navigation, and reload, with the script loaded only once per document. Analytics requests were intercepted locally; no test events reached Plausible.
