### PR TITLE
Refresh the figures card's period rows too

### DIFF
--- a/scripts/refresh-data.mjs
+++ b/scripts/refresh-data.mjs
@@ -288,13 +288,24 @@ if (CF_TOKEN && CF_ZONE) {
       )
       const isoBytes = Number(head.headers.get('content-length'))
       if (!(isoBytes > 1e9)) throw new Error(`odd ISO size: ${isoBytes}`)
-      const rows = await isoTraffic(start, yesterday)
+      // Reach back far enough for the period rows even when the ledger
+      // only needs a day, so one query serves both.
+      const periodDays = Math.max(
+        30,
+        ...(momentum.downloads.periods ?? []).map((p) => p.days),
+      )
+      const fetchStart =
+        start < day(daysAgo(periodDays)) ? start : day(daysAgo(periodDays))
+      const rows = await isoTraffic(fetchStart, yesterday)
       let bytes = 0
+      const perDay = new Map()
       const countries = new Set(counting.countries)
       const perCountryDay = new Map()
       for (const row of rows) {
-        bytes += row.sum.edgeResponseBytes
-        const key = `${row.dimensions.date} ${row.dimensions.clientCountryName}`
+        const date = row.dimensions.date
+        perDay.set(date, (perDay.get(date) ?? 0) + row.sum.edgeResponseBytes)
+        if (date >= start) bytes += row.sum.edgeResponseBytes
+        const key = `${date} ${row.dimensions.clientCountryName}`
         perCountryDay.set(
           key,
           (perCountryDay.get(key) ?? 0) + row.sum.edgeResponseBytes,
@@ -304,6 +315,14 @@ if (CF_TOKEN && CF_ZONE) {
         if (sent >= isoBytes) countries.add(key.split(' ')[1])
       }
       const added = Math.round(bytes / isoBytes)
+      // The Yesterday / Last week / Last month rows on the figures card:
+      // each is its trailing window's bytes ending yesterday, in ISOs.
+      for (const period of momentum.downloads.periods ?? []) {
+        const cutoff = day(daysAgo(period.days))
+        let sent = 0
+        for (const [date, b] of perDay) if (date >= cutoff) sent += b
+        period.count = Math.round(sent / isoBytes)
+      }
       momentum.downloads.total += added
       momentum.downloads.countries = Math.max(
         momentum.downloads.countries,


### PR DESCRIPTION
The six-hourly refresh advances the running ISO download total, but the Yesterday / Last week / Last month rows on the figures card were only ever seeded by hand — they've been frozen on their Sep 6 values while the total moved.

This makes the same run recompute them: the existing analytics query reaches back 30 days regardless of how few days the ledger needs (one query still serves both), the ledger keeps adding only the uncounted days, and each period row is recomputed from its trailing window ending yesterday. Row labels and shape are untouched, so `Figures.tsx` renders as before.

Verified against the live Cloudflare API with the same query and divisor: the recomputed rows come out at Yesterday ≈9.9k / Last week ≈62.7k / Last month ≈273.7k (vs the frozen 9,158 / 75,071 / 242,851), matching independent zone-analytics queries. `node --check` passes. Needs nothing new from CI — the same `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` secrets the ledger already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)