### PR TITLE
Drop the search icon from the header

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -460,19 +460,6 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
     </Link>
   )
 
-  const search = (
-    <Button
-      variant="ghost"
-      size="icon"
-      aria-label={t('Search Omarchy')}
-      data-nav-glyph
-      className="relative h-8 w-8 text-text-secondary transition-[background-color,transform] hover:text-text before:absolute before:-inset-1 lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]"
-      onClick={() => window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))}
-    >
-      <SearchIcon className="size-5" />
-    </Button>
-  )
-
   const theme = (
     <Button
       variant="ghost"
@@ -552,9 +539,6 @@ export function SiteHeader({ path = '/' }: { path?: string }) {
           <div className="ml-auto flex items-center gap-2.5">
             <div className="hidden items-center gap-1 sm:flex">
               <TooltipProvider delay={300}>
-                <NavTooltip label={t('Search Omarchy')} shortcut="⌘K / Ctrl+K">
-                  {search}
-                </NavTooltip>
                 <NavTooltip label={t('Change website theme')} shortcut="T">
                   {theme}
                 </NavTooltip>
@@ -760,9 +744,6 @@ export function HeroNavGhost() {
             className="hidden items-center gap-1 sm:flex"
             style={{ color: 'var(--t-hdr-text-2)' }}
           >
-            <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
-              <SearchIcon className="size-5" />
-            </span>
             <span className="flex h-8 w-8 items-center justify-center lg:h-[calc(var(--pxr)*3)] lg:w-[calc(var(--pxr)*3)]">
               <PaletteIcon className="size-5" />
             </span>


### PR DESCRIPTION
## Summary

The Omarchy mark in the header now opens the search and jump menu, so the looking glass beside the theme picker duplicated it. This removes the desktop button, its ⌘K tooltip, and the matching placeholder in the ghost bar that keeps the header from wiggling during swaps.

Left as is: the "Search Omarchy" row inside the mobile hamburger menu, which is a labeled menu item rather than a bare icon. Happy to drop that too if you'd rather the mark be the only way in.

## Test plan

- [x] `npm run typecheck` and `npm run lint` pass
- [x] Header verified in the dev server: theme, language, RSS, GitHub, Install remain, evenly spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RDDR34nwZxLPdE9pBQ9V8
