### PR TITLE
Keep the phone from zooming into the prompt

### DIFF
--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -327,7 +327,7 @@ export function SearchPalette() {
             autoComplete="off"
             spellCheck={false}
             enterKeyHint="go"
-            className="min-w-0 flex-1 bg-transparent font-mono text-[13px] text-text outline-none placeholder:text-text placeholder:opacity-60 [&::-webkit-search-cancel-button]:hidden"
+            className="min-w-0 flex-1 bg-transparent font-mono text-[13px] text-text outline-none pointer-coarse:text-base placeholder:text-text placeholder:opacity-60 [&::-webkit-search-cancel-button]:hidden"
           />
         </div>
 


### PR DESCRIPTION
iOS Safari zooms the page whenever a field under 16px takes focus, and the menu's prompt does on open since #328 set it to 13px.

This draws the prompt at 16px on a coarse pointer only. The desktop keeps the label's size.
