### PR TITLE
Lock page scroll behind modal overlays

### DIFF
--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/icons'
 import { OmarchyMark } from '@/components/Brand'
 import { GlobeIcon } from '@/components/icons/GlobeIcon'
+import { useScrollLock } from '@/lib/use-scroll-lock'
 import type { SearchEntry } from '@/lib/content'
 import { getSearchIndex } from '@/lib/content'
 import type { SearchHit } from '@/lib/search'
@@ -87,6 +88,7 @@ export function SearchPalette() {
   const restore = useRef<HTMLElement | null>(null)
 
   const [open, setOpen] = useState(false)
+  useScrollLock(open)
   const [query, setQuery] = useState('')
   const [menu, setMenu] = useState('root')
   const [index, setIndex] = useState<SearchEntry[] | null>(null)

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -18,6 +18,7 @@ import {
   readTheme,
 } from '@/lib/theme'
 import { useIsNarrow } from '@/lib/use-media-query'
+import { useScrollLock } from '@/lib/use-scroll-lock'
 import { cn } from '@/lib/utils'
 
 const previewSrc = (id: string) => `/assets/images/theme-previews/${id}.webp`
@@ -44,6 +45,7 @@ const isTyping = (target: EventTarget | null) => {
 export function ThemePicker() {
   const portrait = useIsNarrow()
   const [open, setOpen] = useState(false)
+  useScrollLock(open)
   const [index, setIndex] = useState(0)
   const [hint, setHint] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)

--- a/src/lib/use-scroll-lock.ts
+++ b/src/lib/use-scroll-lock.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+/**
+ * Locks the page scroll while `open` is true. The viewport keeps the current
+ * scroll position through the toggle, so nothing needs to be saved or restored.
+ */
+export function useScrollLock(open: boolean) {
+  useEffect(() => {
+    if (!open) return
+    const body = document.body
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+    return () => {
+      body.style.overflow = previousOverflow
+    }
+  }, [open])
+}


### PR DESCRIPTION
# 



## Why

Opening the theme picker or the search palette left the page behind the dimmer scrollable. On a mouse or trackpad the scroll passes straight through the overlay onto the page underneath, so a reader editing a theme swap can lose their place, and a touch user can drag the page around behind a palette they cannot dismiss without tapping out. The modal is supposed to claim the interaction for its own layer; the page should stay put beneath it.

The workstation photo viewer already locks the background correctly because it is a native `<dialog>` opened with `showModal()`, which freezes the document behind it. The theme picker and the search palette are hand-built overlays, so they never did.

## What

Adds a small `useScrollLock` hook that toggles `overflow: hidden` on `<body>` for as long as the overlay is open, and wires it into the two full-screen overlays:

- `ThemePicker.tsx` — locked while the picker is up.
- `SearchPalette.tsx` — locked while the palette is up.

The hook restores the body's original `overflow` value on close, and the viewport keeps the current scroll position through the toggle, so nothing needs to be saved or restored manually.

## Notes

- `WorkstationLightbox.astro` needs no change: its native `<dialog>` already blocks background scroll.
- `src/components/ui/dialog.tsx` needs no change: Base UI's `Dialog` already locks the document scroll when `modal` (its default) is set.
- No test was added: the repository has no React testing environment, and the hook is a thin `overflow` toggle around `useEffect`.

## Checks

- ESLint clean
- `tsc --noEmit` clean
- Full test suite passing (26 node + 26 python)
- Verified manually: page scroll is frozen behind the picker and palette, and restored on Escape, on choose, and on outside click