### PR TITLE
Fix music playback restarting when seeking or scrubbing track

### DIFF
--- a/src/components/MusicControl.tsx
+++ b/src/components/MusicControl.tsx
@@ -157,6 +157,8 @@ export function MusicControl({ path = '/' }: { path?: string }) {
   const readout = useRef<HTMLSpanElement>(null)
   const bars = useRef<Array<HTMLSpanElement | null>>([])
   const scrubbing = useRef(false)
+  const scrubTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastCommitted = useRef<number | null>(null)
   useEffect(() => {
     if (!shown) return
     const levels = new Float32Array(METER_BARS)
@@ -181,16 +183,36 @@ export function MusicControl({ path = '/' }: { path?: string }) {
       }
     }
     frame = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(frame)
+    return () => {
+      cancelAnimationFrame(frame)
+      if (scrubTimeout.current) clearTimeout(scrubTimeout.current)
+    }
   }, [shown])
 
-  /** The range moved, by hand or key: show it at once, and go there. */
-  const onScrub = (value: number) => {
+  /** Show scrub position immediately without hammering audio.currentTime. */
+  const onScrubInput = (value: number) => {
+    scrubbing.current = true
+    if (scrubTimeout.current) clearTimeout(scrubTimeout.current)
     const at = value / 1000
     if (line.current) line.current.style.transform = `scaleX(${at})`
     if (readout.current)
       readout.current.textContent = `${clock(at * music.duration)} / ${clock(music.duration)}`
+  }
+
+  /** Commit the seek when user releases the slider or commits a keyboard change. */
+  const onScrubCommit = (value: number) => {
+    const at = value / 1000
+    if (lastCommitted.current === at) return
+    lastCommitted.current = at
+    if (line.current) line.current.style.transform = `scaleX(${at})`
+    if (readout.current)
+      readout.current.textContent = `${clock(at * music.duration)} / ${clock(music.duration)}`
     music.seek(at * music.duration)
+    if (scrubTimeout.current) clearTimeout(scrubTimeout.current)
+    scrubTimeout.current = setTimeout(() => {
+      scrubbing.current = false
+      lastCommitted.current = null
+    }, 150)
   }
 
   if (!shown) return null
@@ -283,14 +305,17 @@ export function MusicControl({ path = '/' }: { path?: string }) {
         aria-label={t('Position in the track')}
         onPointerDown={() => {
           scrubbing.current = true
+          if (scrubTimeout.current) clearTimeout(scrubTimeout.current)
         }}
-        onPointerUp={() => {
-          scrubbing.current = false
+        onPointerUp={(event) => {
+          onScrubCommit(Number(event.currentTarget.value))
         }}
         onPointerCancel={() => {
           scrubbing.current = false
+          if (scrubTimeout.current) clearTimeout(scrubTimeout.current)
         }}
-        onInput={(event) => onScrub(Number(event.currentTarget.value))}
+        onInput={(event) => onScrubInput(Number(event.currentTarget.value))}
+        onChange={(event) => onScrubCommit(Number(event.currentTarget.value))}
         className="music-seek absolute inset-x-0 -bottom-[6px] h-[14px] w-full cursor-pointer touch-none appearance-none bg-transparent focus-visible:outline-none"
       />
     </div>

--- a/src/lib/music.ts
+++ b/src/lib/music.ts
@@ -172,6 +172,16 @@ function wire() {
   audio.addEventListener('pause', () => {
     running = false
   })
+  audio.addEventListener('seeked', () => {
+    if (audio && !audio.paused) {
+      running = true
+    }
+  })
+  audio.addEventListener('play', () => {
+    if (audio && !audio.paused) {
+      running = true
+    }
+  })
   audio.addEventListener('error', () => {
     state = 'failed'
     announce()
@@ -354,7 +364,13 @@ export const music = {
     const at = Math.max(0, Math.min(timeline.duration - 0.5, seconds))
     // The track itself if it is running, sound on or off; the silent
     // clock in any case, so the two agree if the sound stops.
-    if (live()) audio!.currentTime = at
+    if (audio) {
+      try {
+        audio.currentTime = at
+      } catch {
+        /* audio element not ready to seek */
+      }
+    }
     clockZero = performance.now() - at * 1000
     timelineAt = at
   },


### PR DESCRIPTION
### Summary
Fixes an issue where attempting to seek or scrub the track in the music player would cause audio playback to restart from 0:00.
### Cause
1. `MusicControl` was calling `music.seek()` synchronously on every `onInput` event during dragging, continuously setting `audio.currentTime` and triggering stream reloads/buffer thrashing.
2. In browsers that fire a momentary `pause` event during seeking, `running` was set to `false`, but no `seeked`/`play` listener existed to restore it, desynchronizing the playback state and snapping the UI back to the silent clock.
3. If `live()` returned false during seeking or pausing, `music.seek()` skipped setting `audio.currentTime`.
### Solution
- Decoupled scrubbing visualization (`onInput`) from actual audio seek (`onPointerUp` / `onChange`), ensuring seeks are committed cleanly on release.
- Added a brief lock so the animation frame loop doesn't prematurely snap the progress line back before the media element completes seeking.
- Handled `seeked` and `play` events on the audio element to keep `running` in sync with playback.
- Safely updated `audio.currentTime` whenever the audio instance exists.
