### PR TITLE
Map Polish (pl) locale to omarchy.pl

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -85,7 +85,7 @@ Cloudflare custom domains handle routing and TLS directly. Registered national d
 | Oʻzbekcha        | [uz.omarchy.org](https://uz.omarchy.org) |
 | Italiano         | [it.omarchy.org](https://it.omarchy.org) |
 | 简体中文         | [zh.omarchy.org](https://zh.omarchy.org) |
-| Polski           | [pl.omarchy.org](https://pl.omarchy.org) |
+| Polski           | [omarchy.pl](https://omarchy.pl)         |
 | Lietuvių         | [lt.omarchy.org](https://lt.omarchy.org) |
 | Gaeilge          | [ga.omarchy.org](https://ga.omarchy.org) |
 | Nederlands       | [nl.omarchy.org](https://nl.omarchy.org) |

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -195,11 +195,10 @@
   },
   "pl": {
     "name": "Polski",
-    "domain": "https://pl.omarchy.org",
+    "domain": "https://omarchy.pl",
     "formatLocale": "pl-PL",
     "ogLocale": "pl_PL",
-    "manual": false,
-    "flag": "PL"
+    "manual": false
   },
   "lt": {
     "name": "Lietuvių",


### PR DESCRIPTION
## Summary
Points the Polish (`pl`) locale at `https://omarchy.pl`.

- **Currently live & working:** `https://pl.omarchy.org` serves the Polish translation properly (HTTP 200).
- **Currently broken:** `https://omarchy.pl` cannot be reached (`ERR_NAME_NOT_RESOLVED` / Server Not Found).

## Context & Root Cause
`omarchy.pl` nameservers are already delegated to Omarchy's Cloudflare zone (`eva.ns.cloudflare.com` / `mario.ns.cloudflare.com`), but because `src/i18n/locales.json` still lists `https://pl.omarchy.org`, the Cloudflare Worker deployment script (`scripts/deploy-locale.mjs`) never attached the Worker custom domain to `omarchy.pl`.

## Changes
- `src/i18n/locales.json`: Set `pl.domain` to `https://omarchy.pl` (matching other country TLD editions like `omarchy.dk`, `omarchy.no`, `omarchy.pt`, etc.)
- `docs/translations.md`: Update Poland primary address table entry to `omarchy.pl`